### PR TITLE
fix file equals fun with a deleted file

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/models/File.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/File.kt
@@ -306,11 +306,12 @@ open class File(
 
     // For applyFileActivity in FileController
     override fun equals(other: Any?): Boolean {
-        if (!isUsable()) return false
-
         if (other is File) {
-            return other.isUsable() && other.id == id
+            return isUsable()
+                    && other.isUsable()
+                    && other.id == id
         }
+
         return super.equals(other)
     }
 

--- a/app/src/main/java/com/infomaniak/drive/data/models/File.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/File.kt
@@ -309,7 +309,6 @@ open class File(
         if (other is File) {
             return isUsable() && other.isUsable() && other.id == id
         }
-
         return super.equals(other)
     }
 

--- a/app/src/main/java/com/infomaniak/drive/data/models/File.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/File.kt
@@ -307,9 +307,7 @@ open class File(
     // For applyFileActivity in FileController
     override fun equals(other: Any?): Boolean {
         if (other is File) {
-            return isUsable()
-                    && other.isUsable()
-                    && other.id == id
+            return isUsable() && other.isUsable() && other.id == id
         }
 
         return super.equals(other)

--- a/app/src/main/java/com/infomaniak/drive/data/models/File.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/File.kt
@@ -306,8 +306,10 @@ open class File(
 
     // For applyFileActivity in FileController
     override fun equals(other: Any?): Boolean {
+        if (!isUsable()) return false
+
         if (other is File) {
-            return other.id == id
+            return other.isUsable() && other.id == id
         }
         return super.equals(other)
     }


### PR DESCRIPTION
Fix: [Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/4641/?project=3&query=is%3Aunresolved+assigned%3Ame&sort=user&statsPeriod=14d)

```
java.lang.IllegalStateException: Object is no longer valid to operate on. Was it deleted by another thread?
    at io.realm.internal.UncheckedRow.nativeGetLong(UncheckedRow.java)
    at io.realm.internal.UncheckedRow.getLong(UncheckedRow.java:136)
    at io.realm.com_infomaniak_drive_data_models_FileRealmProxy.realmGet$id(com_infomaniak_drive_data_models_FileRealmProxy.java:207)
    at com.infomaniak.drive.data.models.File.equals(File.kt:310)
    at java.util.AbstractCollection.remove(AbstractCollection.java:292)
    at io.realm.RealmList.remove(RealmList.java:381)
    at com.infomaniak.drive.ui.fileList.FileAdapter.removeSelectedFile(FileAdapter.kt:356)
    at com.infomaniak.drive.ui.fileList.FileAdapter.onSelectedFile(FileAdapter.kt:337)
    at com.infomaniak.drive.ui.fileList.FileAdapter.onBindViewHolder$lambda-11$lambda-9(FileAdapter.kt:283)
    at com.infomaniak.drive.ui.fileList.FileAdapter.$r8$lambda$mDbwXof2XA5uu0JdXRFnf6NOxzA
    at com.infomaniak.drive.ui.fileList.FileAdapter$$ExternalSyntheticLambda0.onClick
    at android.view.View.performClick(View.java:7460)
    at android.view.View.performClickInternal(View.java:7425)
    at android.view.View.access$3600(View.java:810)
    at android.view.View$PerformClick.run(View.java:28321)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:223)
    at android.app.ActivityThread.main(ActivityThread.java:7721)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:952)
```

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>