### PR TITLE
fix navigation controller state on restore activity

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
@@ -90,7 +90,13 @@ class MainActivity : BaseActivity() {
         downloadReceiver = DownloadReceiver(mainViewModel)
 
         val navHostFragment = supportFragmentManager.findFragmentById(R.id.hostFragment) as NavHostFragment
-        val navController = navHostFragment.navController
+
+        val navController = navHostFragment.navController.apply {
+            if (currentDestination == null) {
+                navigate(graph.startDestinationId)
+            }
+        }
+
         bottomNavigation.setupWithNavController(navController)
         bottomNavigation.itemIconTintList = ContextCompat.getColorStateList(this, R.color.item_icon_tint_bottom)
         bottomNavigation.selectedItemId = UISettings(this).bottomNavigationSelectedItem


### PR DESCRIPTION
Fix: navigation controller state backQueue after activity has been restored

- [Sentry link - PreviewFragment](https://sentry.infomaniak.com/organizations/infomaniak/issues/4684/?project=3&query=is%3Aunresolved+release%3Acom.infomaniak.drive%404.0.41%2B40004101&statsPeriod=14d)
- [Sentry link - MainActivity](https://sentry.infomaniak.com/organizations/infomaniak/issues/3598/?project=3&query=is%3Aunresolved+level%3Afatal&sort=user&statsPeriod=14d)

## Exception:  [Sentry link - PreviewFragment](https://sentry.infomaniak.com/organizations/infomaniak/issues/4684/?project=3&query=is%3Aunresolved+release%3Acom.infomaniak.drive%404.0.41%2B40004101&statsPeriod=14d) ##
```
java.lang.IllegalArgumentException: No destination with ID 2131362753 is on the NavController's back stack. The current destination is Destination(com.infomaniak.drive:id/fileListFragment) label=Fichiers class=com.infomaniak.drive.ui.fileList.FileListFragment
	at androidx.navigation.NavController.getBackStackEntry(NavController.kt:2200)
	at com.infomaniak.drive.ui.fileList.preview.PreviewFragment$special$$inlined$navGraphViewModels$default$1.invoke(NavGraphViewModelLazy.kt:56)
	at com.infomaniak.drive.ui.fileList.preview.PreviewFragment$special$$inlined$navGraphViewModels$default$1.invoke(NavGraphViewModelLazy.kt:55)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at androidx.navigation.NavGraphViewModelLazyKt.navGraphViewModels$lambda-0(NavGraphViewModelLazy.kt:55)
	at androidx.navigation.NavGraphViewModelLazyKt.access$navGraphViewModels$lambda-0(NavGraphViewModelLazy.kt:1)
	at com.infomaniak.drive.ui.fileList.preview.PreviewFragment$special$$inlined$navGraphViewModels$default$3.invoke(NavGraphViewModelLazy.kt:64)
	at com.infomaniak.drive.ui.fileList.preview.PreviewFragment$special$$inlined$navGraphViewModels$default$3.invoke(NavGraphViewModelLazy.kt:61)
	at androidx.lifecycle.ViewModelLazy.getValue(ViewModelProvider.kt:52)
	at androidx.lifecycle.ViewModelLazy.getValue(ViewModelProvider.kt:41)
	at com.infomaniak.drive.ui.fileList.preview.PreviewFragment.getPreviewSliderViewModel(PreviewFragment.kt:38)
	at com.infomaniak.drive.ui.fileList.preview.PreviewFragment.getCurrentFile(PreviewFragment.kt:55)
	at com.infomaniak.drive.ui.fileList.preview.PreviewFragment.onCreate(PreviewFragment.kt:46)
	at androidx.fragment.app.Fragment.performCreate(Fragment.java:2981)
	at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:474)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:257)
	at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:113)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1374)
	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2841)
	at androidx.fragment.app.FragmentManager.dispatchCreate(FragmentManager.java:2773)
	at androidx.fragment.app.Fragment.restoreChildFragmentState(Fragment.java:1935)
	at androidx.fragment.app.Fragment.onCreate(Fragment.java:1911)
	at androidx.fragment.app.Fragment.performCreate(Fragment.java:2981)
	at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:474)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:257)
	at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:113)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1374)
	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2841)
	at androidx.fragment.app.FragmentManager.dispatchCreate(FragmentManager.java:2773)
	at androidx.fragment.app.Fragment.restoreChildFragmentState(Fragment.java:1935)
	at androidx.fragment.app.Fragment.onCreate(Fragment.java:1911)
	at androidx.navigation.fragment.NavHostFragment.onCreate(NavHostFragment.kt:164)
	at androidx.fragment.app.Fragment.performCreate(Fragment.java:2981)
	at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:474)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:257)
	at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:113)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1374)
	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2841)
	at androidx.fragment.app.FragmentManager.dispatchCreate(FragmentManager.java:2773)
	at androidx.fragment.app.FragmentController.dispatchCreate(FragmentController.java:251)
	at androidx.fragment.app.FragmentActivity.onCreate(FragmentActivity.java:252)
	at com.infomaniak.drive.ui.BaseActivity.onCreate(BaseActivity.kt:28)
	at com.infomaniak.drive.ui.MainActivity.onCreate(MainActivity.kt:88)
	at android.app.Activity.performCreate(Activity.java:8051)
	at android.app.Activity.performCreate(Activity.java:8031)
	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1329)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3608)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3792)
	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103)
	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:7838)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```


## Exception: [Sentry link - MainActivity](https://sentry.infomaniak.com/organizations/infomaniak/issues/3598/?project=3&query=is%3Aunresolved+level%3Afatal&sort=user&statsPeriod=14d) ##
```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.infomaniak.drive/com.infomaniak.drive.ui.MainActivity}: java.lang.NullPointerException
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3835)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4011)
    at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
    at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2325)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:246)
    at android.app.ActivityThread.main(ActivityThread.java:8633)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>