### PR TITLE
Fixed rights deletion after update

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
@@ -51,7 +51,7 @@ object ApiRoutes {
 
     fun createFolder(driveId: Int, parentId: Int) = "${DRIVE_API}$driveId/file/folder/$parentId?$with"
 
-    fun createOfficeFile(driveId: Int, folderId: Int) = "${DRIVE_API}$driveId/file/file/${folderId}?with=mobile"
+    fun createOfficeFile(driveId: Int, folderId: Int) = "${DRIVE_API}$driveId/file/file/${folderId}?$with"
 
     fun createTeamFolder(driveId: Int) = "${DRIVE_API}$driveId/file/folder/team/?$with"
 

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -69,6 +69,12 @@ object FileController {
         }
     }
 
+    fun getFileProxyById(fileId: Int, userDrive: UserDrive? = null): File? {
+        return getRealmInstance(userDrive).use { realm ->
+            realm.where(File::class.java).equalTo(File::id.name, fileId).findFirst()
+        }
+    }
+
     fun getFileById(fileId: Int, userDrive: UserDrive? = null): File? {
         return getRealmInstance(userDrive).use { realm ->
             realm.where(File::class.java).equalTo(File::id.name, fileId).findFirst()?.let {
@@ -244,7 +250,7 @@ object FileController {
             val apiResponse = ApiRepository.getFileDetails(File(id = fileId, driveId = userDrive.driveId))
             if (apiResponse.isSuccess()) {
                 apiResponse.data?.let { remoteFile ->
-                    insertOrUpdateFile(realm, remoteFile, getFileById(fileId, userDrive))
+                    insertOrUpdateFile(realm, remoteFile, getFileProxyById(fileId, userDrive))
                     remoteFile
                 }
             } else {
@@ -681,7 +687,7 @@ object FileController {
             getFileById(realm, fileActivity.fileId)?.deleteCaches(Realm.getApplicationContext()!!)
         }
 
-        realm.where(File::class.java).equalTo(File::id.name, fileActivity.fileId).findFirst()?.let { file ->
+        getFileProxyById(fileActivity.fileId)?.let { file ->
             insertOrUpdateFile(realm, fileActivity.file!!, file)
         } ?: also {
             returnResponse[fileActivity.fileId] = File.LocalFileActivity.IS_NEW


### PR DESCRIPTION
Children rights of a folder were deleted from Realm on parent data fetch.
It fixes this bug.