### PR TITLE
Fix shared preview slider view model

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,7 +127,7 @@ dependencies {
     standardImplementation 'com.google.android.play:core:1.10.3'
     standardImplementation 'com.google.firebase:firebase-messaging-ktx:23.0.0'
 
-    implementation 'com.github.hannesa2:paho.mqtt.android:3.3.4'
+    implementation 'com.github.hannesa2:paho.mqtt.android:3.3.5'
 
     implementation 'io.sentry:sentry-android:5.5.2'
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewFragment.kt
@@ -18,10 +18,12 @@
 package com.infomaniak.drive.ui.fileList.preview
 
 import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navGraphViewModels
 import com.infomaniak.drive.R
@@ -37,7 +39,7 @@ open class PreviewFragment : Fragment() {
     private val previewViewModel: PreviewViewModel by viewModels()
     protected val previewSliderViewModel: PreviewSliderViewModel by navGraphViewModels(R.id.previewSliderFragment)
 
-    override fun onCreate(savedInstanceState: Bundle?) {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         if (previewViewModel.currentFile == null) {
 
             arguments?.let {
@@ -47,8 +49,11 @@ open class PreviewFragment : Fragment() {
                 }
             }
         }
-        previewViewModel.currentFile?.let { file = it } ?: run { findNavController().popBackStack() }
-        super.onCreate(savedInstanceState)
+
+        previewViewModel.currentFile?.let { file = it }
+            ?: lifecycleScope.launchWhenResumed { findNavController().popBackStack() }
+
+        super.onViewCreated(view, savedInstanceState)
     }
 
     private fun getCurrentFile(fileId: Int) = try {
@@ -67,7 +72,7 @@ open class PreviewFragment : Fragment() {
         null
     }
 
-    protected fun noFileFound() = previewViewModel.currentFile == null
+    protected fun noCurrentFile() = previewViewModel.currentFile == null
 
     protected class PreviewViewModel : ViewModel() {
         var currentFile: File? = null

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewFragment.kt
@@ -67,7 +67,7 @@ open class PreviewFragment : Fragment() {
             scope.setExtra("destination lifecycle", "${backStackEntry?.lifecycle?.currentState}")
             scope.setExtra("previous", previousName ?: "")
             scope.setExtra("exception", exception.stackTraceToString())
-            Sentry.captureMessage("Get file from preview fragment 🤔")
+            Sentry.captureException(exception)
         }
         null
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewOtherFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewOtherFragment.kt
@@ -27,11 +27,14 @@ import kotlinx.android.synthetic.main.fragment_preview_others.*
 class PreviewOtherFragment : PreviewFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return if (noFileFound()) null else inflater.inflate(R.layout.fragment_preview_others, container, false)
+        return inflater.inflate(R.layout.fragment_preview_others, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        if (noCurrentFile()) return
+
         container?.layoutTransition?.setAnimateParentHierarchy(false)
 
         fileIcon.setImageResource(file.getFileType().icon)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewPDFFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewPDFFragment.kt
@@ -52,11 +52,14 @@ class PreviewPDFFragment : PreviewFragment() {
     private var isDownloading = false
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return if (noFileFound()) null else inflater.inflate(R.layout.fragment_preview_pdf, container, false)
+        return inflater.inflate(R.layout.fragment_preview_pdf, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        if (noCurrentFile()) return
+
         container?.layoutTransition?.setAnimateParentHierarchy(false)
 
         fileIcon.setImageResource(file.getFileType().icon)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewPictureFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewPictureFragment.kt
@@ -42,12 +42,14 @@ import kotlinx.coroutines.withContext
 class PreviewPictureFragment : PreviewFragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return if (noFileFound()) null else inflater.inflate(R.layout.fragment_preview_picture, container, false)
+        return inflater.inflate(R.layout.fragment_preview_picture, container, false)
     }
 
     @SuppressLint("ClickableViewAccessibility")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        if (noCurrentFile()) return
 
         val timer = createRefreshTimer(milliseconds = 400) { noThumbnailLayout?.isVisible = true }.start()
         previewDescription.isGone = true
@@ -72,6 +74,7 @@ class PreviewPictureFragment : PreviewFragment() {
                     }
                 )
                 .build()
+
             lifecycleScope.launch(Dispatchers.IO) {
                 imageLoader.execute(previewRequest).drawable?.let { drawable ->
                     if (!imageViewDisposable.isDisposed) imageViewDisposable.dispose()

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
@@ -69,6 +69,11 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
 
+        if (mainViewModel.currentPreviewFileList.isEmpty()) {
+            findNavController().popBackStack()
+            return null
+        }
+
         if (previewSliderViewModel.currentPreview == null) {
             val isSharedWithMe = arguments?.getBoolean(PREVIEW_IS_SHARED_WITH_ME, false) ?: false
             val driveId = arguments?.getInt(PREVIEW_FILE_DRIVE_ID, 0) ?: 0

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
@@ -68,12 +68,6 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
     private lateinit var userDrive: UserDrive
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_preview_slider, container, false)
-    }
-
-    @SuppressLint("ClickableViewAccessibility")
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
 
         if (previewSliderViewModel.currentPreview == null) {
             val isSharedWithMe = arguments?.getBoolean(PREVIEW_IS_SHARED_WITH_ME, false) ?: false
@@ -94,6 +88,13 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
             previewSliderViewModel.currentPreview?.let { currentPreviewFile = it }
             userDrive = previewSliderViewModel.userDrive
         }
+
+        return inflater.inflate(R.layout.fragment_preview_slider, container, false)
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
         setBackActionHandlers()
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewVideoFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewVideoFragment.kt
@@ -50,11 +50,14 @@ open class PreviewVideoFragment : PreviewFragment() {
     private lateinit var exoPlayer: ExoPlayer
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return if (noFileFound()) null else inflater.inflate(R.layout.fragment_preview_video, container, false)
+        return inflater.inflate(R.layout.fragment_preview_video, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        if (noCurrentFile()) return
+
         fileIcon.setImageResource(file.getFileType().icon)
         container?.layoutTransition?.setAnimateParentHierarchy(false)
         fileName.text = file.name


### PR DESCRIPTION
Fix [Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/4684/events/56207d6c435f4fa88f8b60660b03f5e8/?project=3&statsPeriod=14d)

```
java.lang.IllegalStateException: You cannot access the NavBackStackEntry's ViewModels until it is added to the NavController's back stack (i.e., the Lifecycle of the NavBackStackEntry reaches the CREATED state).
	at androidx.navigation.NavBackStackEntry.getViewModelStore(NavBackStackEntry.kt:180)
	at com.infomaniak.drive.ui.fileList.preview.PreviewFragment$special$$inlined$navGraphViewModels$default$2.invoke(NavGraphViewModelLazy.kt:59)
	at com.infomaniak.drive.ui.fileList.preview.PreviewFragment$special$$inlined$navGraphViewModels$default$2.invoke(NavGraphViewModelLazy.kt:58)
	at androidx.lifecycle.ViewModelLazy.getValue(ViewModelProvider.kt:53)
	at androidx.lifecycle.ViewModelLazy.getValue(ViewModelProvider.kt:41)
	at com.infomaniak.drive.ui.fileList.preview.PreviewFragment.getPreviewSliderViewModel(PreviewFragment.kt:38)
	at com.infomaniak.drive.ui.fileList.preview.PreviewFragment.getCurrentFile(PreviewFragment.kt:55)
	at com.infomaniak.drive.ui.fileList.preview.PreviewFragment.onCreate(PreviewFragment.kt:46)
	at androidx.fragment.app.Fragment.performCreate(Fragment.java:2981)
	at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:474)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:257)
	at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:113)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1374)
	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2841)
	at androidx.fragment.app.FragmentManager.dispatchCreate(FragmentManager.java:2773)
	at androidx.fragment.app.Fragment.restoreChildFragmentState(Fragment.java:1935)
	at androidx.fragment.app.Fragment.onCreate(Fragment.java:1911)
	at androidx.fragment.app.Fragment.performCreate(Fragment.java:2981)
	at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:474)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:257)
	at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:113)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1374)
	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2841)
	at androidx.fragment.app.FragmentManager.dispatchCreate(FragmentManager.java:2773)
	at androidx.fragment.app.Fragment.restoreChildFragmentState(Fragment.java:1935)
	at androidx.fragment.app.Fragment.onCreate(Fragment.java:1911)
	at androidx.navigation.fragment.NavHostFragment.onCreate(NavHostFragment.kt:164)
	at androidx.fragment.app.Fragment.performCreate(Fragment.java:2981)
	at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:474)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:257)
	at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:113)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1374)
	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:2841)
	at androidx.fragment.app.FragmentManager.dispatchCreate(FragmentManager.java:2773)
	at androidx.fragment.app.FragmentController.dispatchCreate(FragmentController.java:251)
	at androidx.fragment.app.FragmentActivity.onCreate(FragmentActivity.java:252)
	at com.infomaniak.drive.ui.BaseActivity.onCreate(BaseActivity.kt:28)
	at com.infomaniak.drive.ui.MainActivity.onCreate(MainActivity.kt:92)
	at android.app.Activity.performCreate(Activity.java:7994)
	at android.app.Activity.performCreate(Activity.java:7978)
	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1309)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3404)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3595)
	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2066)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loop(Looper.java:223)
	at android.app.ActivityThread.main(ActivityThread.java:7664)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```