### PR TITLE
Sync offline in background

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,7 @@ android {
         resValue 'string', 'FILE_AUTHORITY', 'com.infomaniak.drive.files'
 
         resValue 'string', 'EXPOSED_UPLOAD_DIR', 'upload_media'
+        resValue 'string', 'EXPOSED_OFFLINE_DIR', 'offline_storage'
     }
 
     compileOptions {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,7 +130,7 @@ dependencies {
 
     implementation 'com.github.hannesa2:paho.mqtt.android:3.3.4'
 
-    implementation 'io.sentry:sentry-android:5.5.2'
+    implementation 'io.sentry:sentry-android:5.5.3'
 
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'
     testImplementation 'io.github.serpro69:kotlin-faker:1.9.0'

--- a/app/src/main/java/com/infomaniak/drive/data/models/File.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/File.kt
@@ -252,8 +252,7 @@ open class File(
 
     fun getOfflineFile(context: Context, userId: Int = AccountUtils.currentUserId): java.io.File? {
         val userDrive = UserDrive(userId, driveId)
-        val mediaFolder = context.externalMediaDirs?.firstOrNull() ?: context.filesDir
-        val rootFolder = java.io.File(mediaFolder, "offline_storage/${userId}/$driveId")
+        val rootFolder = java.io.File(getOfflineFolder(context), "${userId}/$driveId")
         val path = getRemotePath(userDrive)
 
         if (path.isEmpty()) return null
@@ -417,6 +416,11 @@ open class File(
             return cloudUri to if (isOffline && offlineFile != null) {
                 FileProvider.getUriForFile(context, context.getString(R.string.FILE_AUTHORITY), offlineFile)
             } else cloudUri
+        }
+
+        fun getOfflineFolder(context: Context): java.io.File {
+            val mediaFolder = context.externalMediaDirs?.firstOrNull() ?: context.filesDir
+            return java.io.File(mediaFolder, context.getString(R.string.EXPOSED_OFFLINE_DIR))
         }
     }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -20,7 +20,6 @@ package com.infomaniak.drive.ui
 import android.app.Application
 import android.content.ContentResolver
 import android.content.Context
-import android.net.Uri
 import android.provider.MediaStore
 import androidx.collection.arrayMapOf
 import androidx.lifecycle.*
@@ -30,7 +29,6 @@ import androidx.work.WorkQuery
 import com.google.gson.JsonObject
 import com.infomaniak.drive.ApplicationMain
 import com.infomaniak.drive.data.api.ApiRepository
-import com.infomaniak.drive.data.cache.DriveInfosController
 import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.data.models.*
 import com.infomaniak.drive.data.services.DownloadWorker
@@ -39,7 +37,6 @@ import com.infomaniak.drive.ui.home.HomeViewModel.Companion.DOWNLOAD_INTERVAL
 import com.infomaniak.drive.utils.*
 import com.infomaniak.drive.utils.MediaUtils.deleteInMediaScan
 import com.infomaniak.drive.utils.MediaUtils.isMedia
-import com.infomaniak.drive.utils.SyncUtils.syncImmediately
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.networking.HttpClient
 import io.realm.Realm
@@ -246,84 +243,12 @@ class MainViewModel(appContext: Application) : AndroidViewModel(appContext) {
         }
     }
 
-    private fun migrateOfflineIfNeeded(file: File, offlineFile: java.io.File, userDrive: UserDrive) {
-        val oldPath = java.io.File(getContext().filesDir, "offline_storage/${userDrive.userId}/${userDrive.driveId}/${file.id}")
-        if (oldPath.exists()) oldPath.renameTo(offlineFile)
-    }
 
     suspend fun syncOfflineFiles() {
         syncOfflineFilesJob.cancel()
         syncOfflineFilesJob = Job()
         runInterruptible(Dispatchers.IO + syncOfflineFilesJob) {
-            DriveInfosController.getDrives(AccountUtils.currentUserId).forEach { drive ->
-                val userDrive = UserDrive(driveId = drive.id)
-
-                FileController.getRealmInstance(userDrive).use { realm ->
-                    FileController.getOfflineFiles(null, customRealm = realm).forEach loopFiles@{ file ->
-                        if (file.isPendingOffline(getContext())) return@loopFiles
-
-                        file.getOfflineFile(getContext(), userDrive.userId)?.let { offlineFile ->
-                            migrateOfflineIfNeeded(file, offlineFile, userDrive)
-
-                            val apiResponse = ApiRepository.getFileDetails(file)
-                            apiResponse.data?.let { remoteFile ->
-                                remoteFile.isOffline = true
-
-                                if (offlineFile.lastModified() > file.getLastModifiedInMilliSecond()) {
-                                    uploadFile(file, remoteFile, offlineFile, userDrive, realm)
-                                } else {
-                                    downloadOfflineFile(file, remoteFile, offlineFile, userDrive, realm)
-                                }
-
-                            } ?: let {
-                                if (apiResponse.error?.code?.equals("object_not_found") == true) offlineFile.delete()
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun uploadFile(file: File, remoteFile: File, offlineFile: java.io.File, userDrive: UserDrive, realm: Realm) {
-        val uri = Uri.fromFile(offlineFile)
-        val fileModifiedAt = Date(offlineFile.lastModified())
-        if (UploadFile.canUpload(uri, fileModifiedAt)) {
-            remoteFile.lastModifiedAt = offlineFile.lastModified() / 1000
-            remoteFile.size = offlineFile.length()
-            FileController.updateExistingFile(newFile = remoteFile, realm = realm)
-            UploadFile(
-                uri = uri.toString(),
-                driveId = userDrive.driveId,
-                fileModifiedAt = fileModifiedAt,
-                fileName = file.name,
-                fileSize = offlineFile.length(),
-                remoteFolder = FileController.getParentFile(file.id, realm = realm)!!.id,
-                type = UploadFile.Type.SYNC_OFFLINE.name,
-                userId = userDrive.userId,
-            ).store()
-            getContext().syncImmediately()
-        }
-    }
-
-    private fun downloadOfflineFile(
-        file: File,
-        remoteFile: File,
-        offlineFile: java.io.File,
-        userDrive: UserDrive,
-        realm: Realm
-    ) {
-        val remoteOfflineFile = remoteFile.getOfflineFile(getContext(), userDrive.userId) ?: return
-
-        val pathChanged = offlineFile.path != remoteOfflineFile.path
-        if (pathChanged) {
-            if (file.isMedia()) file.deleteInMediaScan(getContext(), userDrive)
-            offlineFile.delete()
-        }
-
-        if (!file.isPendingOffline(getContext()) && (!remoteFile.isOfflineAndIntact(remoteOfflineFile) || pathChanged)) {
-            FileController.updateExistingFile(newFile = remoteFile, realm = realm)
-            Utils.downloadAsOfflineFile(getContext(), remoteFile, userDrive)
+            SyncOfflineUtils.startSyncOffline(getContext(), syncOfflineFilesJob)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
@@ -21,7 +21,8 @@ import androidx.lifecycle.*
 import com.infomaniak.drive.data.api.ApiRepository
 import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.data.models.*
-import com.infomaniak.drive.data.models.File.*
+import com.infomaniak.drive.data.models.File.SortType
+import com.infomaniak.drive.data.models.File.Type
 import com.infomaniak.drive.data.models.drive.Category
 import com.infomaniak.drive.ui.fileList.FileListFragment.FolderFilesResult
 import com.infomaniak.drive.utils.AccountUtils

--- a/app/src/main/java/com/infomaniak/drive/utils/SyncOfflineUtils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/SyncOfflineUtils.kt
@@ -1,0 +1,148 @@
+/*
+ * Infomaniak kDrive - Android
+ * Copyright (C) 2022 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.drive.utils
+
+import android.content.Context
+import android.net.Uri
+import com.infomaniak.drive.R
+import com.infomaniak.drive.data.api.ApiRepository
+import com.infomaniak.drive.data.cache.DriveInfosController
+import com.infomaniak.drive.data.cache.FileController
+import com.infomaniak.drive.data.models.File
+import com.infomaniak.drive.data.models.UploadFile
+import com.infomaniak.drive.data.models.UserDrive
+import com.infomaniak.drive.utils.MediaUtils.deleteInMediaScan
+import com.infomaniak.drive.utils.MediaUtils.isMedia
+import com.infomaniak.drive.utils.SyncUtils.syncImmediately
+import io.realm.Realm
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.ensureActive
+import java.util.*
+import java.io.File as IOFile
+
+object SyncOfflineUtils {
+
+    fun startSyncOffline(context: Context, syncOfflineFilesJob: CompletableJob) {
+        DriveInfosController.getDrives(AccountUtils.currentUserId).forEach { drive ->
+            val userDrive = UserDrive(driveId = drive.id)
+
+            FileController.getRealmInstance(userDrive).use { realm ->
+                FileController.getOfflineFiles(null, customRealm = realm).forEach loopFiles@{ file ->
+                    syncOfflineFilesJob.ensureActive()
+                    if (file.isPendingOffline(context)) return@loopFiles
+
+                    file.getOfflineFile(context, userDrive.userId)?.let { offlineFile ->
+                        migrateOfflineIfNeeded(context, file, offlineFile, userDrive)
+
+                        val apiResponse = ApiRepository.getFileDetails(file)
+                        apiResponse.data?.let { remoteFile ->
+                            remoteFile.isOffline = true
+                            updateFile(offlineFile, file, context, remoteFile, userDrive, realm)
+
+                        } ?: let {
+                            if (apiResponse.error?.code?.equals("object_not_found") == true) offlineFile.delete()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun updateFile(
+        offlineFile: IOFile,
+        file: File,
+        context: Context,
+        remoteFile: File,
+        userDrive: UserDrive,
+        realm: Realm
+    ) {
+        if (offlineFile.lastModified() > file.getLastModifiedInMilliSecond()) {
+            uploadFile(context, file, remoteFile, offlineFile, userDrive, realm)
+        } else {
+            downloadOfflineFile(context, file, remoteFile, offlineFile, userDrive, realm)
+        }
+    }
+
+    /**
+     * Migrate old offline files to the new offline structure
+     */
+    private fun migrateOfflineIfNeeded(context: Context, file: File, offlineFile: IOFile, userDrive: UserDrive) {
+        val offlineDir = context.getString(R.string.EXPOSED_OFFLINE_DIR)
+        val oldPath = IOFile(context.filesDir, "$offlineDir/${userDrive.userId}/${userDrive.driveId}/${file.id}")
+        if (oldPath.exists()) oldPath.renameTo(offlineFile)
+    }
+
+    /**
+     * Update the remote file with the local file
+     */
+    private fun uploadFile(
+        context: Context,
+        file: File,
+        remoteFile: File,
+        offlineFile: IOFile,
+        userDrive: UserDrive,
+        realm: Realm
+    ) {
+        val uri = Uri.fromFile(offlineFile)
+        val fileModifiedAt = Date(offlineFile.lastModified())
+
+        if (UploadFile.canUpload(uri, fileModifiedAt)) {
+            remoteFile.lastModifiedAt = offlineFile.lastModified() / 1000
+            remoteFile.size = offlineFile.length()
+            FileController.updateExistingFile(newFile = remoteFile, realm = realm)
+            UploadFile(
+                uri = uri.toString(),
+                driveId = userDrive.driveId,
+                fileModifiedAt = fileModifiedAt,
+                fileName = file.name,
+                fileSize = offlineFile.length(),
+                remoteFolder = FileController.getParentFile(file.id, realm = realm)!!.id,
+                type = UploadFile.Type.SYNC_OFFLINE.name,
+                userId = userDrive.userId,
+            ).store()
+
+            context.syncImmediately()
+        }
+    }
+
+    /**
+     * Update the local file with the remote file
+     */
+    private fun downloadOfflineFile(
+        context: Context,
+        file: File,
+        remoteFile: File,
+        offlineFile: IOFile,
+        userDrive: UserDrive,
+        realm: Realm
+    ) {
+        val remoteOfflineFile = remoteFile.getOfflineFile(context, userDrive.userId) ?: return
+        val pathChanged = offlineFile.path != remoteOfflineFile.path
+
+        if (pathChanged) {
+            if (file.isMedia()) file.deleteInMediaScan(context, userDrive)
+            offlineFile.delete()
+        }
+
+        if (!file.isPendingOffline(context) && (!remoteFile.isOfflineAndIntact(remoteOfflineFile) || pathChanged)) {
+            FileController.updateExistingFile(newFile = remoteFile, realm = realm)
+            Utils.downloadAsOfflineFile(context, remoteFile, userDrive)
+        }
+    }
+
+}

--- a/app/src/main/res/xml/exposed_files_path.xml
+++ b/app/src/main/res/xml/exposed_files_path.xml
@@ -20,6 +20,6 @@
         name="@string/EXPOSED_UPLOAD_DIR"
         path="upload_media/" />
     <external-media-path
-        name="offline_storage"
+        name="@string/EXPOSED_OFFLINE_DIR"
         path="offline_storage/" />
 </paths>


### PR DESCRIPTION
I choosed to sync offline folders with [FileObserver](https://developer.android.com/reference/android/os/FileObserver).

The sync will be started only if the app is in foreground, otherwise the data will be updated especially when the application is restarted, to avoid consuming a lot of battery when the user will not necessarily need it.