### PR TITLE
Fixed padding issue in kDrive switch dialog

### DIFF
--- a/app/src/main/res/layout/dialog_switch_drive.xml
+++ b/app/src/main/res/layout/dialog_switch_drive.xml
@@ -40,7 +40,6 @@
         android:layout_marginTop="@dimen/marginStandard"
         android:clipToPadding="false"
         android:orientation="vertical"
-        android:paddingBottom="@dimen/standardHeightCardview"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintTop_toBottomOf="@id/searchViewCard"
         tools:itemCount="4"


### PR DESCRIPTION
When the dialog to switch between kDrives is open, we can't click on the blank part of the screen to cancel the dialog, because of a padding issue.