### PR TITLE
fix external storage(sd-card) uri from progression import view

### DIFF
--- a/app/src/androidTest/java/com/infomaniak/drive/FileControllerTest.kt
+++ b/app/src/androidTest/java/com/infomaniak/drive/FileControllerTest.kt
@@ -123,7 +123,7 @@ class FileControllerTest : KDriveTest() {
         Assert.assertFalse("get pictures response data cannot be null or empty", apiResponse.data.isNullOrEmpty())
 
         // Store remote pictures
-        FileController.storeDriveSoloPictures(apiResponse.data!!, realm)
+        FileController.storeDriveSoloPictures(apiResponse.data!!, customRealm = realm)
 
         // Get saved remote files from realm
         val localFiles = FileController.getDriveSoloPictures(realm)

--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -276,7 +276,7 @@ fun View.setFileItem(
                     filePreview.scaleType = ImageView.ScaleType.CENTER_CROP
                     filePreview.loadUrl(file.thumbnail(), file.getFileType().icon)
                 }
-                file.isFromUploads && (file.getMimeType().contains("image") || file.getMimeType().contains("video")) -> {
+                file.isFromUploads && (file.getMimeType().startsWith("image/") || file.getMimeType().startsWith("video/")) -> {
                     filePreview.scaleType = ImageView.ScaleType.CENTER_CROP
                     filePreview.load(context.getLocalThumbnail(file)) {
                         fallback(file.getFileType().icon)
@@ -604,8 +604,14 @@ fun Context.getLocalThumbnail(file: File): Bitmap? {
             null
         }
     } else {
-        if (fileUri.scheme.equals(ContentResolver.SCHEME_FILE)) {
-            fileUri.path?.let { path ->
+
+        val externalRealPath = if ("com.android.externalstorage.documents" == fileUri.authority) {
+            Utils.getRealPathFromExternalStorage(this, fileUri)
+        } else ""
+
+        if (fileUri.scheme.equals(ContentResolver.SCHEME_FILE) || externalRealPath.isNotBlank()) {
+            val path = if (externalRealPath.isNotBlank()) externalRealPath else fileUri.path
+            path?.let {
                 if (file.getMimeType().contains("video")) {
                     ThumbnailUtils.createVideoThumbnail(path, MediaStore.Video.Thumbnails.MICRO_KIND)
                 } else {

--- a/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
@@ -24,6 +24,8 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.CountDownTimer
+import android.os.Environment
+import android.provider.DocumentsContract
 import android.view.View
 import android.view.View.VISIBLE
 import android.widget.Toast
@@ -360,5 +362,24 @@ object Utils {
         bitmapOptions.inJustDecodeBounds = false
 
         return BitmapFactory.decodeFile(filePath, bitmapOptions)
+    }
+
+    fun getRealPathFromExternalStorage(context: Context, uri: Uri): String {
+        var filePath = ""
+        // ExternalStorageProvider
+        val docId = DocumentsContract.getDocumentId(uri)
+        val split = docId.split(':')
+        val type = split.first()
+
+        return if ("primary".equals(type, true)) {
+            Environment.getExternalStorageDirectory().toString() + "/" + split[1]
+        } else {
+            val external = context.externalMediaDirs
+            if (external.size > 1) {
+                filePath = external[1].absolutePath
+                filePath = filePath.substring(0, filePath.indexOf("Android")) + split[1]
+            }
+            filePath
+        }
     }
 }


### PR DESCRIPTION
Uri from sd card is in format `content://com.android.externalstorage.documents/document/relative_path_file` and it is not compatible with the upload import view

![image](https://user-images.githubusercontent.com/28200274/128015730-a41a7efc-3e91-4a17-a69b-ec69fc96d06f.png)

> this PR is a fix

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>