### PR TITLE
fix okhttp track upload + cancel when work is cancelled

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/utils/SyncUtils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/SyncUtils.kt
@@ -20,8 +20,6 @@ package com.infomaniak.drive.utils
 import android.content.Context
 import android.content.Intent
 import android.database.Cursor
-import android.net.ConnectivityManager
-import android.net.NetworkCapabilities
 import android.net.Uri
 import android.os.Build
 import android.provider.DocumentsContract


### PR DESCRIPTION
Some interceptors cause the upload tracker to be called multiple times and its fake the upload

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>