### PR TITLE
fix illegalState Exception on saving generated path

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -90,7 +90,7 @@ object FileController {
         getRealmInstance(userDrive).use { realm ->
             getFileById(realm, fileId)?.let { file ->
                 realm.executeTransaction {
-                    file.path = generatedPath
+                    if (file.isValid) file.path = generatedPath
                 }
             }
         }


### PR DESCRIPTION
Fix [Sentry issue](https://sentry.infomaniak.com/organizations/infomaniak/issues/4176/?project=3&query=is%3Aunresolved+firstRelease%3Alatest&sort=user&statsPeriod=14d)

`java.lang.IllegalStateException: Object is no longer valid to operate on. Was it deleted by another thread?
    at io.realm.internal.UncheckedRow.nativeSetString(UncheckedRow.java)
    at io.realm.internal.UncheckedRow.setString(UncheckedRow.java:299)
    at io.realm.com_infomaniak_drive_data_models_FileRealmProxy.realmSet$path(com_infomaniak_drive_data_models_FileRealmProxy.java:737)
    at com.infomaniak.drive.data.models.File.setPath(File.kt:84)
    at com.infomaniak.drive.data.cache.FileController.savePath$lambda-4$lambda-3$lambda-2(FileController.kt:93)
    at com.infomaniak.drive.data.cache.FileController.$r8$lambda$-Ptlw_0gprgpjo2t_WSiQXxmBXU
    at com.infomaniak.drive.data.cache.FileController$$ExternalSyntheticLambda5.execute
    at io.realm.Realm.executeTransaction(Realm.java:1593)
    at com.infomaniak.drive.data.cache.FileController.savePath(FileController.kt:92)
    at com.infomaniak.drive.data.cache.FileController.access$savePath(FileController.kt:41)
    at com.infomaniak.drive.data.cache.FileController$generateAndSavePath$1$1$1.invokeSuspend(FileController.kt:79)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)`
Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>