### PR TITLE
Ignore old data from downloadOfflineObserver when file is not offline

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
+++ b/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
@@ -325,7 +325,7 @@ class FileInfoActionsView @JvmOverloads constructor(
 
             currentFile.currentProgress = progress
             // Check isOffline because progressing to 100 doesn't necessarily mean it's finish
-            if (progress == 100 && workInfo.state.isFinished) {
+            if (progress == 100 && workInfo.state.isFinished && currentFile.isOfflineFile(context)) {
                 updateFile?.invoke(fileId)
                 currentFile.isOffline = true
                 refreshBottomSheetUi(currentFile)


### PR DESCRIPTION
**Fix**: Offline status from **file info actions**

It happens that the file is deleted from the off-line but nevertheless from the view of the file information from the filelist it is always displayed as being off-line.

Closes #405 

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>