### PR TITLE
add glide lifecycle on load drawable from url

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/addFiles/AddFileBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/addFiles/AddFileBottomSheetDialog.kt
@@ -83,7 +83,7 @@ class AddFileBottomSheetDialog : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        currentFolder.setFileItem(currentFolderFile)
+        currentFolder.setFileItem(createGlideRequestManager(), currentFolderFile)
 
         openCameraPermissions = DrivePermissions()
         openCameraPermissions.registerPermissions(this) { autorized ->

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/TrashedFileActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/TrashedFileActionsBottomSheetDialog.kt
@@ -33,10 +33,7 @@ import com.infomaniak.drive.data.api.ErrorCode.Companion.translateError
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.ui.fileList.SelectFolderActivity
 import com.infomaniak.drive.ui.menu.TrashViewModel
-import com.infomaniak.drive.utils.AccountUtils
-import com.infomaniak.drive.utils.Utils
-import com.infomaniak.drive.utils.setFileItem
-import com.infomaniak.drive.utils.showSnackbar
+import com.infomaniak.drive.utils.*
 import com.infomaniak.lib.core.models.ApiResponse
 import kotlinx.android.synthetic.main.fragment_bottom_sheet_trashed_file_actions.*
 
@@ -54,7 +51,7 @@ class TrashedFileActionsBottomSheetDialog : BottomSheetDialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         currentTrashedFile = trashViewModel.selectedFile.value ?: File()
 
-        currentFile.setFileItem(currentTrashedFile)
+        currentFile.setFileItem(createGlideRequestManager(), currentTrashedFile)
         restoreFileIn.setOnClickListener {
             val intent = Intent(requireContext(), SelectFolderActivity::class.java).apply {
                 putExtra(SelectFolderActivity.USER_ID_TAG, AccountUtils.currentUserId)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import com.bumptech.glide.RequestManager
 import com.google.android.material.shape.CornerFamily
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.AppSettings
@@ -42,7 +43,8 @@ import kotlinx.android.synthetic.main.cardview_file_list.view.*
 import kotlinx.android.synthetic.main.item_file.view.*
 
 open class FileAdapter(
-    var fileList: OrderedRealmCollection<File> = RealmList()
+    var fileList: OrderedRealmCollection<File> = RealmList(),
+    private val glideRequestManager: RequestManager,
 ) : RealmRecyclerViewAdapter<File, ViewHolder>(fileList, true, true) {
 
     var itemsSelected: OrderedRealmCollection<File> = RealmList()
@@ -244,7 +246,7 @@ open class FileAdapter(
                         .build()
                 }
 
-                setFileItem(file, isGrid)
+                setFileItem(glideRequestManager, file, isGrid)
 
                 checkIfEnableFile(file)
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -471,7 +471,7 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
             noNetwork.isGone = isInternetAvailable
         }
 
-        fileAdapter = FileAdapter(FileController.emptyList(mainViewModel.realm))
+        fileAdapter = FileAdapter(FileController.emptyList(mainViewModel.realm), createGlideRequestManager())
         fileAdapter.stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
         fileAdapter.setHasStableIds(true)
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/FileDetailsFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/FileDetailsFragment.kt
@@ -32,6 +32,7 @@ import androidx.viewpager2.widget.ViewPager2
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.data.models.File
+import com.infomaniak.drive.utils.createGlideRequestManager
 import com.infomaniak.drive.utils.loadGlide
 import com.infomaniak.drive.utils.loadGlideUrl
 import com.infomaniak.drive.views.CollapsingSubTitleToolbarBehavior
@@ -82,7 +83,7 @@ class FileDetailsFragment : FileDetailsSubFragment() {
 
     private fun setBannerThumbnail(file: File) {
         if (file.hasThumbnail) {
-            collapsingBackground.loadGlideUrl(file.thumbnail())
+            collapsingBackground.loadGlideUrl(createGlideRequestManager(), file.thumbnail())
         } else {
             appBar.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.background))
             val params = subtitleToolbar.layoutParams as CoordinatorLayout.LayoutParams

--- a/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
@@ -78,7 +78,7 @@ class HomeFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        lastFilesAdapter = LastFilesAdapter()
+        lastFilesAdapter = LastFilesAdapter(createGlideRequestManager())
         lastFilesRecyclerView.apply {
             adapter = lastFilesAdapter
             layoutManager = object : LinearLayoutManager(requireContext(), HORIZONTAL, false) {
@@ -167,10 +167,16 @@ class HomeFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
                 isProOrTeam = currentDrive.pack == Drive.DrivePack.PRO.value || currentDrive.pack == Drive.DrivePack.TEAM.value
                 // Don't remove unnecessary parentheses from function call with lambda,
                 // else "kotlin.UninitializedPropertyAccessException: lateinit property lastElementsAdapter has not been initialized"
-                lastElementsAdapter = if (isProOrTeam) LastActivitiesAdapter() else HomePicturesAdapter() { file ->
-                    val pictures = (lastElementsAdapter as HomePicturesAdapter).getItems()
-                    Utils.displayFile(mainViewModel, findNavController(), file, pictures)
-                }
+                lastElementsAdapter =
+                    if (isProOrTeam) {
+                        LastActivitiesAdapter(glideRequestManager = createGlideRequestManager())
+                    } else {
+                        HomePicturesAdapter(glideRequestManager = createGlideRequestManager()) { file ->
+                            val pictures = (lastElementsAdapter as HomePicturesAdapter).getItems()
+                            Utils.displayFile(mainViewModel, findNavController(), file, pictures)
+                        }
+                    }
+
                 lastElementsAdapter.stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT
                 layoutManager = if (isProOrTeam) LinearLayoutManager(requireContext()) else StaggeredGridLayoutManager(
                     MAX_PICTURES_COLUMN,

--- a/app/src/main/java/com/infomaniak/drive/ui/home/HomePicturesAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/HomePicturesAdapter.kt
@@ -19,6 +19,7 @@ package com.infomaniak.drive.ui.home
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import com.bumptech.glide.RequestManager
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.utils.loadGlideUrl
@@ -28,6 +29,7 @@ import kotlinx.android.synthetic.main.cardview_picture.view.*
 
 class HomePicturesAdapter(
     override var itemList: ArrayList<File> = arrayListOf(),
+    private val glideRequestManager: RequestManager,
     private val onItemClick: (file: File) -> Unit
 ) : PaginationAdapter<File>() {
 
@@ -38,7 +40,7 @@ class HomePicturesAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val file = itemList[position]
         holder.itemView.apply {
-            picture.loadGlideUrl(file.thumbnail())
+            picture.loadGlideUrl(glideRequestManager, file.thumbnail())
             picture.contentDescription = file.name
             setOnClickListener {
                 onItemClick(file)

--- a/app/src/main/java/com/infomaniak/drive/ui/home/LastActivitiesAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/LastActivitiesAdapter.kt
@@ -25,6 +25,7 @@ import android.widget.ImageView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import com.bumptech.glide.RequestManager
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.DriveUser
 import com.infomaniak.drive.data.models.File
@@ -39,7 +40,7 @@ import kotlinx.android.synthetic.main.cardview_home_file_activity.view.*
 import kotlinx.android.synthetic.main.empty_icon_layout.view.*
 import java.util.*
 
-class LastActivitiesAdapter : LoaderAdapter<FileActivity>() {
+class LastActivitiesAdapter(private val glideRequestManager: RequestManager) : LoaderAdapter<FileActivity>() {
 
     var isComplete = false
     var onFileClicked: ((currentFile: File, validPreviewFiles: ArrayList<File>) -> Unit)? = null
@@ -167,7 +168,7 @@ class LastActivitiesAdapter : LoaderAdapter<FileActivity>() {
         if (this?.hasThumbnail == true && getFileType() == File.ConvertedType.IMAGE || this?.getFileType() == File.ConvertedType.VIDEO) {
             iconView.isGone = true
             imageView.isVisible = true
-            imageView.loadGlideUrl(thumbnail(), getFileType().icon)
+            imageView.loadGlideUrl(glideRequestManager, thumbnail(), getFileType().icon)
         } else {
             imageView.isGone = true
             iconView.isVisible = true

--- a/app/src/main/java/com/infomaniak/drive/ui/home/LastFilesAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/LastFilesAdapter.kt
@@ -21,6 +21,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintSet.WRAP_CONTENT
 import androidx.core.view.isGone
+import com.bumptech.glide.RequestManager
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.utils.setFileItem
@@ -30,7 +31,7 @@ import com.infomaniak.lib.core.views.LoaderAdapter
 import com.infomaniak.lib.core.views.ViewHolder
 import kotlinx.android.synthetic.main.cardview_file_grid.view.*
 
-class LastFilesAdapter : LoaderAdapter<File>() {
+class LastFilesAdapter(private val glideRequestManager: RequestManager) : LoaderAdapter<File>() {
 
     var onFileClicked: ((file: File) -> Unit)? = null
 
@@ -51,7 +52,7 @@ class LastFilesAdapter : LoaderAdapter<File>() {
                 val file = itemList[position]
                 fileCardView.stopLoading()
                 fileNameLayout.layoutParams.width = WRAP_CONTENT
-                setFileItem(file, isGrid = true)
+                setFileItem(glideRequestManager, file, isGrid = true)
                 fileCardView.setOnClickListener { onFileClicked?.invoke(file) }
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/PicturesAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/PicturesAdapter.kt
@@ -20,6 +20,7 @@ package com.infomaniak.drive.ui.menu
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import com.bumptech.glide.RequestManager
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.utils.loadGlideUrl
@@ -32,6 +33,7 @@ import java.util.*
 
 class PicturesAdapter(
     override var itemList: ArrayList<Any> = arrayListOf(),
+    private val glideRequestManager: RequestManager,
     private val onItemClick: (file: File) -> Unit
 ) : PaginationAdapter<Any>() {
 
@@ -91,7 +93,7 @@ class PicturesAdapter(
                 val file = (item as File)
 
                 holder.itemView.apply {
-                    picture.loadGlideUrl(file.thumbnail())
+                    picture.loadGlideUrl(glideRequestManager, file.thumbnail())
                     picture.contentDescription = file.name
 
                     setOnClickListener {

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/PicturesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/PicturesFragment.kt
@@ -33,6 +33,7 @@ import com.infomaniak.drive.R
 import com.infomaniak.drive.ui.MainViewModel
 import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.Utils
+import com.infomaniak.drive.utils.createGlideRequestManager
 import com.infomaniak.drive.utils.getScreenSizeInDp
 import com.infomaniak.lib.core.utils.Utils.createRefreshTimer
 import com.infomaniak.lib.core.utils.toDp
@@ -74,7 +75,7 @@ class PicturesFragment : Fragment() {
             getPictures()
         }
 
-        picturesAdapter = PicturesAdapter { file ->
+        picturesAdapter = PicturesAdapter(glideRequestManager = createGlideRequestManager()) { file ->
             Utils.displayFile(mainViewModel, findNavController(), file, picturesAdapter.pictureList)
         }
         picturesAdapter.stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY

--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -73,6 +73,7 @@ import coil.ImageLoader
 import coil.load
 import coil.request.Disposable
 import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.textfield.MaterialAutoCompleteTextView
@@ -128,6 +129,8 @@ fun Context.isKeyguardSecure(): Boolean {
     return (getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager)?.isKeyguardSecure ?: false
 }
 
+fun Fragment.createGlideRequestManager() = Glide.with(this)
+
 fun ImageView.loadGlide(@DrawableRes drawable: Int) {
     Glide.with(this).load(drawable).into(this)
 }
@@ -143,11 +146,12 @@ fun ImageView.loadGlide(bitmap: Bitmap?, @DrawableRes errorRes: Int) {
 }
 
 fun ImageView.loadGlideUrl(
+    requestManager: RequestManager,
     url: String?,
     @DrawableRes errorRes: Int = R.drawable.fallback_image,
     errorDrawable: Drawable? = null
 ) {
-    Glide.with(this)
+    requestManager
         .load(OkHttpLibraryGlideModule.GlideAuthUrl(url))
         .transition(Utils.CROSS_FADE_TRANSITION)
         .placeholder(R.drawable.placeholder)
@@ -250,7 +254,7 @@ fun Window.lightNavigationBar(enabled: Boolean) {
     }
 }
 
-fun View.setFileItem(file: File, isGrid: Boolean = false) {
+fun View.setFileItem(requestManager: RequestManager, file: File, isGrid: Boolean = false) {
 
     fileName.text = file.name
     fileFavorite.isVisible = file.isFavorite
@@ -297,7 +301,7 @@ fun View.setFileItem(file: File, isGrid: Boolean = false) {
             when {
                 file.hasThumbnail && (isGrid || file.getFileType() == File.ConvertedType.IMAGE
                         || file.getFileType() == File.ConvertedType.VIDEO) -> {
-                    filePreview.loadGlideUrl(file.thumbnail(), file.getFileType().icon)
+                    filePreview.loadGlideUrl(requestManager, file.thumbnail(), file.getFileType().icon)
                 }
                 file.isFromUploads && (file.getMimeType().startsWith("image/") || file.getMimeType().startsWith("video/")) -> {
                     CoroutineScope(Dispatchers.IO).launch {

--- a/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
+++ b/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
@@ -348,7 +348,7 @@ class FileInfoActionsView @JvmOverloads constructor(
         val isPendingOffline = file.isPendingOffline(context)
         val isOfflineFile = file.isOfflineFile(context)
         enableAvailableOffline(!isPendingOffline || file.currentProgress == 100)
-        if (isOfflineProgress) setupFileProgress(file) else fileView.setFileItem(file)
+        if (isOfflineProgress) setupFileProgress(file) else fileView.setFileItem(ownerFragment.createGlideRequestManager(), file)
         if (availableOfflineSwitch.isEnabled && availableOffline.isVisible) {
             availableOfflineSwitch.isChecked = isOfflineFile
         }


### PR DESCRIPTION
Fix: [Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/4703/?project=3)

```
java.lang.IllegalArgumentException: You cannot start a load for a destroyed activity
    at com.bumptech.glide.manager.RequestManagerRetriever.assertNotDestroyed(RequestManagerRetriever.java:348)
    at com.bumptech.glide.manager.RequestManagerRetriever.get(RequestManagerRetriever.java:148)
    at com.bumptech.glide.manager.RequestManagerRetriever.get(RequestManagerRetriever.java:212)
    at com.bumptech.glide.Glide.with(Glide.java:885)
    at com.infomaniak.drive.utils.ExtensionsKt.loadGlide(Extensions.kt:136)
    at com.infomaniak.drive.utils.ExtensionsKt$setFileItem$3$1.invokeSuspend(Extensions.kt:307)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:246)
    at android.app.ActivityThread.main(ActivityThread.java:8595)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>