### PR TITLE
Fix current Uploads count for the current drive

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
@@ -137,11 +137,8 @@ open class UploadFile(
         }
 
         private fun currentDriveAndSharedWithMeIds(): Array<Int> {
-            val sharedWithMeDriveIds =
-                DriveInfosController.getDrives(AccountUtils.currentUserId, sharedWithMe = true).map { it.id }
-            val currentDriveId = AccountUtils.currentDriveId
-
-            return arrayOf(currentDriveId, *sharedWithMeDriveIds.toTypedArray())
+            val sharedWithMeIds = DriveInfosController.getDrives(AccountUtils.currentUserId, sharedWithMe = true).map { it.id }
+            return arrayOf(AccountUtils.currentDriveId, *sharedWithMeIds.toTypedArray())
         }
 
         fun getAllPendingUploads(customRealm: Realm? = null): ArrayList<UploadFile> {
@@ -172,8 +169,7 @@ open class UploadFile(
 
         fun getCurrentUserPendingUploadsCount(folderId: Int? = null): Int {
             return getRealmInstance().use { realm ->
-                val driveIds = currentDriveAndSharedWithMeIds()
-                pendingUploadsQuery(realm, folderId, true, driveIds).count().toInt()
+                pendingUploadsQuery(realm, folderId, true, driveIds = currentDriveAndSharedWithMeIds()).count().toInt()
             }
         }
 

--- a/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
@@ -132,12 +132,16 @@ open class UploadFile(
         }
 
         private fun allPendingFoldersQuery(realm: Realm): RealmQuery<UploadFile> {
+            return pendingUploadsQuery(realm, onlyCurrentUser = true, driveIds = currentDriveAndSharedWithMeIds())
+                .distinct(UploadFile::remoteFolder.name)
+        }
+
+        private fun currentDriveAndSharedWithMeIds(): Array<Int> {
             val sharedWithMeDriveIds =
                 DriveInfosController.getDrives(AccountUtils.currentUserId, sharedWithMe = true).map { it.id }
             val currentDriveId = AccountUtils.currentDriveId
-            val driveIds = arrayOf(currentDriveId, *sharedWithMeDriveIds.toTypedArray())
 
-            return pendingUploadsQuery(realm, onlyCurrentUser = true, driveIds = driveIds).distinct(UploadFile::remoteFolder.name)
+            return arrayOf(currentDriveId, *sharedWithMeDriveIds.toTypedArray())
         }
 
         fun getAllPendingUploads(customRealm: Realm? = null): ArrayList<UploadFile> {
@@ -168,7 +172,8 @@ open class UploadFile(
 
         fun getCurrentUserPendingUploadsCount(folderId: Int? = null): Int {
             return getRealmInstance().use { realm ->
-                pendingUploadsQuery(realm, folderId, true).count().toInt()
+                val driveIds = currentDriveAndSharedWithMeIds()
+                pendingUploadsQuery(realm, folderId, true, driveIds).count().toInt()
             }
         }
 


### PR DESCRIPTION
Fix: [Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/4165/?project=3)

```
java.lang.NullPointerException: null
    at com.infomaniak.drive.ui.fileList.UploadInProgressFragment$DownloadFiles.downloadPendingFolders(UploadInProgressFragment.kt:266)
    at com.infomaniak.drive.ui.fileList.UploadInProgressFragment$DownloadFiles.invoke(UploadInProgressFragment.kt:253)
    at com.infomaniak.drive.ui.fileList.UploadInProgressFragment$DownloadFiles.invoke(UploadInProgressFragment.kt:244)
    at com.infomaniak.drive.ui.fileList.FileListFragment.onViewCreated(FileListFragment.kt:204)
    at com.infomaniak.drive.ui.fileList.UploadInProgressFragment.onViewCreated(UploadInProgressFragment.kt:76)
    at androidx.fragment.app.Fragment.performViewCreated(Fragment.java:3019)
    at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:551)
    at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:261)
    at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:1840)
    at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1764)
    at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1701)
    at androidx.fragment.app.FragmentManager$4.run(FragmentManager.java:488)
    at android.os.Handler.handleCallback(Handler.java:883)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loop(Looper.java:214)
    at android.app.ActivityThread.main(ActivityThread.java:7397)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:935)
```

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>