### PR TITLE
fix navController

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
@@ -198,7 +198,7 @@ class MainActivity : BaseActivity() {
         if (!UISettings(this).updateLater || AppSettings.appLaunches % 10 == 0) {
             checkUpdateIsAvailable { updateIsAvailable ->
                 if (!updateAvailableShow && updateIsAvailable) {
-                    findNavController(R.id.hostFragment).navigate(R.id.updateAvailableBottomSheetDialog)
+                    navController.navigate(R.id.updateAvailableBottomSheetDialog)
                     updateAvailableShow = true
                 }
             }


### PR DESCRIPTION
Fix: [Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/4839/?project=3&query=is%3Aunresolved+level%3Afatal&sort=user&statsPeriod=14d)

```
java.lang.IllegalStateException: Activity com.infomaniak.drive.ui.MainActivity@f18a040 does not have a NavController set on 2131362419
    at androidx.navigation.Navigation.findNavController(Navigation.kt:50)
    at androidx.navigation.ActivityKt.findNavController(Activity.kt:31)
    at com.infomaniak.drive.ui.MainActivity$onCreate$8.invoke(MainActivity.kt:195)
    at com.infomaniak.drive.ui.MainActivity$onCreate$8.invoke(MainActivity.kt:193)
    at com.infomaniak.drive.GplayKt.checkUpdateIsAvailable$lambda-0(Gplay.kt:32)
    at com.infomaniak.drive.GplayKt.$r8$lambda$C4uAgp634eS33MZda16Ef-TN5LY
    at com.infomaniak.drive.GplayKt$$ExternalSyntheticLambda1.onSuccess
    at com.google.android.play.core.tasks.zze.run(com.google.android.play:core@@1.10.2:1)
    at android.os.Handler.handleCallback(Handler.java:883)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loop(Looper.java:237)
    at android.app.ActivityThread.main(ActivityThread.java:8167)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:496)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1100)
```

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>