### PR TITLE
Load all uri in RecyclerView at once from SaveExternalUriAdapter.kt

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -51,7 +51,6 @@ import io.sentry.SentryLevel
 import kotlinx.android.synthetic.main.activity_save_external_file.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.util.*
 
@@ -65,7 +64,6 @@ class SaveExternalFilesActivity : BaseActivity() {
     private var isMultiple = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        runBlocking { AccountUtils.requestCurrentUser() }
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_save_external_file)
 

--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalUriAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalUriAdapter.kt
@@ -30,6 +30,7 @@ import io.sentry.SentryLevel
 import kotlinx.android.synthetic.main.item_file_name.view.*
 
 class SaveExternalUriAdapter(val uris: ArrayList<Uri>) : RecyclerView.Adapter<ViewHolder>() {
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return ViewHolder(
             LayoutInflater.from(parent.context).inflate(R.layout.item_file_name, parent, false)

--- a/app/src/main/res/layout/activity_save_external_file.xml
+++ b/app/src/main/res/layout/activity_save_external_file.xml
@@ -73,6 +73,7 @@
 
         </com.google.android.material.textfield.TextInputLayout>
 
+        <!-- Disabled NestedScrolling to fix URIs with Xiaomi phones -->
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/fileNames"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_save_external_file.xml
+++ b/app/src/main/res/layout/activity_save_external_file.xml
@@ -78,6 +78,7 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/marginStandardSmall"
+            android:nestedScrollingEnabled="false"
             android:overScrollMode="never"
             android:visibility="gone"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"


### PR DESCRIPTION
Sometimes we have the uris that are called 2 times, and therefore we have one of the 2 that fails
I hope that it will fix xiaomi #418 

>I did a lot of tests, and I only managed to get this bug once

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>