### PR TITLE
fix IllegalStateException on multiple selection action

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/models/File.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/File.kt
@@ -114,6 +114,10 @@ open class File(
     @Ignore
     var currentProgress: Int = INDETERMINATE_PROGRESS
 
+    fun isManagedByRealm() = isManaged && isValid
+
+    fun isNotManagedByRealm() = !isManaged
+
     fun isFolder(): Boolean {
         return type == "dir"
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
@@ -348,8 +348,7 @@ open class FileAdapter(
 
     private fun isSelectedFile(file: File): Boolean {
         return itemsSelected.find {
-            val isValidInRealm = it.isManaged && it.isValid
-            (isValidInRealm || !it.isManaged) && it.id == file.id
+            (it.isManagedByRealm() || it.isNotManagedByRealm()) && it.id == file.id
         } != null
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -317,8 +317,12 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
                 val mediator = mainViewModel.createMultiSelectMediator()
                 enableButtonMultiSelect(false)
 
-                fileAdapter.getValidItemsSelected().forEach {
-                    val file = it.realm?.copyFromRealm(it, 0) ?: it
+                selectedFiles.reversed().forEach {
+                    val file = when {
+                        it.isManagedByRealm() -> it.realm.copyFromRealm(it, 0)
+                        it.isNotManagedByRealm() -> it
+                        else -> return@forEach
+                    }
                     val onSuccess: (Int) -> Unit = { fileID ->
                         runBlocking(Dispatchers.Main) { fileAdapter.deleteByFileId(fileID) }
                     }


### PR DESCRIPTION
Fix [Sentry issue](https://sentry.infomaniak.com/organizations/infomaniak/issues/4013/?project=3&referrer=AssignedActivityEmail)

`java.lang.IllegalStateException: the object is already deleted.
    at io.realm.RealmObject.getRealm(RealmObject.java:430)
    at io.realm.RealmObject.getRealm(RealmObject.java:403)
    at com.infomaniak.drive.ui.fileList.FileListFragment$performBulkOperation$onActionApproved$1.invoke(FileListFragment.kt:321)
    at com.infomaniak.drive.ui.fileList.FileListFragment$performBulkOperation$onActionApproved$1.invoke(FileListFragment.kt:303)
    at com.infomaniak.drive.ui.fileList.FileListFragment.performBulkOperation(FileListFragment.kt:389)
    at com.infomaniak.drive.ui.fileList.FileListFragment.onSelectFolderResult(FileListFragment.kt:570)
    at com.infomaniak.drive.ui.fileList.FileListFragment.onActivityResult(FileListFragment.kt:278)
    at androidx.fragment.app.FragmentManager$7.onActivityResult(FragmentManager.java:2605)
    at androidx.fragment.app.FragmentManager$7.onActivityResult(FragmentManager.java:2585)
    at androidx.activity.result.ActivityResultRegistry.doDispatch(ActivityResultRegistry.java:392)
    at androidx.activity.result.ActivityResultRegistry.dispatchResult(ActivityResultRegistry.java:351)
    at androidx.activity.ComponentActivity.onActivityResult(ComponentActivity.java:647)
    at androidx.fragment.app.FragmentActivity.onActivityResult(FragmentActivity.java:140)
    at android.app.Activity.dispatchActivityResult(Activity.java:8550)
    at android.app.ActivityThread.deliverResults(ActivityThread.java:5572)
    at android.app.ActivityThread.handleSendResult(ActivityThread.java:5620)
    at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:51)
    at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2325)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:246)
    at android.app.ActivityThread.main(ActivityThread.java:8633)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)`

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>