### PR TITLE
fix currentPreview from searchFragment

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -59,7 +59,7 @@ class MainViewModel(appContext: Application) : AndroidViewModel(appContext) {
 
     val currentFolder = MutableLiveData<File>()
     val currentFolderOpenAddFileBottom = MutableLiveData<File>()
-    var currentFileList = LinkedHashMap<Int, File>()
+    var currentPreviewFileList = LinkedHashMap<Int, File>()
     val isInternetAvailable = MutableLiveData(true)
 
     val createDropBoxSuccess = SingleLiveEvent<DropBox>()

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
@@ -52,7 +52,7 @@ class FileListViewModel : ViewModel() {
     var isSharedWithMe = false
 
     var currentPage = 1
-    var oldList: OrderedRealmCollection<File>? = null
+    var searchOldFileList: OrderedRealmCollection<File>? = null
     val isListMode = SingleLiveEvent<Boolean>()
 
     var lastItemCount: FileCount? = null

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SearchFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SearchFragment.kt
@@ -37,11 +37,12 @@ import com.infomaniak.drive.utils.safeNavigate
 import com.infomaniak.drive.utils.showSnackbar
 import com.infomaniak.drive.views.DebouncingTextWatcher
 import com.infomaniak.lib.core.utils.setPagination
+import io.realm.RealmList
 import kotlinx.android.synthetic.main.fragment_file_list.*
 import kotlinx.android.synthetic.main.item_search_view.*
 import kotlinx.android.synthetic.main.search_filter.view.*
 import java.util.*
-import kotlin.collections.ArrayList
+import kotlin.collections.LinkedHashMap
 
 class SearchFragment : FileListFragment() {
 
@@ -50,8 +51,20 @@ class SearchFragment : FileListFragment() {
     private lateinit var filterLayoutView: View
     private var isDownloading = false
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        mainViewModel.currentPreviewFileList = LinkedHashMap()
+        super.onCreate(savedInstanceState)
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         fileListViewModel.sortType = File.SortType.RECENT
+
+        // Get preview List if needed
+        if (mainViewModel.currentPreviewFileList.isNotEmpty()) {
+            fileListViewModel.oldList = RealmList(*mainViewModel.currentPreviewFileList.values.toTypedArray())
+            mainViewModel.currentPreviewFileList = LinkedHashMap()
+        }
+
         downloadFiles = DownloadFiles()
         setNoFilesLayout = SetNoFilesLayout()
         filterLayoutView = layoutInflater.inflate(R.layout.search_filter, null)
@@ -225,7 +238,7 @@ class SearchFragment : FileListFragment() {
 
             val oldList = fileListViewModel.oldList?.toMutableList() as? ArrayList
             if (!oldList.isNullOrEmpty() && fileAdapter.getFiles().isEmpty()) {
-                fileAdapter.setFiles(ArrayList(mainViewModel.currentPreviewFileList.values))
+                fileAdapter.setFiles(oldList)
                 fileListViewModel.oldList = null
                 if (fileListViewModel.currentConvertedType != null) convertedTypeLayout.isVisible = true
                 showFilterLayout(false)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SearchFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SearchFragment.kt
@@ -51,17 +51,12 @@ class SearchFragment : FileListFragment() {
     private lateinit var filterLayoutView: View
     private var isDownloading = false
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        mainViewModel.currentPreviewFileList = LinkedHashMap()
-        super.onCreate(savedInstanceState)
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         fileListViewModel.sortType = File.SortType.RECENT
 
         // Get preview List if needed
         if (mainViewModel.currentPreviewFileList.isNotEmpty()) {
-            fileListViewModel.oldList = RealmList(*mainViewModel.currentPreviewFileList.values.toTypedArray())
+            fileListViewModel.searchOldFileList = RealmList(*mainViewModel.currentPreviewFileList.values.toTypedArray())
             mainViewModel.currentPreviewFileList = LinkedHashMap()
         }
 
@@ -196,7 +191,7 @@ class SearchFragment : FileListFragment() {
     }
 
     override fun onPause() {
-        fileListViewModel.oldList = fileAdapter.getFiles()
+        fileListViewModel.searchOldFileList = fileAdapter.getFiles()
         searchView.isFocusable = false
         super.onPause()
     }
@@ -236,10 +231,10 @@ class SearchFragment : FileListFragment() {
                 return
             }
 
-            val oldList = fileListViewModel.oldList?.toMutableList() as? ArrayList
+            val oldList = fileListViewModel.searchOldFileList?.toMutableList() as? ArrayList
             if (!oldList.isNullOrEmpty() && fileAdapter.getFiles().isEmpty()) {
                 fileAdapter.setFiles(oldList)
-                fileListViewModel.oldList = null
+                fileListViewModel.searchOldFileList = null
                 if (fileListViewModel.currentConvertedType != null) convertedTypeLayout.isVisible = true
                 showFilterLayout(false)
                 swipeRefreshLayout.isRefreshing = false

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SearchFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SearchFragment.kt
@@ -225,7 +225,7 @@ class SearchFragment : FileListFragment() {
 
             val oldList = fileListViewModel.oldList?.toMutableList() as? ArrayList
             if (!oldList.isNullOrEmpty() && fileAdapter.getFiles().isEmpty()) {
-                fileAdapter.setFiles(ArrayList(mainViewModel.currentFileList.values))
+                fileAdapter.setFiles(ArrayList(mainViewModel.currentPreviewFileList.values))
                 fileListViewModel.oldList = null
                 if (fileListViewModel.currentConvertedType != null) convertedTypeLayout.isVisible = true
                 showFilterLayout(false)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewFragment.kt
@@ -52,7 +52,7 @@ open class PreviewFragment : Fragment() {
     }
 
     private fun getCurrentFile(fileId: Int) = try {
-        FileController.getFileById(fileId, previewSliderViewModel.userDrive) ?: mainViewModel.currentFileList[fileId]
+        FileController.getFileById(fileId, previewSliderViewModel.userDrive) ?: mainViewModel.currentPreviewFileList[fileId]
     } catch (exception: Exception) {
         exception.printStackTrace()
         Sentry.withScope { scope ->

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
@@ -202,6 +202,14 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
         bottomSheetFileInfos.removeOfflineObservations(this)
     }
 
+    override fun onDestroy() {
+        // Reset current preview file list
+        if (findNavController().previousBackStackEntry?.destination?.id != R.id.searchFragment) {
+            mainViewModel.currentPreviewFileList = LinkedHashMap()
+        }
+        super.onDestroy()
+    }
+
     override fun onSaveInstanceState(outState: Bundle) {
         if (this::currentPreviewFile.isInitialized) outState.putInt(PREVIEW_FILE_ID_TAG, currentPreviewFile.id)
         super.onSaveInstanceState(outState)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
@@ -82,7 +82,7 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
             hideActions = arguments?.getBoolean(PREVIEW_HIDE_ACTIONS, false) ?: false
 
             currentPreviewFile = fileId?.let {
-                FileController.getFileById(it, userDrive) ?: mainViewModel.currentFileList[it]
+                FileController.getFileById(it, userDrive) ?: mainViewModel.currentPreviewFileList[it]
             } ?: throw Exception("No current preview found")
 
             previewSliderViewModel.currentPreview = currentPreviewFile
@@ -132,7 +132,7 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
         openWithButton.setOnClickListener { openWithClicked() }
         backButton.setOnClickListener { findNavController().popBackStack() }
 
-        mainViewModel.currentFileList.let { files ->
+        mainViewModel.currentPreviewFileList.let { files ->
             previewSliderAdapter.setFiles(ArrayList(files.values))
             val position = previewSliderAdapter.getPosition(currentPreviewFile)
             viewPager.setCurrentItem(position, false)
@@ -296,7 +296,7 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
                 } else {
                     toggleBottomSheet(true)
                 }
-                mainViewModel.currentFileList.remove(currentPreviewFile.id)
+                mainViewModel.currentPreviewFileList.remove(currentPreviewFile.id)
                 requireActivity().showSnackbar(R.string.snackbarLeaveShareConfirmation)
             } else {
                 requireActivity().showSnackbar(apiResponse.translatedError)
@@ -315,7 +315,7 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
         mainViewModel.duplicateFile(currentPreviewFile, folderID, result).observe(viewLifecycleOwner) { apiResponse ->
             if (apiResponse.isSuccess()) {
                 apiResponse.data?.let { file ->
-                    mainViewModel.currentFileList[file.id] = file
+                    mainViewModel.currentPreviewFileList[file.id] = file
                     previewSliderAdapter.addFile(file)
                     requireActivity().showSnackbar(getString(R.string.allFileDuplicate, currentPreviewFile.name))
                     toggleBottomSheet(true)
@@ -345,7 +345,7 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
         mainViewModel.deleteFile(currentPreviewFile).observe(viewLifecycleOwner) { apiResponse ->
             onApiResponse()
             if (apiResponse.isSuccess()) {
-                mainViewModel.currentFileList.remove(currentPreviewFile.id)
+                mainViewModel.currentPreviewFileList.remove(currentPreviewFile.id)
                 if (previewSliderAdapter.deleteFile(currentPreviewFile)) {
                     findNavController().popBackStack()
                 } else {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
@@ -80,9 +80,11 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
 
             userDrive = UserDrive(driveId = driveId, sharedWithMe = isSharedWithMe)
             hideActions = arguments?.getBoolean(PREVIEW_HIDE_ACTIONS, false) ?: false
+
             currentPreviewFile = fileId?.let {
                 FileController.getFileById(it, userDrive) ?: mainViewModel.currentFileList[it]
             } ?: throw Exception("No current preview found")
+
             previewSliderViewModel.currentPreview = currentPreviewFile
             previewSliderViewModel.userDrive = userDrive
 

--- a/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
@@ -197,7 +197,7 @@ object Utils {
         fileList: ArrayList<File>,
         isSharedWithMe: Boolean = false
     ) {
-        mainViewModel.currentFileList = fileList.associateBy { it.id } as LinkedHashMap<Int, File>
+        mainViewModel.currentPreviewFileList = fileList.associateBy { it.id } as LinkedHashMap<Int, File>
         val navOptions = NavOptions.Builder()
             .setEnterAnim(R.anim.fragment_open_enter)
             .setExitAnim(R.anim.fragment_open_exit)


### PR DESCRIPTION
Fix: 
- Fix old filter view on previous from preview
- [Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/1868/?project=3)

```
java.lang.Exception: No current preview found
    at com.infomaniak.drive.ui.fileList.preview.PreviewSliderFragment.onViewCreated(PreviewSliderFragment.kt:85)
    at androidx.fragment.app.Fragment.performViewCreated(Fragment.java:3019)
    at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:551)
    at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:261)
    at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:1840)
    at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1764)
    at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1701)
    at androidx.fragment.app.FragmentManager$4.run(FragmentManager.java:488)
    at android.os.Handler.handleCallback(Handler.java:873)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:214)
    at android.app.ActivityThread.main(ActivityThread.java:7050)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:494)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:965)
```

closes #389 

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>