### PR TITLE
Implemented dialog controls locking

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
@@ -250,8 +250,9 @@ class FileInfoActionsBottomSheetDialog : BottomSheetDialogFragment(), FileInfoAc
         }
     }
 
-    override fun onLeaveShare() {
+    override fun onLeaveShare(onApiResponse: () -> Unit) {
         mainViewModel.deleteFile(requireContext(), currentFile).observe(viewLifecycleOwner) { apiResponse ->
+            onApiResponse()
             if (apiResponse.isSuccess()) {
                 transmitActionAndPopBack(getString(R.string.snackbarLeaveShareConfirmation))
                 mainViewModel.refreshActivities.value = true

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
@@ -217,8 +217,9 @@ class FileInfoActionsBottomSheetDialog : BottomSheetDialogFragment(), FileInfoAc
             })
     }
 
-    override fun onDeleteFile() {
+    override fun onDeleteFile(onApiResponse: () -> Unit) {
         mainViewModel.deleteFile(requireContext(), currentFile).observe(viewLifecycleOwner) { apiResponse ->
+            onApiResponse()
             if (apiResponse.isSuccess()) {
                 mainViewModel.refreshActivities.value = true
                 val title = resources.getQuantityString(

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/TrashedFileActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/TrashedFileActionsBottomSheetDialog.kt
@@ -70,8 +70,9 @@ class TrashedFileActionsBottomSheetDialog : BottomSheetDialogFragment() {
         }
 
         delete.setOnClickListener {
-            Utils.confirmFileDeletion(requireContext(), fileName = currentTrashedFile.name, fromTrash = true) {
+            Utils.confirmFileDeletion(requireContext(), fileName = currentTrashedFile.name, fromTrash = true) { dialog ->
                 trashViewModel.deleteTrashFile(currentTrashedFile).observe(viewLifecycleOwner) { apiResponse ->
+                    dialog.dismiss()
                     if (apiResponse.data == true) {
                         val title = resources.getQuantityString(R.plurals.snackbarDeleteConfirmation, 1, currentTrashedFile.name)
                         requireActivity().showSnackbar(title)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
@@ -31,7 +31,6 @@ import com.infomaniak.lib.core.views.ViewHolder
 import kotlinx.android.synthetic.main.cardview_file_list.view.*
 import kotlinx.android.synthetic.main.item_file.view.*
 
-
 open class FileAdapter(
     override val itemList: ArrayList<File> = arrayListOf()
 ) : PaginationAdapter<File>() {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -219,7 +219,7 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
 
         setupFileAdapter()
 
-        if (enabledMultiSelectMode) setupMultiselect()
+        if (enabledMultiSelectMode) setupMultiSelect()
 
         setupDisplay()
 
@@ -245,13 +245,13 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         onSelectFolderResult(requestCode, resultCode, data)
     }
 
-    private fun setupMultiselect() {
+    private fun setupMultiSelect() {
         fileAdapter.enabledMultiSelectMode = true
         closeButtonMultiSelect.setOnClickListener { closeMultiSelect() }
         deleteButtonMultiSelect.setOnClickListener {
             val selectedFiles = fileAdapter.itemSelected
 
-            Utils.confirmFileDeletion(requireContext(), fileName = null, deletionCount = selectedFiles.count()) {
+            Utils.confirmFileDeletion(requireContext(), fileName = null, deletionCount = selectedFiles.count()) { dialog ->
                 val mediator = mainViewModel.createMultiSelectMediator()
                 val selectedCount = selectedFiles.count()
                 enableButtonMultiSelect(false)
@@ -267,6 +267,7 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
                 }
 
                 mediator.observe(viewLifecycleOwner) { (success, total) ->
+                    dialog.dismiss()
                     if (total == selectedCount) {
                         val title = if (success == 0) {
                             getString(R.string.anErrorHasOccurred)
@@ -378,8 +379,9 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
                     safeNavigate(R.id.fileInfoActionsBottomSheetDialog, bundle)
                 }
                 R.id.deleteButton -> {
-                    Utils.confirmFileDeletion(requireContext(), fileName = file.name) {
+                    Utils.confirmFileDeletion(requireContext(), fileName = file.name) { dialog ->
                         mainViewModel.deleteFile(requireContext(), file).observe(viewLifecycleOwner) { apiResponse ->
+                            dialog.dismiss()
                             if (apiResponse.isSuccess()) {
                                 apiResponse?.data?.let { cancellableAction ->
                                     cancellableAction.driveId = file.driveId

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/FileDetailsCommentsFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/FileDetailsCommentsFragment.kt
@@ -137,10 +137,12 @@ class FileDetailsCommentsFragment : FileDetailsSubFragment() {
                 Utils.createConfirmation(
                     context = requireContext(),
                     title = "",
+                    autoDismiss = false,
                     message = getString(R.string.modalCommentDeleteDescription)
-                ) {
+                ) { dialog ->
                     fileDetailsViewModel.deleteFileComment(currentFile, comment.id)
                         .observe(viewLifecycleOwner) { apiResponse ->
+                            dialog.dismiss()
                             if (apiResponse.isSuccess()) {
                                 commentsAdapter.deleteComment(comment)
                                 noCommentsLayout.toggleVisibility(commentsAdapter.itemCount == 0, showRefreshButton = false)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
@@ -18,6 +18,7 @@
 package com.infomaniak.drive.ui.fileList.preview
 
 import android.annotation.SuppressLint
+import android.app.Dialog
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -348,8 +349,9 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
             })
     }
 
-    override fun onDeleteFile() {
+    override fun onDeleteFile(onApiResponse: () -> Unit) {
         mainViewModel.deleteFile(requireContext(), currentPreviewFile).observe(viewLifecycleOwner) { apiResponse ->
+            onApiResponse()
             if (apiResponse.isSuccess()) {
                 mainViewModel.currentFileList.value?.remove(currentPreviewFile)
                 if (previewSliderAdapter.deleteFile(currentPreviewFile)) {
@@ -367,7 +369,6 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
             } else {
                 requireActivity().showSnackbar(getString(R.string.errorDelete))
             }
-
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
@@ -295,8 +295,9 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
         }
     }
 
-    override fun onLeaveShare() {
+    override fun onLeaveShare(onApiResponse: () -> Unit) {
         mainViewModel.deleteFile(requireContext(), currentPreviewFile).observe(viewLifecycleOwner) { apiResponse ->
+            onApiResponse()
             if (apiResponse.isSuccess()) {
                 if (previewSliderAdapter.deleteFile(currentPreviewFile)) {
                     findNavController().popBackStack()

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/TrashFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/TrashFragment.kt
@@ -61,8 +61,9 @@ class TrashFragment : FileSubTypeListFragment() {
                 when (view.id) {
                     R.id.menuButton -> showTrashedFileActions(file)
                     R.id.deleteButton -> {
-                        Utils.confirmFileDeletion(requireContext(), fileName = file.name, fromTrash = true) {
+                        Utils.confirmFileDeletion(requireContext(), fileName = file.name, fromTrash = true) { dialog ->
                             trashViewModel.deleteTrashFile(file).observe(viewLifecycleOwner) { apiResponse ->
+                                dialog.dismiss()
                                 if (apiResponse.isSuccess()) {
                                     val title = resources.getQuantityString(R.plurals.snackbarDeleteConfirmation, 1, file.name)
                                     requireActivity().showSnackbar(title)

--- a/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
@@ -92,22 +92,36 @@ object Utils {
             .setCancelable(false)
             .show()
 
-        val buttonPositive = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
-        buttonPositive.setOnClickListener {
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
             onPositiveButtonClicked(dialog)
             it.isEnabled = false
             dialog.getButton(AlertDialog.BUTTON_NEGATIVE).isEnabled = false
         }
     }
 
-    fun createConfirmation(context: Context, title: String, message: String? = null, onConfirmation: () -> Unit) {
-        MaterialAlertDialogBuilder(context, R.style.DialogStyle).apply {
-            setTitle(title)
-            setMessage(message)
-            setPositiveButton(R.string.buttonConfirm) { _, _ -> onConfirmation() }
-            setNegativeButton(R.string.buttonCancel) { _, _ -> }
-            setCancelable(false)
-            show()
+    fun createConfirmation(
+        context: Context,
+        title: String,
+        message: String? = null,
+        autoDismiss: Boolean = true,
+        onConfirmation: (dialog: Dialog) -> Unit
+    ) {
+        val dialog = MaterialAlertDialogBuilder(context, R.style.DialogStyle)
+            .setTitle(title)
+            .setMessage(message)
+            .setPositiveButton(R.string.buttonConfirm) { _, _ -> }
+            .setNegativeButton(R.string.buttonCancel) { _, _ -> }
+            .setCancelable(false)
+            .show()
+
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+            onConfirmation(dialog)
+            if (autoDismiss) {
+                dialog.dismiss()
+            } else {
+                it.isEnabled = false
+                dialog.getButton(AlertDialog.BUTTON_NEGATIVE).isEnabled = false
+            }
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
@@ -62,7 +62,7 @@ object Utils {
         fileName: String?,
         fromTrash: Boolean = false,
         deletionCount: Int = 1,
-        onPositiveButtonClicked: () -> Unit
+        onPositiveButtonClicked: (dialog: Dialog) -> Unit
     ) {
         val title: Int
         val message: String
@@ -84,14 +84,20 @@ object Utils {
             )
             button = R.string.buttonMove
         }
-        MaterialAlertDialogBuilder(context, R.style.DeleteDialogStyle)
+        val dialog = MaterialAlertDialogBuilder(context, R.style.DeleteDialogStyle)
             .setTitle(title)
             .setMessage(message)
-            .setPositiveButton(button) { _, _ ->
-                onPositiveButtonClicked()
-            }
+            .setPositiveButton(button) { _, _ -> }
             .setNegativeButton(R.string.buttonCancel) { _, _ -> }
-            .setCancelable(false).show()
+            .setCancelable(false)
+            .show()
+
+        val buttonPositive = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+        buttonPositive.setOnClickListener {
+            onPositiveButtonClicked(dialog)
+            it.isEnabled = false
+            dialog.getButton(AlertDialog.BUTTON_NEGATIVE).isEnabled = false
+        }
     }
 
     fun createConfirmation(context: Context, title: String, message: String? = null, onConfirmation: () -> Unit) {

--- a/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
+++ b/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
@@ -354,20 +354,20 @@ class FileInfoActionsView @JvmOverloads constructor(
     }
 
     interface OnItemClickListener {
-        fun addFavoritesClicked()
-        fun displayInfoClicked()
-        fun fileRightsClicked()
-        fun copyPublicLink()
-        fun onDeleteFile()
-        fun openWithClicked()
-        fun onMoveFile(destinationFolder: File)
-        fun onDuplicateFile(result: String, onApiResponse: () -> Unit)
-        fun onRenameFile(newName: String, onApiResponse: () -> Unit)
-        fun downloadFileClicked()
-        fun removeOfflineFile(offlineLocalPath: java.io.File, cacheFile: java.io.File)
-        fun onCacheAddedToOffline() = Unit
-        fun dropBoxClicked(isDropBox: Boolean) = Unit
         fun onLeaveShare()
+        fun copyPublicLink()
+        fun openWithClicked()
+        fun fileRightsClicked()
+        fun displayInfoClicked()
+        fun downloadFileClicked()
+        fun addFavoritesClicked()
+        fun onCacheAddedToOffline() = Unit
+        fun onMoveFile(destinationFolder: File)
+        fun onDeleteFile(onApiResponse: () -> Unit)
+        fun dropBoxClicked(isDropBox: Boolean) = Unit
+        fun onRenameFile(newName: String, onApiResponse: () -> Unit)
+        fun onDuplicateFile(result: String, onApiResponse: () -> Unit)
+        fun removeOfflineFile(offlineLocalPath: java.io.File, cacheFile: java.io.File)
 
         fun editDocumentClicked(ownerFragment: Fragment, currentFile: File) {
             ownerFragment.apply {
@@ -446,8 +446,10 @@ class FileInfoActionsView @JvmOverloads constructor(
         }
 
         fun deleteFileClicked(context: Context, currentFile: File) {
-            Utils.confirmFileDeletion(context, fileName = currentFile.name) {
-                onDeleteFile()
+            Utils.confirmFileDeletion(context, fileName = currentFile.name) { dialog ->
+                onDeleteFile {
+                    dialog.dismiss()
+                }
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
+++ b/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
@@ -354,7 +354,6 @@ class FileInfoActionsView @JvmOverloads constructor(
     }
 
     interface OnItemClickListener {
-        fun onLeaveShare()
         fun copyPublicLink()
         fun openWithClicked()
         fun fileRightsClicked()
@@ -364,6 +363,7 @@ class FileInfoActionsView @JvmOverloads constructor(
         fun onCacheAddedToOffline() = Unit
         fun onMoveFile(destinationFolder: File)
         fun onDeleteFile(onApiResponse: () -> Unit)
+        fun onLeaveShare(onApiResponse: () -> Unit)
         fun dropBoxClicked(isDropBox: Boolean) = Unit
         fun onRenameFile(newName: String, onApiResponse: () -> Unit)
         fun onDuplicateFile(result: String, onApiResponse: () -> Unit)
@@ -421,9 +421,12 @@ class FileInfoActionsView @JvmOverloads constructor(
                 Utils.createConfirmation(
                     context = context,
                     title = context.getString(R.string.modalLeaveShareTitle),
-                    message = context.getString(R.string.modalLeaveShareDescription, currentFile.name)
-                ) {
-                    onLeaveShare()
+                    message = context.getString(R.string.modalLeaveShareDescription, currentFile.name),
+                    autoDismiss = true
+                ) { dialog ->
+                    onLeaveShare {
+                        dialog.dismiss()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
+++ b/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
@@ -422,7 +422,7 @@ class FileInfoActionsView @JvmOverloads constructor(
                     context = context,
                     title = context.getString(R.string.modalLeaveShareTitle),
                     message = context.getString(R.string.modalLeaveShareDescription, currentFile.name),
-                    autoDismiss = true
+                    autoDismiss = false
                 ) { dialog ->
                     onLeaveShare {
                         dialog.dismiss()

--- a/app/src/main/res/color/delete_button.xml
+++ b/app/src/main/res/color/delete_button.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Infomaniak kDrive - Android
+  ~ Copyright (C) 2021 Infomaniak Network SA
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:alpha="0.5" android:color="@color/red_error" android:state_enabled="false" />
+    <item android:color="@color/red_error" android:state_enabled="true" />
+</selector>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -185,7 +185,7 @@
     </style>
 
     <style name="DeletePositiveButtonStyle" parent="PositiveButtonStyle">
-        <item name="android:textColor">@color/red_error</item>
+        <item name="android:textColor">@color/delete_button</item>
     </style>
 
     <style name="MaterialAlertDialogMaterialComponentsTitle" parent="MaterialAlertDialog.MaterialComponents.Title.Text">


### PR DESCRIPTION
We automatically close confirmation dialogs when API is still performing the action. 
This creates some complications with adapters when we manually refresh data.



