### PR TITLE
Fix not shared dropbox activity + refactor activities

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -770,31 +770,29 @@ object FileController {
     }
 
     private fun FileActivity.applyFileActivity(realm: Realm, returnResponse: ArrayMap<Int, FileActivity>, currentFolder: File) {
-        val fileId = this.fileId
         when (this.getAction()) {
             FileActivity.FileActivityType.FILE_DELETE,
             FileActivity.FileActivityType.FILE_MOVE_OUT,
             FileActivity.FileActivityType.FILE_TRASH -> {
-                if (returnResponse[this.fileId] == null || returnResponse[this.fileId]?.createdAt?.time == this.createdAt.time) {
+                if (returnResponse[fileId] == null || returnResponse[fileId]?.createdAt?.time == this.createdAt.time) { // Api fix
                     getParentFile(fileId = fileId, realm = realm)?.let { parent ->
                         if (parent.id == currentFolder.id) {
                             removeFile(fileId, customRealm = realm, recursive = false)
                         }
                     }
-                    returnResponse[this.fileId] = this
+                    returnResponse[fileId] = this
                 }
             }
             FileActivity.FileActivityType.FILE_CREATE,
             FileActivity.FileActivityType.FILE_MOVE_IN,
-            FileActivity.FileActivityType.FILE_RESTORE -> if (returnResponse[this.fileId] == null && this.file != null) {
+            FileActivity.FileActivityType.FILE_RESTORE -> if (returnResponse[fileId] == null && this.file != null) {
                 realm.where(File::class.java).equalTo(File::id.name, currentFolder.id).findFirst()?.let { realmFolder ->
                     if (!realmFolder.children.contains(this.file)) {
                         addChild(realm, realmFolder, this.file!!)
-                        returnResponse[this.fileId] = this
                     } else {
-                        returnResponse[fileId] = this
                         updateFileFromActivity(realm, this, realmFolder.id)
                     }
+                    returnResponse[fileId] = this
                 }
             }
             FileActivity.FileActivityType.COLLABORATIVE_FOLDER_CREATE,
@@ -808,14 +806,13 @@ object FileController {
             FileActivity.FileActivityType.FILE_SHARE_CREATE,
             FileActivity.FileActivityType.FILE_SHARE_DELETE,
             FileActivity.FileActivityType.FILE_SHARE_UPDATE,
-            FileActivity.FileActivityType.FILE_UPDATE -> if (returnResponse[this.fileId] == null) {
+            FileActivity.FileActivityType.FILE_UPDATE -> if (returnResponse[fileId] == null) {
                 if (this.file == null) {
                     removeFile(fileId, customRealm = realm, recursive = false)
-                    returnResponse[this.fileId] = this
                 } else {
-                    returnResponse[fileId] = this
                     updateFileFromActivity(realm, this, currentFolder.id)
                 }
+                returnResponse[fileId] = this
             }
             else -> Unit
         }

--- a/app/src/main/java/com/infomaniak/drive/data/models/File.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/File.kt
@@ -353,10 +353,6 @@ open class File(
         return result
     }
 
-    enum class LocalFileActivity {
-        IS_NEW, IS_UPDATE, IS_DELETE
-    }
-
     enum class VisibilityType {
         ROOT,
         IS_PRIVATE,

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -746,8 +746,8 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
     }
 
     private fun downloadFolderActivities(currentFolder: File) {
-        fileListViewModel.getFolderActivities(currentFolder, userDrive).observe(viewLifecycleOwner) { activities ->
-            if (activities?.isNotEmpty() == true) {
+        fileListViewModel.getFolderActivities(currentFolder, userDrive).observe(viewLifecycleOwner) { isNotEmpty ->
+            if (isNotEmpty == true) {
                 getFolderFiles(
                     ignoreCache = false,
                     onFinish = {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
@@ -22,8 +22,7 @@ import androidx.lifecycle.*
 import com.infomaniak.drive.data.api.ApiRepository
 import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.data.models.*
-import com.infomaniak.drive.data.models.File.SortType
-import com.infomaniak.drive.data.models.File.Type
+import com.infomaniak.drive.data.models.File.*
 import com.infomaniak.drive.ui.fileList.FileListFragment.FolderFilesResult
 import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.FileId

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
@@ -22,7 +22,8 @@ import androidx.lifecycle.*
 import com.infomaniak.drive.data.api.ApiRepository
 import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.data.models.*
-import com.infomaniak.drive.data.models.File.*
+import com.infomaniak.drive.data.models.File.SortType
+import com.infomaniak.drive.data.models.File.Type
 import com.infomaniak.drive.ui.fileList.FileListFragment.FolderFilesResult
 import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.FileId
@@ -178,14 +179,14 @@ class FileListViewModel : ViewModel() {
     }
 
     @Synchronized
-    fun getFolderActivities(folder: File, userDrive: UserDrive? = null): LiveData<Map<out Int, LocalFileActivity>> {
+    fun getFolderActivities(folder: File, userDrive: UserDrive? = null): LiveData<Boolean> {
         getFolderActivitiesJob.cancel()
         getFolderActivitiesJob = Job()
         return liveData(Dispatchers.IO + getFolderActivitiesJob) {
             mutex.withLock {
                 getFolderActivitiesJob.ensureActive()
                 val activities = FileController.getFolderActivities(folder, 1, userDrive)
-                if (activities.isNotEmpty()) emit(activities)
+                emit(activities.isNotEmpty())
             }
         }
     }


### PR DESCRIPTION
**Description**
When you delete a dropbox without any sharing, you get 2 activities that were created at the same time, like dropbox delete and file delete. 
But since we treat only the most recent activity, and the api returns that the dropbox has been deleted as the most recent activity, then the file is not deleted.

**Fix**
*So this fix*, treats the case where we have activities that were created at the same time, and the file was deleted.

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>