### PR TITLE
Actually /sdcard/Android/media⁠ directory is part of shared storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,10 +35,6 @@
     <uses-permission
         android:name="android.permission.ACCESS_MEDIA_LOCATION"
         android:minSdkVersion="29" />
-    <uses-permission
-        android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
-        android:minSdkVersion="29"
-        tools:ignore="ScopedStorage" />
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />


### PR DESCRIPTION
> More information here: https://developer.android.com/training/data-storage/manage-all-files#operations-allowed-manage-external-storage
We will see in the future if we need this

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>