### PR TITLE
restart upload on refresh token + more sentry logs

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/api/ProgressRequestBody.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/ProgressRequestBody.kt
@@ -35,12 +35,10 @@ class ProgressRequestBody(
     private val onProgress: (currentBytes: Int, bytesWritten: Long, contentLength: Long) -> Unit
 ) : RequestBody() {
 
-    @Synchronized
     override fun contentType(): MediaType? {
         return requestBody.contentType()
     }
 
-    @Synchronized
     override fun contentLength(): Long {
         try {
             return requestBody.contentLength()
@@ -49,6 +47,8 @@ class ProgressRequestBody(
         }
         return -1
     }
+
+    override fun isOneShot() = true
 
     @Throws(IOException::class)
     override fun writeTo(sink: BufferedSink) {

--- a/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
@@ -138,14 +138,12 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
             currentUploadFile?.lockErrorNotification(applicationContext)
             Result.retry()
 
-        } catch (exception: UploadTask.ChunksSizeExceededException) {
-            Result.retry()
-
-        } catch (exception: UploadTask.UploadErrorException) {
-            Result.retry()
-
         } catch (exception: Exception) {
             when {
+                exception is UploadTask.ChunksSizeExceededException
+                        || exception is UploadTask.NotAuthorizedException
+                        || exception is UploadTask.UploadErrorException -> Result.retry()
+
                 exception.isNetworkException() -> {
                     currentUploadFile?.networkErrorNotification(applicationContext)
                     Result.retry()


### PR DESCRIPTION
This fixes the bug that was often noted with the upload size exceeded

I didn't notice any other issues that could be related to this apart from the refresh token. So I added more Sentry logs to allow easier debugging in the future if it happens with other cases.

> Hopefully we won't see these errors again 🤞🏽

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>