### PR TITLE
Fix local media operation exceptions

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
@@ -310,28 +310,30 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
             customSelection = "$selection AND $IMAGES_BUCKET_ID = ? $isNotPending"
             customArgs = args + mediaFolder.id.toString()
 
-            val getLastImagesOperation = getLocalLastMediasAsync(
-                syncSettings = syncSettings,
-                contentUri = MediaFoldersProvider.imagesExternalUri,
-                selection = customSelection,
-                args = customArgs,
-                mediaFolder = mediaFolder
-            )
-            jobs.add(getLastImagesOperation)
-
-            if (syncSettings.syncVideo) {
-                isNotPending = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-                    "AND ${MediaStore.Video.Media.IS_PENDING} = 0" else ""
-                customSelection = "$selection AND $VIDEO_BUCKET_ID = ? $isNotPending"
-
-                val getLastVideosOperation = getLocalLastMediasAsync(
+            runCatching {
+                val getLastImagesOperation = getLocalLastMediasAsync(
                     syncSettings = syncSettings,
-                    contentUri = MediaFoldersProvider.videosExternalUri,
+                    contentUri = MediaFoldersProvider.imagesExternalUri,
                     selection = customSelection,
                     args = customArgs,
                     mediaFolder = mediaFolder
                 )
-                jobs.add(getLastVideosOperation)
+                jobs.add(getLastImagesOperation)
+
+                if (syncSettings.syncVideo) {
+                    isNotPending = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+                        "AND ${MediaStore.Video.Media.IS_PENDING} = 0" else ""
+                    customSelection = "$selection AND $VIDEO_BUCKET_ID = ? $isNotPending"
+
+                    val getLastVideosOperation = getLocalLastMediasAsync(
+                        syncSettings = syncSettings,
+                        contentUri = MediaFoldersProvider.videosExternalUri,
+                        selection = customSelection,
+                        args = customArgs,
+                        mediaFolder = mediaFolder
+                    )
+                    jobs.add(getLastVideosOperation)
+                }
             }
         }
 

--- a/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
@@ -60,7 +60,6 @@ import io.sentry.Breadcrumb
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.*
-import java.io.FileNotFoundException
 import java.io.IOException
 import java.util.*
 
@@ -287,7 +286,7 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
     private fun fileDescriptorSize(uri: Uri): Long? {
         return try {
             contentResolver.openFileDescriptor(uri, "r")?.use { it.statSize }
-        } catch (exception: FileNotFoundException) {
+        } catch (exception: Exception) {
             null
         }
     }


### PR DESCRIPTION
Fix some errors in UploadWorker : 
 - Continue the media search when an error occurs
 - [Sentry - IllegalStateException](https://sentry.infomaniak.com/organizations/infomaniak/issues/3477/?project=3&query=is%3Aunresolved+uploadworker&sort=user&statsPeriod=14d)
  - [Sentry - IllegalArgumentException](https://sentry.infomaniak.com/organizations/infomaniak/issues/5350/?project=3&query=is%3Aunresolved+uploadworker&sort=user&statsPeriod=14d)
  
  **IllegalStateException**
```
java.lang.IllegalStateException: Only owner is able to interact with pending item content://media/external/images/media/14078
    at android.os.Parcel.createExceptionOrNull(Parcel.java:2381)
    at android.os.Parcel.createException(Parcel.java:2357)
    at android.os.Parcel.readException(Parcel.java:2340)
    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:190)
    at android.database.DatabaseUtils.readExceptionWithFileNotFoundExceptionFromParcel(DatabaseUtils.java:153)
    at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:804)
    at android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:2002)
    at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1817)
    at android.content.ContentResolver.openFileDescriptor(ContentResolver.java:1650)
    at android.content.ContentResolver.openFileDescriptor(ContentResolver.java:1597)
    at com.infomaniak.drive.data.services.UploadWorker.fileDescriptorSize(UploadWorker.kt:283)
    at com.infomaniak.drive.data.services.UploadWorker.access$fileDescriptorSize(UploadWorker.kt:66)
    at com.infomaniak.drive.data.services.UploadWorker$getLocalLastMediasAsync$1.invokeSuspend(UploadWorker.kt:356)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

**IllegalArgumentException**
```
java.lang.IllegalArgumentException: Volume external_primary not found
    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:172)
    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:142)
    at android.content.ContentProviderProxy.query(ContentProviderNative.java:472)
    at android.content.ContentResolver.query(ContentResolver.java:1193)
    at android.content.ContentResolver.query(ContentResolver.java:1125)
    at android.content.ContentResolver.query(ContentResolver.java:1081)
    at com.infomaniak.drive.data.services.UploadWorker$initUploadFile$2.invokeSuspend(UploadWorker.kt:227)
    at com.infomaniak.drive.data.services.UploadWorker$initUploadFile$2.invoke
    at com.infomaniak.drive.data.services.UploadWorker$initUploadFile$2.invoke
    at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:89)
    at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:165)
    at kotlinx.coroutines.BuildersKt.withContext
    at com.infomaniak.drive.data.services.UploadWorker.initUploadFile(UploadWorker.kt:198)
    at com.infomaniak.drive.data.services.UploadWorker.access$initUploadFile(UploadWorker.kt:66)
    at com.infomaniak.drive.data.services.UploadWorker$startSyncFiles$2.invokeSuspend(UploadWorker.kt:185)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```