### PR TITLE
Fixed missing pending intents for Android 12

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation project(path: ':Core')
 
-    def work_version = '2.5.0'
+    def work_version = '2.7.0-alpha05'
     implementation "androidx.work:work-runtime-ktx:$work_version"
 
     implementation 'androidx.recyclerview:recyclerview:1.2.1'

--- a/app/src/main/java/com/infomaniak/drive/ApplicationMain.kt
+++ b/app/src/main/java/com/infomaniak/drive/ApplicationMain.kt
@@ -38,6 +38,7 @@ import com.infomaniak.drive.data.documentprovider.CloudStorageProvider
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.data.models.UISettings
 import com.infomaniak.drive.data.models.drive.Drive
+import com.infomaniak.drive.data.sync.UploadNotifications.pendingIntentFlags
 import com.infomaniak.drive.ui.LaunchActivity
 import com.infomaniak.drive.utils.*
 import com.infomaniak.drive.utils.NotificationUtils.initNotificationChannel
@@ -164,7 +165,7 @@ class ApplicationMain : Application(), ImageLoaderFactory {
 
     private val refreshTokenError: (User) -> Unit = { user ->
         val openAppIntent = Intent(this, LaunchActivity::class.java).clearStack()
-        val pendingIntent: PendingIntent = PendingIntent.getActivity(this, 0, openAppIntent, 0)
+        val pendingIntent: PendingIntent = PendingIntent.getActivity(this, 0, openAppIntent, pendingIntentFlags)
         val notificationManagerCompat = NotificationManagerCompat.from(this)
         showGeneralNotification(getString(R.string.refreshTokenError)).apply {
             setContentIntent(pendingIntent)


### PR DESCRIPTION
Based on : https://stackoverflow.com/questions/68228666/targeting-s-version-10000-and-above-requires-that-one-of-flag-immutable-or-fl

+ Checked if pendingIntent weren't missing directly in project