### PR TITLE
Implemented cache and remote filtering in my shares

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -241,10 +241,12 @@ object FileController {
         order: File.SortType = File.SortType.NAME_AZ
     ): ArrayList<File> {
         return getRealmInstance(userDrive).use { currentRealm ->
-            currentRealm.where(File::class.java).equalTo(File::id.name, folderID).findFirst()?.children?.where()?.let { query ->
-                val children = query.getSortQueryByOrder(order).findAll()
-                ArrayList(currentRealm.copyFromRealm(children, 0))
-            }
+            currentRealm
+                .where(File::class.java)
+                .equalTo(File::id.name, folderID)
+                .findFirst()?.children?.where()?.getSortQueryByOrder(order)?.findAll()?.let { children ->
+                    ArrayList(currentRealm.copyFromRealm(children, 0))
+                }
         } ?: ArrayList()
     }
 

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -235,10 +235,15 @@ object FileController {
         }
     }
 
-    fun getFilesFromCache(folderID: Int, userDrive: UserDrive? = null): ArrayList<File> {
+    fun getFilesFromCache(
+        folderID: Int,
+        userDrive: UserDrive? = null,
+        order: File.SortType = File.SortType.NAME_AZ
+    ): ArrayList<File> {
         return getRealmInstance(userDrive).use { currentRealm ->
-            currentRealm.where(File::class.java).equalTo(File::id.name, folderID).findFirst()?.let { folder ->
-                ArrayList(currentRealm.copyFromRealm(folder.children, 0))
+            currentRealm.where(File::class.java).equalTo(File::id.name, folderID).findFirst()?.children?.where()?.let { query ->
+                val children = query.getSortQueryByOrder(order).findAll()
+                ArrayList(currentRealm.copyFromRealm(children, 0))
             }
         } ?: ArrayList()
     }
@@ -284,7 +289,7 @@ object FileController {
         transaction: (files: ArrayList<File>, isComplete: Boolean) -> Unit
     ) {
         if (ignoreCloud) {
-            transaction(getFilesFromCache(MY_SHARES_FILE_ID, userDrive), true)
+            transaction(getFilesFromCache(MY_SHARES_FILE_ID, userDrive, sortType), true)
         } else {
             val apiResponse = ApiRepository.getMySharedFiles(
                 KDriveHttpClient.getHttpClient(userDrive.userId), userDrive.driveId, sortType.order, sortType.orderBy, page
@@ -303,7 +308,7 @@ object FileController {
                         getMySharedFiles(userDrive, sortType, page + 1, false, transaction)
                     }
                 }
-            } else if (page == 1) transaction(getFilesFromCache(MY_SHARES_FILE_ID, userDrive), true)
+            } else if (page == 1) transaction(getFilesFromCache(MY_SHARES_FILE_ID, userDrive, sortType), true)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/FileSubTypeListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/FileSubTypeListFragment.kt
@@ -36,8 +36,8 @@ open class FileSubTypeListFragment : FileListFragment() {
         sortButton.visibility = View.GONE
     }
 
-    protected fun populateFileList(files: ArrayList<File>, isComplete: Boolean, ignoreOffline: Boolean = false) {
-        if (fileAdapter.itemCount == 0) fileAdapter.setList(files)
+    protected fun populateFileList(files: ArrayList<File>, isComplete: Boolean, ignoreOffline: Boolean = false, forceClean: Boolean = false) {
+        if (fileAdapter.itemCount == 0 || forceClean) fileAdapter.setList(files)
         else fileRecyclerView.post { fileAdapter.addFileList(files) }
         fileAdapter.isComplete = isComplete
         timer.cancel()

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/MySharesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/MySharesFragment.kt
@@ -19,6 +19,7 @@ package com.infomaniak.drive.ui.menu
 
 import android.os.Bundle
 import android.view.View
+import android.view.View.VISIBLE
 import androidx.navigation.fragment.findNavController
 import com.infomaniak.drive.R
 import com.infomaniak.drive.utils.Utils
@@ -40,6 +41,7 @@ class MySharesFragment : FileSubTypeListFragment() {
 
         collapsingToolbarLayout.title = getString(R.string.mySharesTitle)
         noFilesLayout.setup(icon = R.drawable.ic_share, title = R.string.mySharesNoFile, initialListView = fileRecyclerView)
+        sortButton.visibility = VISIBLE
 
         fileAdapter.onFileClicked = { file ->
             fileListViewModel.cancelDownloadFiles()
@@ -59,7 +61,7 @@ class MySharesFragment : FileSubTypeListFragment() {
             fileAdapter.isComplete = false
 
             fileListViewModel.getMySharedFiles(sortType).observe(viewLifecycleOwner) {
-                populateFileList(it?.first ?: ArrayList(), true)
+                populateFileList(files = it?.first ?: ArrayList(), isComplete = true, forceClean = true)
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/MySharesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/MySharesFragment.kt
@@ -61,6 +61,7 @@ class MySharesFragment : FileSubTypeListFragment() {
             fileAdapter.isComplete = false
 
             fileListViewModel.getMySharedFiles(sortType).observe(viewLifecycleOwner) {
+                // forceClean because myShares is not paginated
                 populateFileList(files = it?.first ?: ArrayList(), isComplete = true, forceClean = true)
             }
         }


### PR DESCRIPTION
No side-effect detected in other instances of FileSubTypeList but check carefully !
I had to : 
- Add a `forceClean` argument in `populateFileList` because list wasn't cleaned after a remote fetch
- Provide order types in FileController about FavoritesFiles fetch