### PR TITLE
fix upload file size + alternative fix for valid chunks

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
@@ -111,6 +111,15 @@ open class UploadFile(
             }
         }
 
+        fun update(uri: String, transaction: (uploadFile: UploadFile) -> Unit): Boolean {
+            getRealmInstance().use { realm ->
+                return syncFileByUriQuery(realm, uri).findFirst()?.let { uploadFile ->
+                    realm.executeTransaction { transaction(uploadFile) }
+                    true
+                } ?: false
+            }
+        }
+
         fun getLastDate(context: Context): Date {
             val date: Date? = getRealmInstance().use { realm ->
                 realm.where(SyncSettings::class.java).findFirst()?.lastSync

--- a/app/src/main/java/com/infomaniak/drive/data/sync/UploadAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/sync/UploadAdapter.kt
@@ -206,6 +206,10 @@ class UploadAdapter @JvmOverloads constructor(
     @Throws(Exception::class)
     private suspend fun startUploadFile(uploadFile: UploadFile, size: Long, syncResult: SyncResult?) {
         if (size != 0L) {
+            if (uploadFile.fileSize < size) {
+                UploadFile.update(uploadFile.uri) { it.fileSize = size }
+            }
+
             UploadTask(
                 context = context.applicationContext,
                 uploadFile = uploadFile,


### PR DESCRIPTION
## Fix:
1. file_already_exists_error
> Sometimes we have valid chunks that are imported and it causes this error 
> `{"result":"error","error":{"code":"file_already_exists_error","description":"File already exists error"}}`
> **This is an alternative solution that makes us ignore this error because it is already valid, but the reason is unknown for now.**

2. upload_error

> This commit also fixes the following error
> `{"result":"error","error":{"code":"upload_error","description":"Upload error"}}`
> Which was due to an incorrect size during an import