### PR TITLE
Fix IllegalStateException on deletion a syncFile

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
@@ -216,7 +216,9 @@ open class UploadFile(
             getRealmInstance().use { realm ->
                 syncFileByUriQuery(realm, uri.toString()).findFirst()?.let { syncFile ->
                     realm.executeTransaction {
-                        if (keepFile) syncFile.deletedAt = Date() else syncFile.deleteFromRealm()
+                        if (syncFile.isValid) {
+                            if (keepFile) syncFile.deletedAt = Date() else syncFile.deleteFromRealm()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fix: [Sentry issue](https://sentry.infomaniak.com/organizations/infomaniak/issues/4407/?project=3&query=is%3Aunresolved+firstRelease%3Alatest&sort=user&statsPeriod=14d)

```
java.lang.IllegalStateException: Object is no longer valid to operate on. Was it deleted by another thread?
    at io.realm.internal.UncheckedRow.nativeGetObjectKey(UncheckedRow.java)
    at io.realm.internal.UncheckedRow.getObjectKey(UncheckedRow.java:131)
    at io.realm.RealmObject.deleteFromRealm(RealmObject.java:123)
    at io.realm.RealmObject.deleteFromRealm(RealmObject.java:95)
    at com.infomaniak.drive.data.models.UploadFile$Companion.deleteIfExists$lambda-19$lambda-18$lambda-17(UploadFile.kt:219)
    at com.infomaniak.drive.data.models.UploadFile$Companion.$r8$lambda$YQ4quZ6-J2si4cDR7WI65-cWomU
    at com.infomaniak.drive.data.models.UploadFile$Companion$$ExternalSyntheticLambda4.execute
    at io.realm.Realm.executeTransaction(Realm.java:1593)
    at com.infomaniak.drive.data.models.UploadFile$Companion.deleteIfExists(UploadFile.kt:218)
    at com.infomaniak.drive.data.models.UploadFile$Companion.deleteIfExists$default(UploadFile.kt:215)
    at com.infomaniak.drive.data.services.UploadWorker$getLocalLastMediasAsync$1.invokeSuspend(UploadWorker.kt:352)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```
Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>