### PR TITLE
remove sharing file from argument in preview

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -46,6 +46,7 @@ import io.realm.Realm
 import io.sentry.Sentry
 import kotlinx.coroutines.*
 import java.util.*
+import kotlin.collections.LinkedHashMap
 
 class MainViewModel(appContext: Application) : AndroidViewModel(appContext) {
 
@@ -53,7 +54,7 @@ class MainViewModel(appContext: Application) : AndroidViewModel(appContext) {
 
     val currentFolder = MutableLiveData<File>()
     val currentFolderOpenAddFileBottom = MutableLiveData<File>()
-    var currentFileList = ArrayList<File>()
+    var currentFileList = LinkedHashMap<Int, File>()
     val isInternetAvailable = MutableLiveData(true)
 
     val createDropBoxSuccess = SingleLiveEvent<DropBox>()

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderAdapter.kt
@@ -33,7 +33,7 @@ class PreviewSliderAdapter(manager: FragmentManager, lifecycle: Lifecycle) : Fra
 
     override fun createFragment(position: Int): Fragment {
         val file = getFile(position)
-        val args = bundleOf(PreviewFragment.FILE_TAG to file)
+        val args = bundleOf(PreviewFragment.FILE_ID_TAG to file.id)
         return when (file.getFileType()) {
             File.ConvertedType.IMAGE -> PreviewPictureFragment().apply { arguments = args }
             File.ConvertedType.VIDEO -> PreviewVideoFragment().apply { arguments = args }

--- a/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
@@ -197,7 +197,7 @@ object Utils {
         fileList: ArrayList<File>,
         isSharedWithMe: Boolean = false
     ) {
-        mainViewModel.currentFileList = fileList
+        mainViewModel.currentFileList = fileList.associateBy { it.id } as LinkedHashMap<Int, File>
         val navOptions = NavOptions.Builder()
             .setEnterAnim(R.anim.fragment_open_enter)
             .setExitAnim(R.anim.fragment_open_exit)


### PR DESCRIPTION
Fix: [Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/1669/?project=3)

```
android.os.BadParcelableException: ClassNotFoundException when unmarshalling: abonnements.odt￿￿'com.infomaniak.drive.data.models.Rights½private￿￿
    at android.os.Parcel.readParcelableCreator(Parcel.java:3050)
    at android.os.Parcel.readParcelable(Parcel.java:2967)
    at com.infomaniak.drive.data.models.File$Creator.createFromParcel
    at com.infomaniak.drive.data.models.File$Creator.createFromParcel
    at android.os.Parcel.readParcelable(Parcel.java:2976)
    at android.os.Parcel.readValue(Parcel.java:2869)
    at android.os.Parcel.readArrayMapInternal(Parcel.java:3252)
    at android.os.BaseBundle.initializeFromParcelLocked(BaseBundle.java:292)
    at android.os.BaseBundle.unparcel(BaseBundle.java:236)
    at android.os.Bundle.getParcelable(Bundle.java:951)
    at com.infomaniak.drive.ui.fileList.preview.PreviewFragment.onCreate(PreviewFragment.kt:41)
    at androidx.fragment.app.Fragment.performCreate(Fragment.java:2979)
    at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:473)
    at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:257)
    at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:113)
    at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1362)
    at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2829)
    at androidx.fragment.app.FragmentManager.dispatchCreate(FragmentManager.java:2761)
    at androidx.fragment.app.Fragment.restoreChildFragmentState(Fragment.java:1933)
    at androidx.fragment.app.Fragment.onCreate(Fragment.java:1909)
    at androidx.fragment.app.Fragment.performCreate(Fragment.java:2979)
    at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:473)
    at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:257)
    at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:113)
    at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1362)
    at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2829)
    at androidx.fragment.app.FragmentManager.dispatchCreate(FragmentManager.java:2761)
    at androidx.fragment.app.Fragment.restoreChildFragmentState(Fragment.java:1933)
    at androidx.fragment.app.Fragment.onCreate(Fragment.java:1909)
    at androidx.navigation.fragment.NavHostFragment.onCreate(NavHostFragment.kt:164)
    at androidx.fragment.app.Fragment.performCreate(Fragment.java:2979)
    at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:473)
    at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:257)
    at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:113)
    at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1362)
    at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2829)
    at androidx.fragment.app.FragmentManager.dispatchCreate(FragmentManager.java:2761)
    at androidx.fragment.app.FragmentController.dispatchCreate(FragmentController.java:251)
    at androidx.fragment.app.FragmentActivity.onCreate(FragmentActivity.java:252)
    at com.infomaniak.drive.ui.BaseActivity.onCreate(BaseActivity.kt:28)
    at com.infomaniak.drive.ui.MainActivity.onCreate(MainActivity.kt:89)
    at android.app.Activity.performCreate(Activity.java:7893)
    at android.app.Activity.performCreate(Activity.java:7880)
    at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1307)
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3279)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3443)
    at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
    at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2040)
    at android.os.Handler.dispatchMessage(Handler.java:107)
    at android.os.Looper.loop(Looper.java:224)
    at android.app.ActivityThread.main(ActivityThread.java:7520)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:539)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)

java.lang.RuntimeException: Unable to start activity ComponentInfo{com.infomaniak.drive/com.infomaniak.drive.ui.MainActivity}: android.os.BadParcelableException: ClassNotFoundException when unmarshalling: abonnements.odt￿￿'com.infomaniak.drive.data.models.Rights½private￿￿
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3304)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3443)
    at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
    at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2040)
    at android.os.Handler.dispatchMessage(Handler.java:107)
    at android.os.Looper.loop(Looper.java:224)
    at android.app.ActivityThread.main(ActivityThread.java:7520)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:539)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
```
Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>