### PR TITLE
Fixed a crashy bug on cancellable actions snackbars (lifecycle issue)

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -210,10 +210,6 @@ class MainViewModel : ViewModel() {
         emit(ApiRepository.duplicateFile(file, copyName, folderId ?: Utils.ROOT_ID))
     }
 
-    fun cancelAction(action: CancellableAction) = liveData(Dispatchers.IO) {
-        emit(ApiRepository.cancelAction(action))
-    }
-
     fun convertFile(file: File) = liveData(Dispatchers.IO) {
         emit(ApiRepository.convertFile(file))
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -46,6 +46,7 @@ import androidx.work.WorkManager
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.shape.CornerFamily
 import com.infomaniak.drive.R
+import com.infomaniak.drive.data.api.ApiRepository
 import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.data.models.*
 import com.infomaniak.drive.data.services.DownloadWorker
@@ -66,8 +67,7 @@ import kotlinx.android.synthetic.main.fragment_home.*
 import kotlinx.android.synthetic.main.fragment_new_folder.*
 import kotlinx.android.synthetic.main.fragment_new_folder.toolbar
 import kotlinx.android.synthetic.main.item_file.view.*
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 
 open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
 
@@ -151,9 +151,11 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
                     }
 
                     requireActivity().showSnackbar(title, anchorView = requireActivity().mainFab) {
-                        mainViewModel.cancelAction(action).observe(viewLifecycleOwner) { apiResponse ->
-                            if (apiResponse.data == true) {
-                                refreshActivities()
+                        GlobalScope.launch(Dispatchers.IO) {
+                            if (ApiRepository.cancelAction(action).data == true && isResumed) {
+                                withContext(Dispatchers.Main) {
+                                    refreshActivities()
+                                }
                             }
                         }
                     }
@@ -394,9 +396,11 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
                                         file.name
                                     )
                                     requireActivity().showSnackbar(title, anchorView = requireActivity().mainFab) {
-                                        mainViewModel.cancelAction(cancellableAction).observe(viewLifecycleOwner) { apiResponse ->
-                                            if (apiResponse.data == true) {
-                                                refreshActivities()
+                                        GlobalScope.launch(Dispatchers.IO) {
+                                            if (ApiRepository.cancelAction(cancellableAction).data == true && isResumed) {
+                                                withContext(Dispatchers.Main) {
+                                                    refreshActivities()
+                                                }
                                             }
                                         }
                                     }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
@@ -221,7 +221,6 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
                 apiResponse.data?.valid?.users?.forEach {
                     it.permission = selectedPermission.apiValue
                 }
-
                 setBackNavigationResult(SHARE_SELECTION_KEY, apiResponse.data?.valid)
             } else {
                 Utils.showSnackbar(requireView(), apiResponse.translateError())


### PR DESCRIPTION
All is in the title.

The app crashed when a cancellable action was aborted in another fragment.

Signed-off-by: Kilian Périsset <kilian.perisset@infomaniak.com>