### PR TITLE
Fixed toggle issue (fast click) in ShareLinkContainer view

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/FileDetailsInfosFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/FileDetailsInfosFragment.kt
@@ -109,8 +109,16 @@ class FileDetailsInfosFragment : FileDetailsSubFragment() {
             shareDivider.visibility = VISIBLE
             shareLinkContainer.setup(shareLink = share?.link, file = currentFile, onSwitchClicked = { isEnabled ->
                 mainViewModel.apply {
-                    if (isEnabled) createShareLink(currentFile)
-                    else deleteShareLink(currentFile)
+                    if (isEnabled) {
+                        createShareLink(currentFile) {
+                            shareLinkContainer.toggleSwitchingApproval(true)
+                        }
+                    }
+                    else {
+                        deleteShareLink(currentFile) {
+                            shareLinkContainer.toggleSwitchingApproval(true)
+                        }
+                    }
                 }
             })
         } else {
@@ -158,8 +166,9 @@ class FileDetailsInfosFragment : FileDetailsSubFragment() {
         }
     }
 
-    private fun createShareLink(currentFile: File) {
+    private fun createShareLink(currentFile: File, onApiResponse: () -> Unit) {
         mainViewModel.postFileShareLink(currentFile).observe(viewLifecycleOwner) { apiResponse ->
+            onApiResponse()
             if (apiResponse.isSuccess()) {
                 shareLinkContainer.update(apiResponse.data)
             } else {
@@ -168,7 +177,8 @@ class FileDetailsInfosFragment : FileDetailsSubFragment() {
         }
     }
 
-    private fun deleteShareLink(currentFile: File) {
+    private fun deleteShareLink(currentFile: File, onApiResponse: () -> Unit) {
+        onApiResponse()
         mainViewModel.deleteFileShareLink(currentFile).observe(viewLifecycleOwner) { apiResponse ->
             if (apiResponse.data == true) {
                 shareLinkContainer.update(null)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareDetailsFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareDetailsFragment.kt
@@ -143,15 +143,20 @@ class FileShareDetailsFragment : Fragment() {
             shareLinkLayout.visibility = VISIBLE
             shareLinkContainer.setup(shareLink = shareLink,
                 file = file,
-                onSwitchClicked = { isEnabled -> shareLinkSwitched(isEnabled, file) }
+                onSwitchClicked = { isEnabled ->
+                    shareLinkSwitched(isEnabled, file) {
+                        shareLinkContainer.toggleSwitchingApproval(true)
+                    }
+                }
             )
         }
     }
 
-    private fun shareLinkSwitched(isEnabled: Boolean, file: File) {
+    private fun shareLinkSwitched(isEnabled: Boolean, file: File, onApiResponse: () -> Unit) {
         mainViewModel.apply {
             if (isEnabled) {
                 postFileShareLink(file).observe(viewLifecycleOwner) { apiResponse ->
+                    onApiResponse()
                     if (apiResponse.isSuccess()) {
                         shareLinkContainer.update(apiResponse.data)
                     } else {
@@ -160,6 +165,7 @@ class FileShareDetailsFragment : Fragment() {
                 }
             } else {
                 deleteFileShareLink(file).observe(viewLifecycleOwner) { apiResponse ->
+                    onApiResponse()
                     if (apiResponse.data == true) {
                         shareLinkContainer.update(null)
                     } else {

--- a/app/src/main/java/com/infomaniak/drive/views/ShareLinkContainerView.kt
+++ b/app/src/main/java/com/infomaniak/drive/views/ShareLinkContainerView.kt
@@ -90,6 +90,7 @@ class ShareLinkContainerView @JvmOverloads constructor(
         updateUi()
         shareLinkTitle.setText(title)
         shareLinkSwitch.setOnCheckedChangeListener { _, isChecked ->
+            toggleSwitchingApproval(false)
             onSwitchClicked(isChecked)
         }
         shareLinkSettings.setOnClickListener {
@@ -104,6 +105,10 @@ class ShareLinkContainerView @JvmOverloads constructor(
         this.shareLink = shareLink
         if (shareLink == null) urlValue = ""
         updateUi()
+    }
+
+    fun toggleSwitchingApproval(allow: Boolean) {
+        shareLinkSwitch.isClickable = allow
     }
 
     private fun updateUi() {


### PR DESCRIPTION
By fast-clicking on ShareLink switch, you may create an UI invalidation issue.
This PR fixes it.

Signed-off-by: Kilian Périsset <kilian.perisset@infomaniak.com>