### PR TITLE
fix remove uploaded files from uploads fragment

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/UploadInProgressFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/UploadInProgressFragment.kt
@@ -83,8 +83,7 @@ class UploadInProgressFragment : FileListFragment() {
             val position = fileAdapter.indexOf(fileName)
 
             if (folderID == remoteFolderId && position >= 0) {
-                if (isUploaded) whenAnUploadIsDone()
-                else fileAdapter.updateFileProgress(position = position, progress = progress)
+                if (!isUploaded) fileAdapter.updateFileProgress(position = position, progress = progress)
             }
 
             Log.d("uploadInProgress", "$fileName $progress%")
@@ -96,7 +95,6 @@ class UploadInProgressFragment : FileListFragment() {
             pendingFiles.find { it.fileName == fileName }?.let { syncFile ->
                 val title = getString(R.string.uploadInProgressCancelFileUploadTitle, syncFile.fileName)
                 Utils.createConfirmation(requireContext(), title) {
-                    val position = fileAdapter.getFiles().indexOfFirst { it.name == fileName }
                     if (fileAdapter.contains(syncFile.fileName)) {
                         closeItemClicked(uploadFiles = arrayListOf(syncFile))
                     }
@@ -132,14 +130,14 @@ class UploadInProgressFragment : FileListFragment() {
                     fileAdapter.deleteAt(fileIndex)
                 }
                 fileAdapter.notifyItemRangeRemoved(range.startIndex, range.length)
-                if (fileAdapter.fileList.isEmpty()) popBackStack()
+                whenAnUploadIsDone()
             }
         }
     }
 
 
     private fun whenAnUploadIsDone() {
-        if (uploadFiles?.isEmpty() == true) {
+        if (fileAdapter.fileList.isEmpty()) {
             noFilesLayout.toggleVisibility(true)
             requireActivity().showSnackbar(R.string.allUploadFinishedTitle)
             popBackStack()


### PR DESCRIPTION
When an upload is done, remove it from adapter list and popback if empty list

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>