### PR TITLE
Implemented in-app review flow

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
@@ -144,9 +144,7 @@ class MainActivity : BaseActivity() {
 
         launchAllUpload()
 
-        if (AppSettings.appLaunches == 20 || AppSettings.appLaunches % 120 == 0) {
-            launchInAppReview()
-        }
+        if (AppSettings.appLaunches == 20 || AppSettings.appLaunches % 100 == 0) launchInAppReview()
 
         if (!UISettings(this).updateLater || AppSettings.appLaunches % 10 == 0) {
             // Will never be successful on emulator (update check is not functional on AVD)
@@ -250,12 +248,7 @@ class MainActivity : BaseActivity() {
         ReviewManagerFactory.create(this).apply {
             val requestReviewFlow = requestReviewFlow()
             requestReviewFlow.addOnCompleteListener { request ->
-                if (request.isSuccessful) {
-                    val reviewInfo = request.result
-                    launchReviewFlow(this@MainActivity, reviewInfo)
-                } else {
-                    Log.d("Review Error: ", request.exception.toString())
-                }
+                if (request.isSuccessful) launchReviewFlow(this@MainActivity, request.result)
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
@@ -47,6 +47,7 @@ import com.google.android.material.navigation.NavigationBarItemView
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.UpdateAvailability
+import com.google.android.play.core.review.ReviewManagerFactory
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.data.models.AppSettings
@@ -142,6 +143,10 @@ class MainActivity : BaseActivity() {
         }
 
         launchAllUpload()
+
+        if (AppSettings.appLaunches == 20 || AppSettings.appLaunches % 120 == 0) {
+            launchInAppReview()
+        }
 
         if (!UISettings(this).updateLater || AppSettings.appLaunches % 10 == 0) {
             // Will never be successful on emulator (update check is not functional on AVD)
@@ -239,6 +244,20 @@ class MainActivity : BaseActivity() {
 
         canvas.drawCircle(50F, 50F, 46F, paint)
         return bitmap
+    }
+
+    private fun launchInAppReview() {
+        ReviewManagerFactory.create(this).apply {
+            val requestReviewFlow = requestReviewFlow()
+            requestReviewFlow.addOnCompleteListener { request ->
+                if (request.isSuccessful) {
+                    val reviewInfo = request.result
+                    launchReviewFlow(this@MainActivity, reviewInfo)
+                } else {
+                    Log.d("Review Error: ", request.exception.toString())
+                }
+            }
+        }
     }
 
     companion object {


### PR DESCRIPTION
I've chosen to display the in-app review bottomsheet : 
- When it's the 20th launch of the app 
- Every 120 launches (because I count an average of 4 onResume per day for someone who uses the app ordinarily)

Signed-off-by: Kilian Périsset <kilian.perisset@infomaniak.com>