### PR TITLE
Change priority migration

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileMigration.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileMigration.kt
@@ -72,12 +72,12 @@ class FileMigration : RealmMigration {
                 isEmbedded = true
             }
             schema.get(Rights::class.java.simpleName)?.apply {
-                removePrimaryKey()
                 transform { // apply for each right
                     val fileId = it.getInt("fileId")
                     val file = realm.where(File::class.java.simpleName).equalTo(File::id.name, fileId).findFirst()
                     if (file == null) it.deleteFromRealm() // Delete if it's orphan
                 }
+                removePrimaryKey()
                 removeField("fileId")
                 isEmbedded = true
             }


### PR DESCRIPTION
Rights migration doesn't works for some smartphone, I can't reproduce  the bug, if other people can test it would be nice to have more information, knowing that the orphan files are well deleted.

In case it's just the file id that was not found, then this PR will fix the problem.

[Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/6317/?project=3&query=is%3Aunresolved+dist%3A40100001&statsPeriod=14d)

```
java.lang.IllegalStateException: At least one object in 'class_Rights' does not have a backlink (data would get lost).
    at io.realm.internal.Table.nativeSetEmbedded(Table.java)
    at io.realm.internal.Table.setEmbedded(Table.java:796)
    at io.realm.RealmObjectSchema.setEmbedded(RealmObjectSchema.java:595)
    at com.infomaniak.drive.data.cache.FileMigration.migrate(FileMigration.kt:82)
    at io.realm.BaseRealm$6.onMigrationNeeded(BaseRealm.java:867)
    at io.realm.internal.OsSharedRealm.runMigrationCallback(OsSharedRealm.java:561)
    at io.realm.internal.OsSharedRealm.nativeGetSharedRealm(OsSharedRealm.java)
    at io.realm.internal.OsSharedRealm.<init>(OsSharedRealm.java:175)
    at io.realm.internal.OsSharedRealm.getInstance(OsSharedRealm.java:251)
    at io.realm.BaseRealm.<init>(BaseRealm.java:141)
    at io.realm.BaseRealm.<init>(BaseRealm.java:108)
    at io.realm.Realm.<init>(Realm.java:159)
    at io.realm.Realm.createInstance(Realm.java:495)
    at io.realm.RealmCache.createInstance(RealmCache.java:494)
    at io.realm.RealmCache.doCreateRealmOrGetFromCache(RealmCache.java:461)
    at io.realm.RealmCache.createRealmOrGetFromCache(RealmCache.java:422)
    at io.realm.Realm.getInstance(Realm.java:424)
    at com.infomaniak.drive.data.cache.FileController.getRealmInstance(FileController.kt:300)
    at com.infomaniak.drive.ui.MainViewModel$syncOfflineFiles$2.invoke(MainViewModel.kt:261)
    at com.infomaniak.drive.ui.MainViewModel$syncOfflineFiles$2.invoke(MainViewModel.kt:257)
    at kotlinx.coroutines.InterruptibleKt.runInterruptibleInExpectedContext(Interruptible.kt:46)
    at kotlinx.coroutines.InterruptibleKt.access$runInterruptibleInExpectedContext(Interruptible.kt:1)
    at kotlinx.coroutines.InterruptibleKt$runInterruptible$2.invokeSuspend(Interruptible.kt:38)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:39)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>