### PR TITLE
skip deleted old file on update a file

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -219,11 +219,11 @@ object FileController {
         moreTransaction: (() -> Unit)? = null
     ) {
         realm.executeTransaction {
-            oldFile?.let { file ->
-                newFile.isComplete = file.isComplete
-                newFile.children = file.children
-                newFile.responseAt = file.responseAt
-                newFile.isOffline = file.isOffline
+            if (oldFile?.isUsable() == true) {
+                newFile.isComplete = oldFile.isComplete
+                newFile.children = oldFile.children
+                newFile.responseAt = oldFile.responseAt
+                newFile.isOffline = oldFile.isOffline
             }
             moreTransaction?.invoke()
             it.insertOrUpdate(newFile)


### PR DESCRIPTION
Fix: [Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/4648/?project=3&query=is%3Aunresolved+assigned%3Ame&sort=user&statsPeriod=14d)

```
java.lang.IllegalStateException: Object is no longer valid to operate on. Was it deleted by another thread?
    at io.realm.internal.UncheckedRow.nativeGetBoolean(UncheckedRow.java)
    at io.realm.internal.UncheckedRow.getBoolean(UncheckedRow.java:141)
    at io.realm.com_infomaniak_drive_data_models_FileRealmProxy.realmGet$isComplete(com_infomaniak_drive_data_models_FileRealmProxy.java:1029)
    at com.infomaniak.drive.data.models.File.isComplete(File.kt:101)
    at com.infomaniak.drive.data.cache.FileController.insertOrUpdateFile$lambda-11(FileController.kt:223)
    at com.infomaniak.drive.data.cache.FileController.$r8$lambda$YJDBmmTnIIG1friIESiBdJKDoM4
    at com.infomaniak.drive.data.cache.FileController$$ExternalSyntheticLambda6.execute
    at io.realm.Realm.executeTransaction(Realm.java:1593)
    at com.infomaniak.drive.data.cache.FileController.insertOrUpdateFile(FileController.kt:221)
    at com.infomaniak.drive.data.cache.FileController.insertOrUpdateFile$default(FileController.kt:215)
    at com.infomaniak.drive.data.cache.FileController.updateFileFromActivity(FileController.kt:846)
    at com.infomaniak.drive.data.cache.FileController.applyFileActivity(FileController.kt:781)
    at com.infomaniak.drive.data.cache.FileController.getFolderActivitiesRec(FileController.kt:728)
    at com.infomaniak.drive.data.cache.FileController.getFolderActivities(FileController.kt:709)
    at com.infomaniak.drive.ui.fileList.FileListViewModel$getFolderActivities$1.invokeSuspend(FileListViewModel.kt:186)
    at com.infomaniak.drive.ui.fileList.FileListViewModel$getFolderActivities$1.invoke
    at com.infomaniak.drive.ui.fileList.FileListViewModel$getFolderActivities$1.invoke
    at androidx.lifecycle.BlockRunner$maybeRun$1.invokeSuspend(CoroutineLiveData.kt:176)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>