### PR TITLE
fix filedetails navigation to parent folder content in bottomnavigation

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
@@ -34,6 +34,7 @@ import android.os.FileObserver
 import android.provider.DocumentsContract
 import android.provider.MediaStore
 import android.util.Log
+import android.view.View
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -148,6 +149,8 @@ class MainActivity : BaseActivity() {
                     message = "Upload notification has been clicked"
                     level = SentryLevel.INFO
                 })
+
+                bottomNavigation.findViewById<View>(R.id.fileListFragment).performClick()
                 mainViewModel.navigateFileListToFolderId(navController, folderId)
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -78,7 +78,12 @@ class MainViewModel(appContext: Application) : AndroidViewModel(appContext) {
     private fun getContext() = getApplication<ApplicationMain>()
 
     fun navigateFileListToFolderId(navController: NavController, folderId: Int) {
-        navController.navigate(R.id.fileListFragment)
+        // Clear FileListFragment stack
+        with(navController) {
+            popBackStack(R.id.homeFragment, false)
+            navigate(R.id.fileListFragment)
+        }
+        // Emit destination folder id
         if (folderId > Utils.ROOT_ID) navigateFileListToFolderId.value = folderId
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/FileDetailsInfoFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/FileDetailsInfoFragment.kt
@@ -38,11 +38,13 @@ import com.infomaniak.drive.data.models.Permission
 import com.infomaniak.drive.data.models.Share
 import com.infomaniak.drive.data.models.ShareLink
 import com.infomaniak.drive.data.models.drive.Category
+import com.infomaniak.drive.ui.MainActivity
 import com.infomaniak.drive.ui.bottomSheetDialogs.SelectPermissionBottomSheetDialog
 import com.infomaniak.drive.utils.*
 import com.infomaniak.drive.views.ShareLinkContainerView
 import com.infomaniak.drive.views.UserAvatarView
 import com.infomaniak.lib.core.utils.format
+import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.fragment_file_details.*
 import kotlinx.android.synthetic.main.fragment_file_details_infos.*
 
@@ -148,9 +150,9 @@ class FileDetailsInfoFragment : FileDetailsSubFragment() {
             pathLocationButton.setOnClickListener {
                 with(findNavController()) {
                     popBackStack(R.id.homeFragment, false)
+                    (requireActivity() as MainActivity).bottomNavigation.findViewById<View>(R.id.fileListFragment).performClick()
                     mainViewModel.navigateFileListToFolderId(this, folder.id)
                 }
-
             }
         }
     }


### PR DESCRIPTION
When navigating to the parent folder from the FileDetails in the home, the navigation with the bottomNavigation is badly handled.

This fix corrects this problem

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>