### PR TITLE
Hide switch drive button if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,7 @@
 *.iml
 .gradle
 /local.properties
-/.idea/caches
-/.idea/libraries
-/.idea/modules.xml
-/.idea/workspace.xml
-/.idea/navEditor.xml
-/.idea/assetWizardSettings.xml
+/.idea
 .DS_Store
 /build
 /captures

--- a/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
@@ -27,6 +27,7 @@ import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.RealmModules
 import io.realm.Realm
 import io.realm.RealmConfiguration
+import io.realm.RealmQuery
 import io.realm.Sort
 import io.realm.kotlin.oneOf
 
@@ -58,8 +59,8 @@ object DriveInfosController {
         driveId: Int?,
         sharedWithMe: Boolean?,
         maintenance: Boolean?
-    ): io.realm.RealmQuery<Drive> =
-        realm.where(Drive::class.java)
+    ): RealmQuery<Drive> {
+        return realm.where(Drive::class.java)
             .sort(Drive::id.name, Sort.ASCENDING)
             .equalTo(Drive::userId.name, userId)
             .apply {
@@ -67,7 +68,7 @@ object DriveInfosController {
                 sharedWithMe?.let { equalTo(Drive::sharedWithMe.name, it) }
                 maintenance?.let { equalTo(Drive::maintenance.name, it) }
             }
-
+    }
 
     fun storeDriveInfos(userId: Int, driveInfo: DriveInfo): List<Drive> {
         val driveList = arrayListOf<Drive>()

--- a/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
@@ -63,15 +63,9 @@ object DriveInfosController {
             .sort(Drive::id.name, Sort.ASCENDING)
             .equalTo(Drive::userId.name, userId)
             .apply {
-                driveId?.let {
-                    equalTo(Drive::id.name, it)
-                }
-                sharedWithMe?.let {
-                    equalTo(Drive::sharedWithMe.name, it)
-                }
-                maintenance?.let {
-                    equalTo(Drive::maintenance.name, it)
-                }
+                driveId?.let { equalTo(Drive::id.name, it) }
+                sharedWithMe?.let { equalTo(Drive::sharedWithMe.name, it) }
+                maintenance?.let { equalTo(Drive::maintenance.name, it) }
             }
 
 

--- a/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
@@ -52,6 +52,29 @@ object DriveInfosController {
         add(drive)
     }
 
+    private fun getDrivesQuery(
+        realm: Realm,
+        userId: Int,
+        driveId: Int?,
+        sharedWithMe: Boolean?,
+        maintenance: Boolean?
+    ): io.realm.RealmQuery<Drive> =
+        realm.where(Drive::class.java)
+            .sort(Drive::id.name, Sort.ASCENDING)
+            .equalTo(Drive::userId.name, userId)
+            .apply {
+                driveId?.let {
+                    equalTo(Drive::id.name, it)
+                }
+                sharedWithMe?.let {
+                    equalTo(Drive::sharedWithMe.name, it)
+                }
+                maintenance?.let {
+                    equalTo(Drive::maintenance.name, it)
+                }
+            }
+
+
     fun storeDriveInfos(userId: Int, driveInfo: DriveInfo): List<Drive> {
         val driveList = arrayListOf<Drive>()
         for (drive in driveInfo.drives.main) {
@@ -106,26 +129,17 @@ object DriveInfosController {
         maintenance: Boolean? = null
     ): ArrayList<Drive> {
         return getRealmInstance().use { realm ->
-            val driveList = realm.copyFromRealm(
-                realm.where(Drive::class.java)
-                    .sort(Drive::id.name, Sort.ASCENDING)
-                    .equalTo(Drive::userId.name, userId)
-                    .apply {
-                        driveId?.let {
-                            equalTo(Drive::id.name, it)
-                        }
-                        sharedWithMe?.let {
-                            equalTo(Drive::sharedWithMe.name, it)
-                        }
-                        maintenance?.let {
-                            equalTo(Drive::maintenance.name, it)
-                        }
-                    }
-                    .findAll(), 1
-            )
+            val driveList = realm.copyFromRealm(getDrivesQuery(realm, userId, driveId, sharedWithMe, maintenance).findAll(), 1)
             driveList?.let { ArrayList(it) } ?: ArrayList()
         }
     }
+
+    fun getDrivesCount(
+        userId: Int,
+        driveId: Int? = null,
+        sharedWithMe: Boolean? = false,
+        maintenance: Boolean? = null
+    ) = getRealmInstance().use { getDrivesQuery(it, userId, driveId, sharedWithMe, maintenance).count() }
 
     fun getTeams(drive: Drive): List<Team> {
         val teamList = getRealmInstance().use { realm ->

--- a/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
@@ -178,8 +178,8 @@ class CloudStorageProvider : DocumentsProvider() {
             isRootFolder -> {
                 cursor.addRootDrives(userId, isRootFolder = true)
 
-                val documentId = parentDocumentId + SEPARATOR + MY_SHARES_FOLDER_ID
-                val name = context?.getString(R.string.mySharesTitle) ?: "My Shares"
+                var documentId = parentDocumentId + SEPARATOR + MY_SHARES_FOLDER_ID
+                var name = context?.getString(R.string.mySharesTitle) ?: "My Shares"
                 cursor.addFile(null, documentId, name)
 
                 if (DriveInfosController.getDrivesCount(userId = userId, sharedWithMe = true) > 0) {

--- a/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
@@ -178,12 +178,11 @@ class CloudStorageProvider : DocumentsProvider() {
             isRootFolder -> {
                 cursor.addRootDrives(userId, isRootFolder = true)
 
-                var documentId = parentDocumentId + SEPARATOR + MY_SHARES_FOLDER_ID
-                var name = context?.getString(R.string.mySharesTitle) ?: "My Shares"
+                val documentId = parentDocumentId + SEPARATOR + MY_SHARES_FOLDER_ID
+                val name = context?.getString(R.string.mySharesTitle) ?: "My Shares"
                 cursor.addFile(null, documentId, name)
 
-                val sharesWithMe = DriveInfosController.getDrives(userId = userId, sharedWithMe = true).isNotEmpty()
-                if (sharesWithMe) {
+                if (DriveInfosController.getDrivesCount(userId = userId, sharedWithMe = true) > 0) {
                     documentId = parentDocumentId + SEPARATOR + SHARED_WITHME_FOLDER_ID
                     name = context?.getString(R.string.sharedWithMeTitle) ?: "Shared with me"
                     cursor.addFile(null, documentId, name)

--- a/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
@@ -182,7 +182,7 @@ class CloudStorageProvider : DocumentsProvider() {
                 var name = context?.getString(R.string.mySharesTitle) ?: "My Shares"
                 cursor.addFile(null, documentId, name)
 
-                if (DriveInfosController.getDrivesCount(userId = userId, sharedWithMe = true) > 0) {
+                if (DriveInfosController.getDrivesCount(userId = userId, sharedWithMe = true).isPositive()) {
                     documentId = parentDocumentId + SEPARATOR + SHARED_WITHME_FOLDER_ID
                     name = context?.getString(R.string.sharedWithMeTitle) ?: "Shared with me"
                     cursor.addFile(null, documentId, name)

--- a/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
@@ -51,6 +51,7 @@ import com.infomaniak.drive.utils.NotificationUtils.cancelNotification
 import com.infomaniak.drive.utils.NotificationUtils.showGeneralNotification
 import com.infomaniak.drive.utils.SyncUtils.syncImmediately
 import com.infomaniak.drive.utils.Utils
+import com.infomaniak.drive.utils.isPositive
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.utils.ApiController
 import io.realm.Realm

--- a/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
@@ -46,7 +46,7 @@ class LaunchActivity : AppCompatActivity() {
                     startActivity(Intent(this@LaunchActivity, LockActivity::class.java))
                 }
                 else -> {
-                    if (DriveInfosController.getDrivesCount(AccountUtils.currentUserId) <= 0L) {
+                    if (DriveInfosController.getDrivesCount(AccountUtils.currentUserId) == 0L) {
                         AccountUtils.updateCurrentUserAndDrives(this@LaunchActivity)
                     }
                     if (DriveInfosController.getDrives(AccountUtils.currentUserId).all { it.maintenance }) {

--- a/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
@@ -46,7 +46,7 @@ class LaunchActivity : AppCompatActivity() {
                     startActivity(Intent(this@LaunchActivity, LockActivity::class.java))
                 }
                 else -> {
-                    if (DriveInfosController.getDrives(AccountUtils.currentUserId).firstOrNull() == null) {
+                    if (DriveInfosController.getDrivesCount(AccountUtils.currentUserId) <= 0L) {
                         AccountUtils.updateCurrentUserAndDrives(this@LaunchActivity)
                     }
                     if (DriveInfosController.getDrives(AccountUtils.currentUserId).all { it.maintenance }) {

--- a/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.google.android.material.appbar.AppBarLayout
 import com.infomaniak.drive.R
+import com.infomaniak.drive.data.cache.DriveInfosController
 import com.infomaniak.drive.data.models.UISettings
 import com.infomaniak.drive.data.models.UploadFile
 import com.infomaniak.drive.data.models.drive.Drive
@@ -39,6 +40,7 @@ import com.infomaniak.drive.data.services.UploadWorker.Companion.trackUploadWork
 import com.infomaniak.drive.ui.MainViewModel
 import com.infomaniak.drive.ui.menu.PicturesFragment
 import com.infomaniak.drive.utils.*
+import com.infomaniak.drive.utils.AccountUtils.currentUser
 import com.infomaniak.drive.utils.TabViewPagerUtils.getFragment
 import com.infomaniak.drive.utils.TabViewPagerUtils.setup
 import kotlinx.android.synthetic.main.activity_main.*
@@ -67,9 +69,13 @@ class HomeFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         mainViewModel.isInternetAvailable.observe(viewLifecycleOwner) { isInternetAvailable ->
             noNetworkCard.isGone = isInternetAvailable
         }
-
+        currentUser?.let { currentUser ->
+            if (DriveInfosController.getDrives(currentUser.id).size == 1) {
+                switchDriveButton.isEnabled = false
+                switchDriveButton.icon = null
+            }
+        }
         switchDriveButton.setOnClickListener { safeNavigate(R.id.switchDriveDialog) }
-
         searchView.isGone = true
         searchViewText.isVisible = true
         ViewCompat.requestApplyInsets(homeCoordinator)

--- a/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
@@ -69,13 +69,13 @@ class HomeFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         mainViewModel.isInternetAvailable.observe(viewLifecycleOwner) { isInternetAvailable ->
             noNetworkCard.isGone = isInternetAvailable
         }
-        currentUser?.let { currentUser ->
-            if (DriveInfosController.getDrives(currentUser.id).size == 1) {
-                switchDriveButton.isEnabled = false
-                switchDriveButton.icon = null
-            }
+        if (DriveInfosController.getDrivesCount(AccountUtils.currentUserId) == 1L) {
+            switchDriveButton.icon = null
+            switchDriveButton.isEnabled = false
+        } else {
+            switchDriveButton.setOnClickListener { safeNavigate(R.id.switchDriveDialog) }
         }
-        switchDriveButton.setOnClickListener { safeNavigate(R.id.switchDriveDialog) }
+
         searchView.isGone = true
         searchViewText.isVisible = true
         ViewCompat.requestApplyInsets(homeCoordinator)

--- a/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
@@ -69,13 +69,15 @@ class HomeFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         mainViewModel.isInternetAvailable.observe(viewLifecycleOwner) { isInternetAvailable ->
             noNetworkCard.isGone = isInternetAvailable
         }
-        if (DriveInfosController.getDrivesCount(AccountUtils.currentUserId) == 1L) {
-            switchDriveButton.icon = null
-            switchDriveButton.isEnabled = false
-        } else {
-            switchDriveButton.setOnClickListener { safeNavigate(R.id.switchDriveDialog) }
+        switchDriveButton.apply {
+            if (DriveInfosController.getDrivesCount(AccountUtils.currentUserId) == 1L) {
+                icon = null
+                isEnabled = false
+            } else {
+                setOnClickListener { safeNavigate(R.id.switchDriveDialog) }
+            }
         }
-
+        
         searchView.isGone = true
         searchViewText.isVisible = true
         ViewCompat.requestApplyInsets(homeCoordinator)

--- a/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
@@ -40,7 +40,6 @@ import com.infomaniak.drive.data.services.UploadWorker.Companion.trackUploadWork
 import com.infomaniak.drive.ui.MainViewModel
 import com.infomaniak.drive.ui.menu.PicturesFragment
 import com.infomaniak.drive.utils.*
-import com.infomaniak.drive.utils.AccountUtils.currentUser
 import com.infomaniak.drive.utils.TabViewPagerUtils.getFragment
 import com.infomaniak.drive.utils.TabViewPagerUtils.setup
 import kotlinx.android.synthetic.main.activity_main.*

--- a/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
@@ -77,7 +77,7 @@ class HomeFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
                 setOnClickListener { safeNavigate(R.id.switchDriveDialog) }
             }
         }
-        
+
         searchView.isGone = true
         searchViewText.isVisible = true
         ViewCompat.requestApplyInsets(homeCoordinator)

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/MenuFragment.kt
@@ -76,14 +76,18 @@ class MenuFragment : Fragment() {
             }
 
             userImage.loadAvatar(currentUser)
-            driveIcon.isVisible = DriveInfosController.getDrives(currentUser.id).size != 1
-            driveIcon.setOnClickListener { safeNavigate(R.id.switchDriveDialog) }
+            if (DriveInfosController.getDrivesCount(currentUser.id) == 1L) {
+                driveIcon.isVisible = false;
+            } else {
+                driveIcon.setOnClickListener { safeNavigate(R.id.switchDriveDialog) }
+            }
 
-            sharedWithMeFiles.isVisible =
-                DriveInfosController.getDrives(userId = AccountUtils.currentUserId, sharedWithMe = true).isNotEmpty()
-
-            sharedWithMeFiles.setOnClickListener {
-                safeNavigate(MenuFragmentDirections.actionMenuFragmentToSharedWithMeFragment())
+            if (DriveInfosController.getDrivesCount(userId = AccountUtils.currentUserId, sharedWithMe = true) > 0L) {
+                sharedWithMeFiles.isVisible = false
+            } else {
+                sharedWithMeFiles.setOnClickListener {
+                    safeNavigate(MenuFragmentDirections.actionMenuFragmentToSharedWithMeFragment())
+                }
             }
 
             recentChanges.setOnClickListener {

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/MenuFragment.kt
@@ -84,7 +84,7 @@ class MenuFragment : Fragment() {
                 }
             }
             sharedWithMeFiles.apply {
-                if (DriveInfosController.getDrivesCount(userId = AccountUtils.currentUserId, sharedWithMe = true) > 0L) {
+                if (DriveInfosController.getDrivesCount(userId = AccountUtils.currentUserId, sharedWithMe = true).isPositive()) {
                     isVisible = false
                 } else {
                     setOnClickListener { safeNavigate(MenuFragmentDirections.actionMenuFragmentToSharedWithMeFragment()) }

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/MenuFragment.kt
@@ -76,7 +76,7 @@ class MenuFragment : Fragment() {
             }
 
             userImage.loadAvatar(currentUser)
-
+            driveIcon.isVisible = DriveInfosController.getDrives(currentUser.id).size != 1
             driveIcon.setOnClickListener { safeNavigate(R.id.switchDriveDialog) }
 
             sharedWithMeFiles.isVisible =

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/MenuFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/MenuFragment.kt
@@ -76,19 +76,21 @@ class MenuFragment : Fragment() {
             }
 
             userImage.loadAvatar(currentUser)
-            if (DriveInfosController.getDrivesCount(currentUser.id) == 1L) {
-                driveIcon.isVisible = false;
-            } else {
-                driveIcon.setOnClickListener { safeNavigate(R.id.switchDriveDialog) }
-            }
-
-            if (DriveInfosController.getDrivesCount(userId = AccountUtils.currentUserId, sharedWithMe = true) > 0L) {
-                sharedWithMeFiles.isVisible = false
-            } else {
-                sharedWithMeFiles.setOnClickListener {
-                    safeNavigate(MenuFragmentDirections.actionMenuFragmentToSharedWithMeFragment())
+            driveIcon.apply {
+                if (DriveInfosController.getDrivesCount(currentUser.id) == 1L) {
+                    isVisible = false
+                } else {
+                    setOnClickListener { safeNavigate(R.id.switchDriveDialog) }
                 }
             }
+            sharedWithMeFiles.apply {
+                if (DriveInfosController.getDrivesCount(userId = AccountUtils.currentUserId, sharedWithMe = true) > 0L) {
+                    isVisible = false
+                } else {
+                    setOnClickListener { safeNavigate(MenuFragmentDirections.actionMenuFragmentToSharedWithMeFragment()) }
+                }
+            }
+
 
             recentChanges.setOnClickListener {
                 safeNavigate(MenuFragmentDirections.actionMenuFragmentToRecentChangesFragment())

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
@@ -74,12 +74,17 @@ class SyncSettingsActivity : BaseActivity() {
 
         oldSyncSettings = UploadFile.getAppSyncSettings()
 
-        selectDriveViewModel.selectedUserId.value = oldSyncSettings?.userId
-        selectDriveViewModel.selectedDrive.value = oldSyncSettings?.run {
-            DriveInfosController.getDrives(this.userId, driveId = this.driveId).firstOrNull()
+        with(selectDriveViewModel) {
+            selectedUserId.value = oldSyncSettings?.userId
+            selectedDrive.value = oldSyncSettings?.run {
+                DriveInfosController.getDrives(userId, driveId).firstOrNull()
+            }
         }
-        syncSettingsViewModel.syncIntervalType.value = oldSyncSettings?.getIntervalType() ?: SyncSettings.IntervalType.IMMEDIATELY
-        syncSettingsViewModel.syncFolder.value = oldSyncSettings?.syncFolder
+
+        with(syncSettingsViewModel) {
+            syncIntervalType.value = oldSyncSettings?.getIntervalType() ?: SyncSettings.IntervalType.IMMEDIATELY
+            syncFolder.value = oldSyncSettings?.syncFolder
+        }
 
         AccountUtils.getAllUsers().observe(this) { users ->
             if (users.size > 1) {

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
@@ -85,12 +85,12 @@ class SyncSettingsActivity : BaseActivity() {
             if (users.size > 1) {
                 activeSelectDrive()
             } else {
-                val currentUserDrives = DriveInfosController.getDrives(AccountUtils.currentUserId)
-                if (currentUserDrives.size > 1) {
+                if (DriveInfosController.getDrivesCount(AccountUtils.currentUserId) > 1) {
                     activeSelectDrive()
                 } else {
                     selectDriveViewModel.selectedUserId.value = AccountUtils.currentUserId
-                    selectDriveViewModel.selectedDrive.value = currentUserDrives.firstOrNull()
+                    selectDriveViewModel.selectedDrive.value =
+                        DriveInfosController.getDrives(AccountUtils.currentUserId).firstOrNull()
                 }
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
@@ -74,14 +74,14 @@ class SyncSettingsActivity : BaseActivity() {
 
         oldSyncSettings = UploadFile.getAppSyncSettings()
 
-        with(selectDriveViewModel) {
+        selectDriveViewModel.apply {
             selectedUserId.value = oldSyncSettings?.userId
             selectedDrive.value = oldSyncSettings?.run {
                 DriveInfosController.getDrives(userId, driveId).firstOrNull()
             }
         }
 
-        with(syncSettingsViewModel) {
+        syncSettingsViewModel.apply {
             syncIntervalType.value = oldSyncSettings?.getIntervalType() ?: SyncSettings.IntervalType.IMMEDIATELY
             syncFolder.value = oldSyncSettings?.syncFolder
         }
@@ -90,12 +90,12 @@ class SyncSettingsActivity : BaseActivity() {
             if (users.size > 1) {
                 activeSelectDrive()
             } else {
-                if (DriveInfosController.getDrivesCount(AccountUtils.currentUserId) > 1) {
+                val currentUserDrives = DriveInfosController.getDrives(AccountUtils.currentUserId)
+                if (currentUserDrives.size > 1) {
                     activeSelectDrive()
                 } else {
                     selectDriveViewModel.selectedUserId.value = AccountUtils.currentUserId
-                    selectDriveViewModel.selectedDrive.value =
-                        DriveInfosController.getDrives(AccountUtils.currentUserId).firstOrNull()
+                    selectDriveViewModel.selectedDrive.value = currentUserDrives.firstOrNull()
                 }
             }
         }


### PR DESCRIPTION
Changes when user only have 1 drive
- Disable the switchDriveButton on home page and hide its icon.
- Hide the switchDriveButton in the user menu