### PR TITLE
Fix illegal state exception for move file

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -199,7 +199,11 @@ class MainViewModel(appContext: Application) : AndroidViewModel(appContext) {
                 FileController.removeFile(file.id, recursive = false, customRealm = realm)
                 FileController.updateFile(newParent.id, realm) { localFolder ->
                     file.isOffline = false
-                    runCatching { localFolder.children.add(file) } // Ignore expired transactions when it's suspended
+                    // Ignore expired transactions when it's suspended
+                    // In case the phone is slow or in standby, the transaction can create an IllegalStateException
+                    // because realm will not be available anymore, the transaction is resumed afterwards
+                    // so we ignore the cases where it fails.
+                    runCatching { localFolder.children.add(file) }
                 }
             }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -196,6 +196,7 @@ class MainViewModel(appContext: Application) : AndroidViewModel(appContext) {
         val apiResponse = ApiRepository.moveFile(file, newParent)
         if (apiResponse.isSuccess()) {
             FileController.getRealmInstance().use { realm ->
+                file.getStoredFile(getContext())?.let { if (it.exists()) it.delete() }
                 FileController.removeFile(file.id, recursive = false, customRealm = realm)
                 FileController.updateFile(newParent.id, realm) { localFolder ->
                     file.isOffline = false

--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -43,7 +43,6 @@ import io.realm.Realm
 import io.sentry.Sentry
 import kotlinx.coroutines.*
 import java.util.*
-import kotlin.collections.LinkedHashMap
 
 class MainViewModel(appContext: Application) : AndroidViewModel(appContext) {
 
@@ -200,7 +199,7 @@ class MainViewModel(appContext: Application) : AndroidViewModel(appContext) {
                 FileController.removeFile(file.id, recursive = false, customRealm = realm)
                 FileController.updateFile(newParent.id, realm) { localFolder ->
                     file.isOffline = false
-                    localFolder.children.add(file)
+                    runCatching { localFolder.children.add(file) }
                 }
             }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -199,7 +199,7 @@ class MainViewModel(appContext: Application) : AndroidViewModel(appContext) {
                 FileController.removeFile(file.id, recursive = false, customRealm = realm)
                 FileController.updateFile(newParent.id, realm) { localFolder ->
                     file.isOffline = false
-                    runCatching { localFolder.children.add(file) }
+                    runCatching { localFolder.children.add(file) } // Ignore expired transactions when it's suspended
                 }
             }
 


### PR DESCRIPTION
After several tests, I managed to reproduce it once but making my phone slow down, or in case the phone is in standby mode, but the file is still taken into account and well saved, so we can just ignore this exception

**Exception** [Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/3289/events/60b0cbee86b24daeb3e02616857b4cab/?project=3&statsPeriod=14d)
```
java.lang.IllegalStateException: This Realm instance has already been closed, making it unusable.
    at io.realm.BaseRealm.checkIfValid(BaseRealm.java:516)
    at io.realm.RealmList.checkValidRealm(RealmList.java:783)
    at io.realm.RealmList.size(RealmList.java:598)
    at io.realm.com_infomaniak_drive_data_models_FileRealmProxy.copy(com_infomaniak_drive_data_models_FileRealmProxy.java:1960)
    at io.realm.com_infomaniak_drive_data_models_FileRealmProxy.copyOrUpdate(com_infomaniak_drive_data_models_FileRealmProxy.java:1900)
    at io.realm.LocalFilesModuleMediator.copyOrUpdate(LocalFilesModuleMediator.java:148)
    at io.realm.Realm.copyOrUpdate(Realm.java:1804)
    at io.realm.Realm.copyToRealmOrUpdate(Realm.java:1188)
    at io.realm.CollectionUtils.copyToRealm(CollectionUtils.java:168)
    at io.realm.RealmModelListOperator.appendValue(ManagedListOperator.java:219)
    at io.realm.ManagedListOperator.append(ManagedListOperator.java:98)
    at io.realm.RealmList.add(RealmList.java:254)
    at com.infomaniak.drive.ui.MainViewModel$moveFile$1$1$1.invoke(MainViewModel.kt:202)
    at com.infomaniak.drive.ui.MainViewModel$moveFile$1$1$1.invoke(MainViewModel.kt:200)
    at com.infomaniak.drive.data.cache.FileController$updateFile$block$1.invoke$lambda-1$lambda-0(FileController.kt:191)
    at com.infomaniak.drive.data.cache.FileController$updateFile$block$1.$r8$lambda$ZBcJ3XVJKHckWSkmaXjfWYBOQc0
    at com.infomaniak.drive.data.cache.FileController$updateFile$block$1$$ExternalSyntheticLambda0.execute
    at io.realm.Realm.executeTransaction(Realm.java:1593)
    at com.infomaniak.drive.data.cache.FileController$updateFile$block$1.invoke(FileController.kt:190)
    at com.infomaniak.drive.data.cache.FileController$updateFile$block$1.invoke(FileController.kt:188)
    at com.infomaniak.drive.data.cache.FileController.updateFile(FileController.kt:195)
    at com.infomaniak.drive.data.cache.FileController.updateFile$default(FileController.kt:186)
    at com.infomaniak.drive.ui.MainViewModel$moveFile$1.invokeSuspend(MainViewModel.kt:200)
    at com.infomaniak.drive.ui.MainViewModel$moveFile$1.invoke
    at com.infomaniak.drive.ui.MainViewModel$moveFile$1.invoke
    at androidx.lifecycle.BlockRunner$maybeRun$1.invokeSuspend(CoroutineLiveData.kt:176)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:39)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

Close #503 