### PR TITLE
Fix IllegalStateException when a file is clicked

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/models/File.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/File.kt
@@ -114,7 +114,7 @@ open class File(
     @Ignore
     var currentProgress: Int = INDETERMINATE_PROGRESS
 
-    fun isManagedByRealm() = isManaged && isValid
+    fun isManagedAndValidByRealm() = isManaged && isValid
 
     fun isNotManagedByRealm() = !isManaged
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
@@ -354,7 +354,7 @@ open class FileAdapter(
 
     private fun isSelectedFile(file: File): Boolean {
         return itemsSelected.find {
-            (it.isManagedByRealm() || it.isNotManagedByRealm()) && it.id == file.id
+            (it.isManagedAndValidByRealm() || it.isNotManagedByRealm()) && it.id == file.id
         } != null
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -319,7 +319,7 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
 
                 selectedFiles.reversed().forEach {
                     val file = when {
-                        it.isManagedByRealm() -> it.realm.copyFromRealm(it, 0)
+                        it.isManagedAndValidByRealm() -> it.realm.copyFromRealm(it, 0)
                         it.isNotManagedByRealm() -> it
                         else -> return@forEach
                     }
@@ -475,7 +475,7 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         fileAdapter.stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
         fileAdapter.setHasStableIds(true)
         fileAdapter.onFileClicked = { file ->
-            if (file.isManagedByRealm() || file.isNotManagedByRealm()) {
+            if (file.isManagedAndValidByRealm() || file.isNotManagedByRealm()) {
                 if (file.isFolder())
                     openFolder(file)
                 else

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -476,10 +476,7 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         fileAdapter.setHasStableIds(true)
         fileAdapter.onFileClicked = { file ->
             if (file.isManagedAndValidByRealm() || file.isNotManagedByRealm()) {
-                if (file.isFolder())
-                    openFolder(file)
-                else
-                    displayFile(file)
+                if (file.isFolder()) openFolder(file) else displayFile(file)
             } else {
                 refreshActivities()
             }


### PR DESCRIPTION
Fix: [Sentry Issue](https://sentry.infomaniak.com/organizations/infomaniak/issues/4248/?project=3&query=is%3Aunresolved+firstRelease%3Alatest&sort=user&statsPeriod=14d)

```
java.lang.IllegalStateException: Object is no longer valid to operate on. Was it deleted by another thread?
    at io.realm.internal.UncheckedRow.nativeGetString(UncheckedRow.java)
    at io.realm.internal.UncheckedRow.getString(UncheckedRow.java:161)
    at io.realm.com_infomaniak_drive_data_models_FileRealmProxy.realmGet$type(com_infomaniak_drive_data_models_FileRealmProxy.java:912)
    at com.infomaniak.drive.data.models.File.isFolder(File.kt:118)
    at com.infomaniak.drive.ui.fileList.FileListFragment$setupFileAdapter$2.invoke(FileListFragment.kt:474)
    at com.infomaniak.drive.ui.fileList.FileListFragment$setupFileAdapter$2.invoke(FileListFragment.kt:472)
    at com.infomaniak.drive.ui.fileList.FileAdapter.onBindViewHolder$lambda-10$lambda-8(FileAdapter.kt:279)
    at com.infomaniak.drive.ui.fileList.FileAdapter.$r8$lambda$uY-AMSqNHjdoPzD2QcMYPxUuYBA
    at com.infomaniak.drive.ui.fileList.FileAdapter$$ExternalSyntheticLambda0.onClick
    at android.view.View.performClick(View.java:7171)
    at android.view.View.performClickInternal(View.java:7148)
    at android.view.View.access$3500(View.java:802)
    at android.view.View$PerformClick.run(View.java:27409)
    at android.os.Handler.handleCallback(Handler.java:883)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loop(Looper.java:214)
    at android.app.ActivityThread.main(ActivityThread.java:7642)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:503)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>