### PR TITLE
fix pendingIntent android +31 flags

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/sync/UploadNotifications.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/sync/UploadNotifications.kt
@@ -123,7 +123,7 @@ object UploadNotifications {
     fun permissionErrorNotification(context: Context) {
         val mainActivityIntent = PendingIntent.getActivity(
             context, 0,
-            Intent(context, MainActivity::class.java).clearStack(), PendingIntent.FLAG_UPDATE_CURRENT
+            Intent(context, MainActivity::class.java).clearStack(), pendingIntentFlags
         )
         showNotification(
             context = context,


### PR DESCRIPTION
Fix: [Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/4447/?project=3&query=is%3Aunresolved)

```
java.lang.IllegalArgumentException: com.infomaniak.drive: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
    at android.app.PendingIntent.checkFlags(PendingIntent.java:382)
    at android.app.PendingIntent.getActivityAsUser(PendingIntent.java:465)
    at android.app.PendingIntent.getActivity(PendingIntent.java:451)
    at android.app.PendingIntent.getActivity(PendingIntent.java:415)
    at com.infomaniak.drive.data.sync.UploadNotifications.permissionErrorNotification(UploadNotifications.kt:124)
    at com.infomaniak.drive.data.services.UploadWorker.doWork(UploadWorker.kt:94)
    at com.infomaniak.drive.data.services.UploadWorker$doWork$1.invokeSuspend
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>