### PR TITLE
Fix and enhance shares workflow

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
@@ -76,14 +76,14 @@ object DriveInfosController {
         return driveRemoved
     }
 
-    fun getUsers(userIds: ArrayList<Int>? = arrayListOf()): ArrayList<DriveUser> {
+    fun getUsers(userIds: ArrayList<Int>? = arrayListOf()): List<DriveUser> {
         return getRealmInstance().use { realm ->
             val userList = realm.copyFromRealm(realm.where(DriveUser::class.java).apply {
                 if (!userIds.isNullOrEmpty()) {
                     this.oneOf(Drive::id.name, userIds.toTypedArray())
                 }
             }.findAll(), 1)
-            userList?.let { ArrayList(it) } ?: ArrayList()
+            userList?.let { ArrayList(it) } ?: listOf()
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
@@ -138,6 +138,7 @@ class AvailableShareableItemsAdapter(
                     itemList = initialList
                     notifyDataSetInvalidated()
                 } else {
+                    val oldListItem = itemList.size
                     itemList = if (constraint.toString().isEmail()) {
                         arrayListOf(
                             Invitation(
@@ -146,7 +147,7 @@ class AvailableShareableItemsAdapter(
                             )
                         )
                     } else results.values as ArrayList<Shareable>
-                    notifyDataSetChanged()
+                    if (itemList.size != oldListItem) notifyDataSetChanged()
                 }
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
@@ -44,7 +44,7 @@ import kotlin.collections.ArrayList
 class AvailableShareableItemsAdapter(
     context: Context,
     private var itemList: ArrayList<Shareable>,
-    var notShareableUsers: ArrayList<DriveUser> = arrayListOf(),
+    var notShareableUserIds: ArrayList<Int> = arrayListOf(),
     private val onItemClick: (item: Shareable) -> Unit,
 ) : ArrayAdapter<Shareable>(context, R.layout.item_user, itemList), Filterable {
     var initialList: ArrayList<Shareable> = ArrayList()
@@ -109,7 +109,7 @@ class AvailableShareableItemsAdapter(
                         it.getFilterValue().lowercase(Locale.ROOT)
                             .contains(searchTerm) || ((it is DriveUser) && it.email.lowercase(Locale.ROOT).contains(searchTerm))
                     }.filterNot { displayedItem ->
-                        notShareableUsers.any { it.id == displayedItem.id }
+                        notShareableUserIds.any { it == displayedItem.id }
                     }
                 return FilterResults().apply {
                     values = finalUserList

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
@@ -47,7 +47,7 @@ class AvailableShareableItemsAdapter(
     var notShareableUsers: ArrayList<DriveUser> = arrayListOf(),
     private val onItemClick: (item: Shareable) -> Unit,
 ) : ArrayAdapter<Shareable>(context, R.layout.item_user, itemList), Filterable {
-    private var initialList: ArrayList<Shareable> = ArrayList()
+    var initialList: ArrayList<Shareable> = ArrayList()
 
     init {
         cleanItemList()

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
@@ -53,9 +53,8 @@ class AvailableShareableItemsAdapter(
         initialList = ArrayList(itemList)
     }
 
-    fun setAll(items: ArrayList<Shareable>) {
-        itemList = items
-        initialList = items
+    fun setAll(items: List<Shareable>) {
+        itemList = ArrayList(items)
         notifyDataSetChanged()
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
@@ -138,7 +138,7 @@ class AvailableShareableItemsAdapter(
                     itemList = initialList
                     notifyDataSetInvalidated()
                 } else {
-                    val oldListItem = itemList.size
+                    val oldListCount = itemList.size
                     itemList = if (constraint.toString().isEmail()) {
                         arrayListOf(
                             Invitation(
@@ -147,7 +147,7 @@ class AvailableShareableItemsAdapter(
                             )
                         )
                     } else results.values as ArrayList<Shareable>
-                    if (itemList.size != oldListItem) notifyDataSetChanged()
+                    if (itemList.size != oldListCount) notifyDataSetChanged()
                 }
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
@@ -54,7 +54,8 @@ class AvailableShareableItemsAdapter(
     }
 
     fun setAll(items: List<Shareable>) {
-        itemList = ArrayList(items)
+        itemList.clear()
+        itemList.addAll(items)
         notifyDataSetChanged()
     }
 
@@ -69,9 +70,7 @@ class AvailableShareableItemsAdapter(
     }
 
     fun removeItemList(itemIdList: Iterable<Int>) {
-        itemList.removeAll {
-            itemIdList.contains(it.id)
-        }
+        itemList.removeAll { shareable -> itemIdList.contains(shareable.id) }
         notifyDataSetChanged()
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
@@ -80,8 +80,9 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
         }
 
         availableUsersAdapter = userAutoCompleteTextView.setupAvailableShareableItems(
-            requireContext(),
-            getAvailableUsers()
+            context = requireContext(),
+            itemList = getAvailableUsers(),
+            notShareableItems = ArrayList(navigationArgs.notShareableUsersIds.map { id -> DriveUser(id = id) })
         ) { element ->
             userAutoCompleteTextView.setText("")
             addToSharedElementList(if (element is Invitation) element.email else element)
@@ -135,7 +136,6 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
                         emails.add(element)
                         createChip(element).setOnClickListener {
                             emails.remove(element)
-                            availableUsersAdapter.setAll(getAvailableUsers())
                             selectedUsersChipGroup.removeView(it)
                         }
                     }
@@ -143,10 +143,10 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
                 is DriveUser -> {
                     if (!users.any { it.id == element.id }) {
                         users.add(element)
-                        availableUsersAdapter.removeItem(element.id)
+                        availableUsersAdapter.notShareableUsers.add(element)
                         createChip(element).setOnClickListener {
                             users.remove(element)
-                            availableUsersAdapter.setAll(getAvailableUsers())
+                            availableUsersAdapter.notShareableUsers.remove(element)
                             selectedUsersChipGroup.removeView(it)
                         }
                     }
@@ -155,7 +155,6 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
                     tags.add(element)
                     createChip(element).setOnClickListener {
                         tags.remove(element)
-                        availableUsersAdapter.setAll(getAvailableUsers())
                         selectedUsersChipGroup.removeView(it)
                     }
                 }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
@@ -134,10 +134,14 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
                 is String -> {
                     availableUsersAdapter.initialList.find { user -> user is DriveUser && user.email == element }
                         ?.let { potentialUser ->
-                            if (!availableUsersAdapter.notShareableUsers.contains(potentialUser)) {
+                            if (!availableUsersAdapter.notShareableUsers.any { potentialUser.id == it.id }) {
                                 addToSharedElementList(potentialUser)
                             } else {
-                                // TODO TF show something like "user already shared"
+                                Utils.showSnackbar(
+                                    view = requireView(),
+                                    title = R.string.errorShareAddUser,
+                                    anchorView = shareButton
+                                )
                             }
                         } ?: run {
                         if (!emails.contains(element)) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
@@ -134,7 +134,7 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
                 is String -> {
                     availableUsersAdapter.initialList.find { user -> user is DriveUser && user.email == element }
                         ?.let { potentialUser ->
-                            if (!availableUsersAdapter.notShareableUserIds.any { id == potentialUser.id }) {
+                            if (!availableUsersAdapter.notShareableUserIds.any { it == potentialUser.id }) {
                                 addToSharedElementList(potentialUser)
                             } else {
                                 Utils.showSnackbar(

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
@@ -82,7 +82,7 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
         availableUsersAdapter = userAutoCompleteTextView.setupAvailableShareableItems(
             context = requireContext(),
             itemList = AccountUtils.getCurrentDrive().getDriveUsers(),
-            notShareableItems = ArrayList(navigationArgs.notShareableUsersIds.map { id -> DriveUser(id = id) })
+            notShareableItems = navigationArgs.notShareableUsersIds.toMutableList() as ArrayList<Int>
         ) { element ->
             userAutoCompleteTextView.setText("")
             addToSharedElementList(if (element is Invitation) element.email else element)
@@ -134,7 +134,7 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
                 is String -> {
                     availableUsersAdapter.initialList.find { user -> user is DriveUser && user.email == element }
                         ?.let { potentialUser ->
-                            if (!availableUsersAdapter.notShareableUsers.any { potentialUser.id == it.id }) {
+                            if (!availableUsersAdapter.notShareableUserIds.any { id == potentialUser.id }) {
                                 addToSharedElementList(potentialUser)
                             } else {
                                 Utils.showSnackbar(
@@ -156,10 +156,10 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
                 is DriveUser -> {
                     if (!users.any { it.id == element.id }) {
                         users.add(element)
-                        availableUsersAdapter.notShareableUsers.add(element)
+                        availableUsersAdapter.notShareableUserIds.add(element.id)
                         createChip(element).setOnClickListener {
                             users.remove(element)
-                            availableUsersAdapter.notShareableUsers.remove(element)
+                            availableUsersAdapter.notShareableUserIds.remove(element.id)
                             selectedUsersChipGroup.removeView(it)
                         }
                     }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
@@ -81,7 +81,7 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
 
         availableUsersAdapter = userAutoCompleteTextView.setupAvailableShareableItems(
             requireContext(),
-            getAvailableShareableElements()
+            getAvailableUsers()
         ) { element ->
             userAutoCompleteTextView.setText("")
             addToSharedElementList(if (element is Invitation) element.email else element)
@@ -135,7 +135,7 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
                         emails.add(element)
                         createChip(element).setOnClickListener {
                             emails.remove(element)
-                            availableUsersAdapter.setAll(getAvailableShareableElements())
+                            availableUsersAdapter.setAll(getAvailableUsers())
                             selectedUsersChipGroup.removeView(it)
                         }
                     }
@@ -146,7 +146,7 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
                         availableUsersAdapter.removeItem(element.id)
                         createChip(element).setOnClickListener {
                             users.remove(element)
-                            availableUsersAdapter.setAll(getAvailableShareableElements())
+                            availableUsersAdapter.setAll(getAvailableUsers())
                             selectedUsersChipGroup.removeView(it)
                         }
                     }
@@ -155,7 +155,7 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
                     tags.add(element)
                     createChip(element).setOnClickListener {
                         tags.remove(element)
-                        availableUsersAdapter.setAll(getAvailableShareableElements())
+                        availableUsersAdapter.setAll(getAvailableUsers())
                         selectedUsersChipGroup.removeView(it)
                     }
                 }
@@ -205,14 +205,12 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
         return chip
     }
 
-    private fun getAvailableShareableElements(): ArrayList<Shareable> {
-        return ArrayList(
-            fileShareViewModel.availableUsers.value
-                ?.removeCommonUsers(ArrayList(fileShareViewModel.currentFile.value?.users ?: arrayListOf()))
-                ?.filterNot { availableUser ->
-                    selectedItems.users.any { it.id == availableUser.id }
-                }
-        )
+    private fun getAvailableUsers(): List<Shareable> {
+        return fileShareViewModel.availableUsers.value
+            ?.removeCommonUsers(ArrayList(fileShareViewModel.currentFile.value?.users ?: arrayListOf()))
+            ?.filterNot { availableUser ->
+                selectedItems.users.any { it.id == availableUser.id }
+            } ?: listOf()
     }
 
     private fun createShareAndCloseDialog(file: File, body: MutableMap<String, Serializable>) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareDetailsFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareDetailsFragment.kt
@@ -31,7 +31,6 @@ import androidx.navigation.fragment.navArgs
 import androidx.navigation.navGraphViewModels
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.api.ErrorCode.Companion.translateError
-import com.infomaniak.drive.data.cache.DriveInfosController
 import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.data.models.*
 import com.infomaniak.drive.ui.MainViewModel
@@ -56,15 +55,13 @@ class FileShareDetailsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val allUserList = AccountUtils.getCurrentDrive()?.users?.let { categories ->
-            return@let DriveInfosController.getUsers(ArrayList(categories.drive + categories.account))
-        } ?: listOf()
+        val allUserList = AccountUtils.getCurrentDrive().getDriveUsers()
 
         fileShareViewModel.availableUsers.value = ArrayList(allUserList) // add available tags if in common
         availableShareableItemsAdapter =
             userAutoCompleteTextView.setupAvailableShareableItems(
-                requireContext(),
-                allUserList
+                context = requireContext(),
+                itemList = allUserList
             ) { selectedElement ->
                 userAutoCompleteTextView.setText("")
                 openAddUserDialog(selectedElement)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareDetailsFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareDetailsFragment.kt
@@ -80,8 +80,7 @@ class FileShareDetailsFragment : Fragment() {
             fileDetails?.let { file ->
                 fileShareViewModel.currentFile.value = file
                 availableShareableItemsAdapter.setAll(allUserList)
-                availableShareableItemsAdapter.notShareableUsers.addAll(file.users.map { userId -> DriveUser(id = userId) })
-
+                availableShareableItemsAdapter.notShareableUserIds.addAll(file.users)
                 sharedItemsAdapter = SharedItemsAdapter(file) { shareable ->
                     openSelectPermissionDialog(shareable)
                 }
@@ -89,8 +88,8 @@ class FileShareDetailsFragment : Fragment() {
                 mainViewModel.getFileShare(file.id).observe(viewLifecycleOwner) { (_, data) ->
                     data?.let { share ->
                         sharedUsersTitle.visibility = VISIBLE
-                        availableShareableItemsAdapter.notShareableUsers.clear()
-                        availableShareableItemsAdapter.notShareableUsers.addAll(share.users)
+                        availableShareableItemsAdapter.notShareableUserIds.clear()
+                        availableShareableItemsAdapter.notShareableUserIds.addAll(share.users.map { it.id })
                         sharedItemsAdapter.setAll(ArrayList(share.users + share.invitations + share.tags))
                         setupShareLinkContainer(file, share.link)
                     }
@@ -111,7 +110,7 @@ class FileShareDetailsFragment : Fragment() {
                 shareable?.let { shareableItem ->
                     if (permission == Shareable.ShareablePermission.DELETE) {
                         sharedItemsAdapter.removeItem(shareableItem)
-                        if (shareableItem is DriveUser) availableShareableItemsAdapter.notShareableUsers.remove(shareableItem)
+                        if (shareableItem is DriveUser) availableShareableItemsAdapter.notShareableUserIds.remove(shareableItem.id)
                     } else {
                         sharedItemsAdapter.updateItemPermission(shareableItem, permission as Shareable.ShareablePermission)
                     }
@@ -121,7 +120,7 @@ class FileShareDetailsFragment : Fragment() {
 
         getBackNavigationResult<ShareableItems>(SHARE_SELECTION_KEY) { (users, _, tags, invitations) ->
             sharedItemsAdapter.putAll(ArrayList(users + tags + invitations))
-            availableShareableItemsAdapter.notShareableUsers.addAll(users)
+            availableShareableItemsAdapter.notShareableUserIds.addAll(users.map { it.id })
         }
 
         toolbar.setNavigationOnClickListener {
@@ -207,7 +206,7 @@ class FileShareDetailsFragment : Fragment() {
             FileShareDetailsFragmentDirections.actionFileShareDetailsFragmentToFileShareAddUserDialog(
                 sharedEmail = sharedEmail,
                 sharedUserId = sharedUserId,
-                notShareableUsersIds = availableShareableItemsAdapter.notShareableUsers.map { it.id }.toIntArray()
+                notShareableUsersIds = availableShareableItemsAdapter.notShareableUserIds.toIntArray()
             )
         )
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareDetailsFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareDetailsFragment.kt
@@ -56,15 +56,15 @@ class FileShareDetailsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val allUserList = ArrayList(AccountUtils.getCurrentDrive()?.users?.let { categories ->
-            DriveInfosController.getUsers(ArrayList(categories.drive + categories.account))
-        })
+        val allUserList = AccountUtils.getCurrentDrive()?.users?.let { categories ->
+            return@let DriveInfosController.getUsers(ArrayList(categories.drive + categories.account))
+        } ?: listOf()
 
-        fileShareViewModel.availableUsers.value = allUserList // add available tags if in common
+        fileShareViewModel.availableUsers.value = ArrayList(allUserList) // add available tags if in common
         availableShareableItemsAdapter =
             userAutoCompleteTextView.setupAvailableShareableItems(
                 requireContext(),
-                allUserList as ArrayList<Shareable>
+                allUserList
             ) { selectedElement ->
                 userAutoCompleteTextView.setText("")
                 openAddUserDialog(selectedElement)
@@ -82,7 +82,7 @@ class FileShareDetailsFragment : Fragment() {
         mainViewModel.getFileDetails(navigationArgs.fileId, UserDrive()).observe(viewLifecycleOwner) { fileDetails ->
             fileDetails?.let { file ->
                 fileShareViewModel.currentFile.value = file
-                availableShareableItemsAdapter.setAll(allUserList.removeCommonUsers(ArrayList(file.users)) as ArrayList<Shareable>)
+                availableShareableItemsAdapter.setAll(allUserList.removeCommonUsers(ArrayList(file.users)))
                 sharedItemsAdapter = SharedItemsAdapter(file) { shareable ->
                     openSelectPermissionDialog(shareable)
                 }

--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -432,7 +432,7 @@ fun String.isEmail(): Boolean {
 fun MaterialAutoCompleteTextView.setupAvailableShareableItems(
     context: Context,
     itemList: List<Shareable>,
-    notShareableItems: ArrayList<DriveUser> = arrayListOf(),
+    notShareableItems: ArrayList<Int> = arrayListOf(),
     onDataPassed: (t: Any) -> Unit
 ): AvailableShareableItemsAdapter {
     setDropDownBackgroundResource(R.drawable.background_popup)

--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -78,9 +78,11 @@ import com.google.android.material.textfield.MaterialAutoCompleteTextView
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.infomaniak.drive.R
+import com.infomaniak.drive.data.cache.DriveInfosController
 import com.infomaniak.drive.data.models.DriveUser
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.data.models.Shareable
+import com.infomaniak.drive.data.models.drive.Drive
 import com.infomaniak.drive.ui.LockActivity
 import com.infomaniak.drive.ui.LockActivity.Companion.FACE_ID_LOG_TAG
 import com.infomaniak.drive.ui.OnlyOfficeActivity
@@ -585,6 +587,10 @@ fun Fragment.safeNavigate(
 ) {
     if (canNavigate()) findNavController().navigate(resId, args, navOptions, navigatorExtras)
 }
+
+fun Drive?.getDriveUsers(): List<DriveUser> = this?.users?.let { categories ->
+    return@let DriveInfosController.getUsers(ArrayList(categories.drive + categories.account))
+} ?: listOf()
 
 fun Context.getLocalThumbnail(file: File): Bitmap? {
     val fileUri = file.path.toUri()

--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -428,11 +428,11 @@ fun String.isEmail(): Boolean {
 
 fun MaterialAutoCompleteTextView.setupAvailableShareableItems(
     context: Context,
-    itemList: ArrayList<Shareable>,
+    itemList: List<Shareable>,
     onDataPassed: (t: Any) -> Unit
 ): AvailableShareableItemsAdapter {
     setDropDownBackgroundResource(R.drawable.background_popup)
-    val availableUsersAdapter = AvailableShareableItemsAdapter(context, itemList) { user ->
+    val availableUsersAdapter = AvailableShareableItemsAdapter(context, ArrayList(itemList)) { user ->
         onDataPassed(user)
         dismissDropDown()
     }
@@ -463,7 +463,7 @@ fun MaterialAutoCompleteTextView.setupAvailableShareableItems(
     return availableUsersAdapter
 }
 
-fun ArrayList<DriveUser>.removeCommonUsers(intersectedUsers: ArrayList<Int>): ArrayList<DriveUser> {
+fun Collection<DriveUser>.removeCommonUsers(intersectedUsers: ArrayList<Int>): ArrayList<DriveUser> {
     return this.filterNot { availableUser ->
         intersectedUsers.any { it == availableUser.id }
     } as ArrayList<DriveUser>

--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -103,6 +103,7 @@ import kotlinx.android.synthetic.main.item_file.view.filePreview
 import kotlinx.android.synthetic.main.item_file.view.progressLayout
 import kotlinx.android.synthetic.main.item_user.view.*
 import java.util.*
+import kotlin.collections.ArrayList
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
@@ -429,10 +430,11 @@ fun String.isEmail(): Boolean {
 fun MaterialAutoCompleteTextView.setupAvailableShareableItems(
     context: Context,
     itemList: List<Shareable>,
+    notShareableItems: ArrayList<DriveUser> = arrayListOf(),
     onDataPassed: (t: Any) -> Unit
 ): AvailableShareableItemsAdapter {
     setDropDownBackgroundResource(R.drawable.background_popup)
-    val availableUsersAdapter = AvailableShareableItemsAdapter(context, ArrayList(itemList)) { user ->
+    val availableUsersAdapter = AvailableShareableItemsAdapter(context, ArrayList(itemList), notShareableItems) { user ->
         onDataPassed(user)
         dismissDropDown()
     }

--- a/app/src/main/res/layout/fragment_file_share_details.xml
+++ b/app/src/main/res/layout/fragment_file_share_details.xml
@@ -104,7 +104,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="@dimen/marginStandard"
                 android:layout_marginTop="@dimen/marginStandardSmall"
-                android:layout_marginBottom="@dimen/marginStandard">
+                android:layout_marginBottom="@dimen/recyclerViewPaddingBottom">
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/sharedUsersRecyclerView"

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -440,6 +440,9 @@
             android:name="sharedTagId"
             android:defaultValue="-1"
             app:argType="integer" />
+        <argument
+            android:name="notShareableUsersIds"
+            app:argType="integer[]"/>
         <action
             android:id="@+id/action_fileShareAddUserDialog_to_selectPermissionBottomSheetDialog"
             app:destination="@id/selectPermissionBottomSheetDialog" />

--- a/app/src/main/res/navigation/select_folder.xml
+++ b/app/src/main/res/navigation/select_folder.xml
@@ -165,6 +165,9 @@
             android:name="sharedTagId"
             android:defaultValue="-1"
             app:argType="integer" />
+        <argument
+            android:name="notShareableUsersIds"
+            app:argType="integer[]"/>
         <action
             android:id="@+id/action_fileShareAddUserDialog_to_selectPermissionBottomSheetDialog"
             app:destination="@id/selectPermissionBottomSheetDialog" />

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -222,6 +222,7 @@
     <string name="errorRestore">Fehler bei der Wiederherstellung</string>
     <string name="errorRightModification">Fehler bei der Änderung der Rechte</string>
     <string name="errorSave">Fehler bei der Speicherung</string>
+    <string name="errorShareAddUser">Diese Datei ist bereits für diesen Benutzer freigegeben.</string>
     <string name="errorShareLink">Fehler bei der Erstellung des Links</string>
     <string name="favoritesNoFile">Derzeit keine Favoriten</string>
     <string name="favoritesTitle">Favoriten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -222,6 +222,7 @@
     <string name="errorRestore">Error al restaurar</string>
     <string name="errorRightModification">Error al modificar los derechos</string>
     <string name="errorSave">Error al guardar</string>
+    <string name="errorShareAddUser">Este archivo ya está compartido con este usuario.</string>
     <string name="errorShareLink">Error al crear el enlace</string>
     <string name="favoritesNoFile">Todavía no hay favoritos</string>
     <string name="favoritesTitle">Favoritos</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -222,6 +222,7 @@
     <string name="errorRestore">Erreur lors de la restauration</string>
     <string name="errorRightModification">Erreur lors de la modification des droits</string>
     <string name="errorSave">Erreur lors de l’enregistrement</string>
+    <string name="errorShareAddUser">Ce fichier est déjà partagé avec cet utilisateur.</string>
     <string name="errorShareLink">Erreur lors de la création du lien</string>
     <string name="favoritesNoFile">Aucun favori pour le moment</string>
     <string name="favoritesTitle">Favoris</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -222,6 +222,7 @@
     <string name="errorRestore">Errore durante il ripristino</string>
     <string name="errorRightModification">Errore durante la modifica dei diritti</string>
     <string name="errorSave">Errore durante il salvataggio</string>
+    <string name="errorShareAddUser">Questo file è già condiviso con questo utente.</string>
     <string name="errorShareLink">Errore durante la creazione del link</string>
     <string name="favoritesNoFile">Al momento non sono disponibili preferiti</string>
     <string name="favoritesTitle">Preferiti</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -231,6 +231,7 @@
     <string name="errorRestore">Recover error</string>
     <string name="errorRightModification">Error when editing rights</string>
     <string name="errorSave">Save error</string>
+    <string name="errorShareAddUser">This file is already shared with this user.</string>
     <string name="errorShareLink">Error when creating link</string>
     <string name="favoritesNoFile">No favorites at this time</string>
     <string name="favoritesTitle">Favorites</string>


### PR DESCRIPTION
This PR : 
- Cleans the existing code for shares
- Fixes a bug concerning available users (previously you weren't able to add a user after his deletion)
- Optimizes the workflow of available user check (previously we were fetching the totality of the users and we filtered them **AT EACH ADAPTER REFRESH** -> now we only pass the user we no longer want to see available 😂 )
- Fixes a crashy bug (sometimes users could be led to a crash due to an empty adapter -> because we permanently reassigned the itemList, it's no the case.)
- Add a "feature" which converts an email in user if possible
- Add a "security" that checks if an user is not already shared and if that's the case -> show a snackbar