### PR TITLE
Fix IllegalSateException on update a file

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -321,7 +321,7 @@ object FileController {
             val apiResponse = ApiRepository.getFileDetails(File(id = fileId, driveId = userDrive.driveId))
             if (apiResponse.isSuccess()) {
                 apiResponse.data?.let { remoteFile ->
-                    insertOrUpdateFile(realm, remoteFile, getFileProxyById(fileId, userDrive))
+                    insertOrUpdateFile(realm, remoteFile, getFileProxyById(fileId, customRealm = realm))
                     remoteFile
                 }
             } else {
@@ -813,7 +813,7 @@ object FileController {
     ) {
         returnResponse[fileActivity.fileId] = File.LocalFileActivity.IS_UPDATE
 
-        getFileProxyById(fileActivity.fileId)?.let { file ->
+        getFileProxyById(fileActivity.fileId, customRealm = realm)?.let { file ->
             insertOrUpdateFile(realm, fileActivity.file!!, file)
         } ?: also {
             returnResponse[fileActivity.fileId] = File.LocalFileActivity.IS_NEW


### PR DESCRIPTION
Fix: [Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/4241/?project=3&query=is%3Aunresolved+firstRelease%3Alatest+level%3Afatal&sort=user&statsPeriod=14d)

```
java.lang.IllegalStateException: This Realm instance has already been closed, making it unusable.
    at io.realm.BaseRealm.checkIfValid(BaseRealm.java:516)
    at io.realm.com_infomaniak_drive_data_models_FileRealmProxy.realmGet$isComplete(com_infomaniak_drive_data_models_FileRealmProxy.java:1028)
    at com.infomaniak.drive.data.models.File.isComplete(File.kt:101)
    at com.infomaniak.drive.data.cache.FileController.insertOrUpdateFile$lambda-11(FileController.kt:195)
    at com.infomaniak.drive.data.cache.FileController.$r8$lambda$YJDBmmTnIIG1friIESiBdJKDoM4(FileController.kt)
    at com.infomaniak.drive.data.cache.FileController$$ExternalSyntheticLambda7.execute
    at io.realm.Realm.executeTransaction(Realm.java:1593)
    at com.infomaniak.drive.data.cache.FileController.insertOrUpdateFile(FileController.kt:193)
    at com.infomaniak.drive.data.cache.FileController.insertOrUpdateFile$default(FileController.kt:187)
    at com.infomaniak.drive.data.cache.FileController.updateFileFromActivity(FileController.kt:817)
    at com.infomaniak.drive.data.cache.FileController.applyFileActivity(FileController.kt:752)
    at com.infomaniak.drive.data.cache.FileController.getFolderActivitiesRec(FileController.kt:699)
    at com.infomaniak.drive.data.cache.FileController.getFolderActivities(FileController.kt:680)
    at com.infomaniak.drive.ui.fileList.FileListViewModel$getFolderActivities$1.invokeSuspend(FileListViewModel.kt:186)
    at com.infomaniak.drive.ui.fileList.FileListViewModel$getFolderActivities$1.invoke(FileListViewModel.kt)
    at com.infomaniak.drive.ui.fileList.FileListViewModel$getFolderActivities$1.invoke(FileListViewModel.kt)
    at androidx.lifecycle.BlockRunner$maybeRun$1.invokeSuspend(CoroutineLiveData.kt:176)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>