### PR TITLE
Don't start retry or start upload when the mobile storage is low

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
@@ -371,6 +371,7 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
             val networkType = if (AppSettings.onlyWifiSync) NetworkType.UNMETERED else NetworkType.CONNECTED
             return Constraints.Builder()
                 .setRequiredNetworkType(networkType)
+                .setRequiresStorageNotLow(true)
                 .build()
         }
 


### PR DESCRIPTION
Warn the system not to restart the sync when the device storage is low.

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>