### PR TITLE
ignore stable id if position doesn't exists

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
@@ -196,7 +196,8 @@ open class FileAdapter(
     override fun getItemCount() = fileList.size + if (showLoading) 1 else 0
 
     override fun getItemId(position: Int): Long {
-        return if (hasStableIds()) fileList[position].id.toLong() else super.getItemId(position)
+        val file = fileList.getOrNull(position)
+        return if (hasStableIds() && file != null) file.id.toLong() else super.getItemId(position)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {


### PR DESCRIPTION
Fix: [Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/4610/?project=3&query=is%3Aunresolved+release%3Acom.infomaniak.drive%404.0.38%2B40003801&statsPeriod=14d)

```
java.lang.ArrayIndexOutOfBoundsException: Out of range  in /tmp/realm-java/realm/realm-library/src/main/cpp/io_realm_internal_OsResults.cpp line 103(requested: 13 valid: 13)
    at io.realm.internal.OsResults.nativeGetRow(OsResults.java)
    at io.realm.internal.OsResults.getUncheckedRow(OsResults.java:357)
    at io.realm.OrderedRealmCollectionImpl$ModelCollectionOperator.get(OrderedRealmCollectionImpl.java:701)
    at io.realm.OrderedRealmCollectionImpl.get(OrderedRealmCollectionImpl.java:138)
    at io.realm.RealmResults.get(RealmResults.java:71)
    at com.infomaniak.drive.ui.fileList.FileAdapter.getItemId(FileAdapter.kt:199)
    at androidx.recyclerview.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline(RecyclerView.java:6370)
    at androidx.recyclerview.widget.GapWorker.prefetchPositionWithDeadline(GapWorker.java:288)
    at androidx.recyclerview.widget.GapWorker.flushTaskWithDeadline(GapWorker.java:345)
    at androidx.recyclerview.widget.GapWorker.flushTasksWithDeadline(GapWorker.java:361)
    at androidx.recyclerview.widget.GapWorker.prefetch(GapWorker.java:368)
    at androidx.recyclerview.widget.GapWorker.run(GapWorker.java:399)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:246)
    at android.app.ActivityThread.main(ActivityThread.java:8425)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:596)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>