### PR TITLE
Fix bulk selection for offline and favorite

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/models/BulkOperationType.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/BulkOperationType.kt
@@ -36,7 +36,8 @@ enum class BulkOperationType(@StringRes val title: Int, @PluralsRes val successM
     COLOR_FOLDER(0, R.plurals.fileListColorFolderConfirmationSnackbar),
 
     SET_OFFLINE(0, successMessage = R.plurals.fileListAddOfflineConfirmationSnackbar),
-    ADD_FAVORITES(0, successMessage = R.plurals.fileListAddFavorisConfirmationSnackbar);
+    ADD_FAVORITES(0, successMessage = R.plurals.fileListAddFavoritesConfirmationSnackbar),
+    REMOVE_FAVORITES(0, successMessage = R.plurals.fileListRemoveFavoritesConfirmationSnackbar);
 
     fun getNotificationBuilder(context: Context): NotificationCompat.Builder {
         return when (this) {

--- a/app/src/main/java/com/infomaniak/drive/data/models/BulkOperationType.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/BulkOperationType.kt
@@ -35,7 +35,8 @@ enum class BulkOperationType(@StringRes val title: Int, @PluralsRes val successM
     COPY(R.string.fileListCopyInProgressSnackbar, R.plurals.fileListDuplicationConfirmationSnackbar),
     COLOR_FOLDER(0, R.plurals.fileListColorFolderConfirmationSnackbar),
 
-    SET_OFFLINE(0, successMessage = R.plurals.fileListAddOfflineConfirmationSnackbar),
+    ADD_OFFLINE(0, successMessage = R.plurals.fileListAddOfflineConfirmationSnackbar),
+    REMOVE_OFFLINE(0, successMessage = R.plurals.fileListRemoveOfflineConfirmationSnackbar),
     ADD_FAVORITES(0, successMessage = R.plurals.fileListAddFavoritesConfirmationSnackbar),
     REMOVE_FAVORITES(0, successMessage = R.plurals.fileListRemoveFavoritesConfirmationSnackbar);
 

--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -42,7 +42,6 @@ import com.infomaniak.lib.core.networking.HttpClient
 import io.realm.Realm
 import io.sentry.Sentry
 import kotlinx.coroutines.*
-import java.util.*
 
 class MainViewModel(appContext: Application) : AndroidViewModel(appContext) {
 

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
@@ -81,15 +81,21 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
     }
 
     private fun configureAvailableOffline(otherActionsVisibility: Boolean) {
-        availableOfflineSwitch.apply {
-            isChecked = navigationArgs.onlyOffline
-            setOnCheckedChangeListener { _, _ -> onActionSelected(SelectDialogAction.OFFLINE) }
+        with(navigationArgs) {
+            availableOfflineSwitch.apply {
+                isChecked = onlyOffline
+                setOnCheckedChangeListener { _, _ -> selectOfflineDialogActionCallBack(onlyOffline) }
+            }
+            disabledAvailableOffline.isVisible = onlyFolders
+            availableOffline.apply {
+                setOnClickListener { selectOfflineDialogActionCallBack(onlyOffline) }
+                isVisible = otherActionsVisibility
+            }
         }
-        disabledAvailableOffline.isVisible = navigationArgs.onlyFolders
-        availableOffline.apply {
-            setOnClickListener { onActionSelected(SelectDialogAction.OFFLINE) }
-            isVisible = otherActionsVisibility
-        }
+    }
+
+    private fun selectOfflineDialogActionCallBack(onlyOffline: Boolean) {
+        onActionSelected(if (onlyOffline) SelectDialogAction.REMOVE_OFFLINE else SelectDialogAction.ADD_OFFLINE)
     }
 
     private fun configureDownloadFile() {
@@ -131,7 +137,8 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
         val finalType = when (type) {
             SelectDialogAction.ADD_FAVORITES -> BulkOperationType.ADD_FAVORITES
             SelectDialogAction.REMOVE_FAVORITE -> BulkOperationType.REMOVE_FAVORITES
-            SelectDialogAction.OFFLINE -> BulkOperationType.SET_OFFLINE
+            SelectDialogAction.ADD_OFFLINE -> BulkOperationType.ADD_OFFLINE
+            SelectDialogAction.REMOVE_OFFLINE -> BulkOperationType.REMOVE_OFFLINE
             SelectDialogAction.DUPLICATE -> BulkOperationType.COPY
             SelectDialogAction.COLOR_FOLDER -> BulkOperationType.COLOR_FOLDER
             else -> null
@@ -151,7 +158,7 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
     }
 
     enum class SelectDialogAction {
-        ADD_FAVORITES, REMOVE_FAVORITE, OFFLINE, DUPLICATE, COLOR_FOLDER
+        ADD_FAVORITES, REMOVE_FAVORITE, ADD_OFFLINE, REMOVE_OFFLINE, DUPLICATE, COLOR_FOLDER
     }
 
     companion object {

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
@@ -83,17 +83,18 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
     private fun configureAvailableOffline(otherActionsVisibility: Boolean) = with(navigationArgs) {
         availableOfflineSwitch.apply {
             isChecked = onlyOffline
-            setOnCheckedChangeListener { _, _ -> selectOfflineDialogActionCallBack(onlyOffline) }
+            setOnCheckedChangeListener { _, _ -> selectOfflineDialogActionCallBack() }
         }
         disabledAvailableOffline.isVisible = onlyFolders
         availableOffline.apply {
-            setOnClickListener { selectOfflineDialogActionCallBack(onlyOffline) }
+            setOnClickListener { selectOfflineDialogActionCallBack() }
             isVisible = otherActionsVisibility
         }
     }
 
-    private fun selectOfflineDialogActionCallBack(onlyOffline: Boolean) {
-        onActionSelected(if (onlyOffline) SelectDialogAction.REMOVE_OFFLINE else SelectDialogAction.ADD_OFFLINE)
+    private fun selectOfflineDialogActionCallBack() {
+        val action = if (navigationArgs.onlyOffline) SelectDialogAction.REMOVE_OFFLINE else SelectDialogAction.ADD_OFFLINE
+        onActionSelected(action)
     }
 
     private fun configureDownloadFile() {

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
@@ -37,6 +37,7 @@ import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.data.models.BulkOperationType
 import com.infomaniak.drive.utils.*
 import kotlinx.android.synthetic.main.fragment_bottom_sheet_action_multi_select.*
+import kotlinx.android.synthetic.main.view_file_info_actions.view.*
 import kotlinx.coroutines.Dispatchers
 
 class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
@@ -67,9 +68,19 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
 
     private fun configureAddFavorites(otherActionsVisibility: Boolean) {
         addFavorites.apply {
-            setOnClickListener { onActionSelected(SelectDialogAction.ADD_FAVORITES) }
+            with(navigationArgs) {
+                addFavoritesIcon.isEnabled = onlyFavorite
+                if (onlyFavorite) {
+                    addFavoritesText.setText(R.string.buttonRemoveFavorites)
+                    setOnClickListener { onActionSelected(SelectDialogAction.REMOVE_FAVORITE) }
+                } else {
+                    addFavoritesText.setText(R.string.buttonAddFavorites)
+                    setOnClickListener { onActionSelected(SelectDialogAction.ADD_FAVORITES) }
+                }
+            }
             isVisible = otherActionsVisibility
         }
+
     }
 
     private fun configureAvailableOffline(otherActionsVisibility: Boolean) {
@@ -122,6 +133,7 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
     private fun onActionSelected(type: SelectDialogAction? = null) {
         val finalType = when (type) {
             SelectDialogAction.ADD_FAVORITES -> BulkOperationType.ADD_FAVORITES
+            SelectDialogAction.REMOVE_FAVORITE -> BulkOperationType.REMOVE_FAVORITES
             SelectDialogAction.OFFLINE -> BulkOperationType.SET_OFFLINE
             SelectDialogAction.DUPLICATE -> BulkOperationType.COPY
             SelectDialogAction.COLOR_FOLDER -> BulkOperationType.COLOR_FOLDER
@@ -142,7 +154,7 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
     }
 
     enum class SelectDialogAction {
-        ADD_FAVORITES, OFFLINE, DUPLICATE, COLOR_FOLDER
+        ADD_FAVORITES, REMOVE_FAVORITE, OFFLINE, DUPLICATE, COLOR_FOLDER
     }
 
     companion object {

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
@@ -69,28 +69,26 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
     private fun configureAddFavorites(otherActionsVisibility: Boolean) {
         addFavorites.apply {
             addFavoritesIcon.isEnabled = navigationArgs.onlyFavorite
-            if (navigationArgs.onlyFavorite) {
-                addFavoritesText.setText(R.string.buttonRemoveFavorites)
-                setOnClickListener { onActionSelected(SelectDialogAction.REMOVE_FAVORITE) }
+            val (text, action) = if (navigationArgs.onlyFavorite) {
+                R.string.buttonRemoveFavorites to SelectDialogAction.REMOVE_FAVORITE
             } else {
-                addFavoritesText.setText(R.string.buttonAddFavorites)
-                setOnClickListener { onActionSelected(SelectDialogAction.ADD_FAVORITES) }
+                R.string.buttonAddFavorites to SelectDialogAction.ADD_FAVORITES
             }
+            addFavoritesText.setText(text)
+            setOnClickListener { onActionSelected(action) }
             isVisible = otherActionsVisibility
         }
     }
 
-    private fun configureAvailableOffline(otherActionsVisibility: Boolean) {
-        with(navigationArgs) {
-            availableOfflineSwitch.apply {
-                isChecked = onlyOffline
-                setOnCheckedChangeListener { _, _ -> selectOfflineDialogActionCallBack(onlyOffline) }
-            }
-            disabledAvailableOffline.isVisible = onlyFolders
-            availableOffline.apply {
-                setOnClickListener { selectOfflineDialogActionCallBack(onlyOffline) }
-                isVisible = otherActionsVisibility
-            }
+    private fun configureAvailableOffline(otherActionsVisibility: Boolean) = with(navigationArgs) {
+        availableOfflineSwitch.apply {
+            isChecked = onlyOffline
+            setOnCheckedChangeListener { _, _ -> selectOfflineDialogActionCallBack(onlyOffline) }
+        }
+        disabledAvailableOffline.isVisible = onlyFolders
+        availableOffline.apply {
+            setOnClickListener { selectOfflineDialogActionCallBack(onlyOffline) }
+            isVisible = otherActionsVisibility
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
@@ -68,19 +68,16 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
 
     private fun configureAddFavorites(otherActionsVisibility: Boolean) {
         addFavorites.apply {
-            with(navigationArgs) {
-                addFavoritesIcon.isEnabled = onlyFavorite
-                if (onlyFavorite) {
-                    addFavoritesText.setText(R.string.buttonRemoveFavorites)
-                    setOnClickListener { onActionSelected(SelectDialogAction.REMOVE_FAVORITE) }
-                } else {
-                    addFavoritesText.setText(R.string.buttonAddFavorites)
-                    setOnClickListener { onActionSelected(SelectDialogAction.ADD_FAVORITES) }
-                }
+            addFavoritesIcon.isEnabled = navigationArgs.onlyFavorite
+            if (navigationArgs.onlyFavorite) {
+                addFavoritesText.setText(R.string.buttonRemoveFavorites)
+                setOnClickListener { onActionSelected(SelectDialogAction.REMOVE_FAVORITE) }
+            } else {
+                addFavoritesText.setText(R.string.buttonAddFavorites)
+                setOnClickListener { onActionSelected(SelectDialogAction.ADD_FAVORITES) }
             }
             isVisible = otherActionsVisibility
         }
-
     }
 
     private fun configureAvailableOffline(otherActionsVisibility: Boolean) {

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
@@ -66,10 +66,10 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
         }
     }
 
-    private fun configureAddFavorites(otherActionsVisibility: Boolean) {
+    private fun configureAddFavorites(otherActionsVisibility: Boolean) = with(navigationArgs) {
         addFavorites.apply {
-            addFavoritesIcon.isEnabled = navigationArgs.onlyFavorite
-            val (text, action) = if (navigationArgs.onlyFavorite) {
+            addFavoritesIcon.isEnabled = onlyFavorite
+            val (text, action) = if (onlyFavorite) {
                 R.string.buttonRemoveFavorites to SelectDialogAction.REMOVE_FAVORITE
             } else {
                 R.string.buttonAddFavorites to SelectDialogAction.ADD_FAVORITES

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
@@ -73,7 +73,10 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
     }
 
     private fun configureAvailableOffline(otherActionsVisibility: Boolean) {
-        availableOfflineSwitch.setOnCheckedChangeListener { _, _ -> onActionSelected(SelectDialogAction.OFFLINE) }
+        availableOfflineSwitch.apply {
+            isChecked = navigationArgs.onlyOffline
+            setOnCheckedChangeListener { _, _ -> onActionSelected(SelectDialogAction.OFFLINE) }
+        }
         disabledAvailableOffline.isVisible = navigationArgs.onlyFolders
         availableOffline.apply {
             setOnClickListener { onActionSelected(SelectDialogAction.OFFLINE) }

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/ActionMultiSelectBottomSheetDialog.kt
@@ -70,7 +70,7 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
         addFavorites.apply {
             addFavoritesIcon.isEnabled = onlyFavorite
             val (text, action) = if (onlyFavorite) {
-                R.string.buttonRemoveFavorites to SelectDialogAction.REMOVE_FAVORITE
+                R.string.buttonRemoveFavorites to SelectDialogAction.REMOVE_FAVORITES
             } else {
                 R.string.buttonAddFavorites to SelectDialogAction.ADD_FAVORITES
             }
@@ -135,7 +135,7 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
     private fun onActionSelected(type: SelectDialogAction? = null) {
         val finalType = when (type) {
             SelectDialogAction.ADD_FAVORITES -> BulkOperationType.ADD_FAVORITES
-            SelectDialogAction.REMOVE_FAVORITE -> BulkOperationType.REMOVE_FAVORITES
+            SelectDialogAction.REMOVE_FAVORITES -> BulkOperationType.REMOVE_FAVORITES
             SelectDialogAction.ADD_OFFLINE -> BulkOperationType.ADD_OFFLINE
             SelectDialogAction.REMOVE_OFFLINE -> BulkOperationType.REMOVE_OFFLINE
             SelectDialogAction.DUPLICATE -> BulkOperationType.COPY
@@ -157,7 +157,7 @@ class ActionMultiSelectBottomSheetDialog : BottomSheetDialogFragment() {
     }
 
     enum class SelectDialogAction {
-        ADD_FAVORITES, REMOVE_FAVORITE, ADD_OFFLINE, REMOVE_OFFLINE, DUPLICATE, COLOR_FOLDER
+        ADD_FAVORITES, REMOVE_FAVORITES, ADD_OFFLINE, REMOVE_OFFLINE, DUPLICATE, COLOR_FOLDER
     }
 
     companion object {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -484,8 +484,7 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
                     fileIds = fileAdapter.getValidItemsSelected().map { it.id }.toIntArray(),
                     onlyFolders = fileAdapter.getValidItemsSelected().all { it.isFolder() },
                 )
-            }
-
+            )
         }
 
         selectAllButton.apply {
@@ -663,30 +662,22 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         if (!file.isFolder()) {
             val cacheFile = file.getCacheFile(requireContext())
             val offlineFile = file.getOfflineFile(requireContext())
-            if (mustAdd) {
-                addSelectedFileToOffline(file, offlineFile, cacheFile)
-            } else {
-                removeSelectedFileFromOffline(file, offlineFile, cacheFile)
-            }
-            closeMultiSelect()
-        }
-    }
 
-    private fun addSelectedFileToOffline(file: File, offlineFile: java.io.File?, cacheFile: java.io.File) {
-        if (offlineFile != null && !file.isObsoleteOrNotIntact(cacheFile)) {
-            Utils.moveCacheFileToOffline(file, cacheFile, offlineFile)
-            runBlocking(Dispatchers.IO) { FileController.updateOfflineStatus(file.id, true) }
+            if (offlineFile != null && !file.isObsoleteOrNotIntact(cacheFile)) {
+                Utils.moveCacheFileToOffline(file, cacheFile, offlineFile)
+                runBlocking(Dispatchers.IO) { FileController.updateOfflineStatus(file.id, true) }
 
-            fileAdapter.updateFileProgressByFileId(file.id, 100) { _, currentFile ->
-                currentFile.apply {
-                    if (isNotManagedByRealm()) {
-                        isOffline = true
-                        currentProgress = 0
+                fileAdapter.updateFileProgressByFileId(file.id, 100) { _, currentFile ->
+                    currentFile.apply {
+                        if (isNotManagedByRealm()) {
+                            isOffline = true
+                            currentProgress = 0
+                        }
                     }
                 }
+            } else {
+                Utils.downloadAsOfflineFile(requireContext(), file)
             }
-        } else {
-            Utils.downloadAsOfflineFile(requireContext(), file)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -450,6 +450,12 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
                     mainViewModel.updateMultiSelectMediator(mediator),
                 )
             }
+            BulkOperationType.REMOVE_FAVORITES -> {
+                mediator.addSource(
+                    mainViewModel.deleteFileFromFavorites(file),
+                    mainViewModel.updateMultiSelectMediator(mediator),
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -434,9 +434,7 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
                     }
                 }
             }
-            BulkOperationType.ADD_OFFLINE, BulkOperationType.REMOVE_OFFLINE -> {
-                addOrRemoveSelectedFilesToOffline(file, type == BulkOperationType.ADD_OFFLINE)
-            }
+            BulkOperationType.ADD_OFFLINE, BulkOperationType.REMOVE_OFFLINE -> addOrRemoveSelectedFilesToOffline(file, type)
             BulkOperationType.ADD_FAVORITES -> {
                 mediator.addSource(
                     mainViewModel.addFileToFavorites(file) {
@@ -669,11 +667,11 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         }
     }
 
-    private fun addOrRemoveSelectedFilesToOffline(file: File, mustAdd: Boolean) {
+    private fun addOrRemoveSelectedFilesToOffline(file: File, type: BulkOperationType) {
         if (!file.isFolder()) {
             val cacheFile = file.getCacheFile(requireContext())
             val offlineFile = file.getOfflineFile(requireContext())
-            if (mustAdd) {
+            if (type == BulkOperationType.ADD_OFFLINE) {
                 addSelectedFileToOffline(file, offlineFile, cacheFile)
             } else {
                 removeSelectedFileFromOffline(file, offlineFile, cacheFile)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -479,16 +479,23 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         moveButtonMultiSelect.setOnClickListener { Utils.moveFileClicked(this, folderId) }
 
         menuButtonMultiSelect.setOnClickListener {
-            with(fileAdapter.getValidItemsSelected()) {
-                safeNavigate(
-                    FileListFragmentDirections.actionFileListFragmentToActionMultiSelectBottomSheetDialog(
-                        fileIds = this.map { it.id }.toIntArray(),
-                        onlyFolders = this.all { it.isFolder() },
-                        onlyFavorite = this.all { it.isFavorite },
-                        onlyOffline = this.all { it.isOffline },
-                    )
-                )
+            val fileIds = arrayListOf<Int>()
+            var (onlyFolders, onlyFavorite, onlyOffline) = arrayOf(true, true, true)
+            fileAdapter.getValidItemsSelected().forEach {
+                fileIds.add(it.id)
+                if (!it.isFolder()) onlyFolders = false
+                if (!it.isFavorite) onlyFavorite = false
+                if (!it.isOffline) onlyOffline = false
             }
+
+            safeNavigate(
+                FileListFragmentDirections.actionFileListFragmentToActionMultiSelectBottomSheetDialog(
+                    fileIds = fileIds.toIntArray(),
+                    onlyFolders = onlyFolders,
+                    onlyFavorite = onlyFavorite,
+                    onlyOffline = onlyOffline,
+                )
+            )
         }
 
         selectAllButton.apply {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -678,12 +678,16 @@ open class FileListFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
             runBlocking(Dispatchers.IO) { FileController.updateOfflineStatus(file.id, true) }
 
             fileAdapter.updateFileProgressByFileId(file.id, 100) { _, currentFile ->
-                if (currentFile.isNotManagedByRealm()) {
-                    currentFile.isOffline = true
-                    currentFile.currentProgress = 0
+                currentFile.apply {
+                    if (isNotManagedByRealm()) {
+                        isOffline = true
+                        currentProgress = 0
+                    }
                 }
             }
-        } else Utils.downloadAsOfflineFile(requireContext(), file)
+        } else {
+            Utils.downloadAsOfflineFile(requireContext(), file)
+        }
     }
 
     private fun removeSelectedFileFromOffline(file: File, offlineFile: java.io.File?, cacheFile: java.io.File) {

--- a/app/src/main/res/layout/fragment_bottom_sheet_action_multi_select.xml
+++ b/app/src/main/res/layout/fragment_bottom_sheet_action_multi_select.xml
@@ -74,10 +74,10 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/marginStandard"
             android:src="@drawable/ic_star_filled"
-            app:tint="@color/star_favorites"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            app:tint="@color/star_favorites"
             tools:ignore="ContentDescription" />
 
         <TextView

--- a/app/src/main/res/layout/fragment_bottom_sheet_action_multi_select.xml
+++ b/app/src/main/res/layout/fragment_bottom_sheet_action_multi_select.xml
@@ -74,6 +74,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/marginStandard"
             android:src="@drawable/ic_star_filled"
+            app:tint="@color/star_favorites"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -202,6 +202,14 @@
             android:name="onlyFolders"
             android:defaultValue="false"
             app:argType="boolean" />
+        <argument
+            android:name="onlyFavorite"
+            android:defaultValue="false"
+            app:argType="boolean" />
+        <argument
+            android:name="onlyOffline"
+            android:defaultValue="false"
+            app:argType="boolean" />
     </dialog>
 
     <dialog

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -363,9 +363,13 @@
     <string name="fileDetailsNoComments">Derzeit kein Kommentar</string>
     <string name="fileInfoInputDuplicateFile">Bezeichnung der Kopie</string>
     <string name="fileInfoLinkCopiedToClipboard">Link in Zwischenablage kopiert</string>
-    <plurals name="fileListAddFavorisConfirmationSnackbar">
+    <plurals name="fileListAddFavoritesConfirmationSnackbar">
         <item quantity="one">Datei erfolgreich zu Favoriten hinzugefügt</item>
         <item quantity="other">%d Dateien erfolgreich zu Favoriten hinzugefügt</item>
+    </plurals>
+    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
+        <item quantity="one">Datei erfolgreich aus den Favoriten entfernt</item>
+        <item quantity="other">%d Dateien erfolgreich aus den Favoriten entfernt</item>
     </plurals>
     <plurals name="fileListAddOfflineConfirmationSnackbar">
         <item quantity="one">Datei offline verfügbar</item>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -367,17 +367,9 @@
         <item quantity="one">Datei erfolgreich zu Favoriten hinzugefügt</item>
         <item quantity="other">%d Dateien erfolgreich zu Favoriten hinzugefügt</item>
     </plurals>
-    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
-        <item quantity="one">Datei erfolgreich aus den Favoriten entfernt</item>
-        <item quantity="other">%d Dateien erfolgreich aus den Favoriten entfernt</item>
-    </plurals>
     <plurals name="fileListAddOfflineConfirmationSnackbar">
         <item quantity="one">Datei offline verfügbar</item>
         <item quantity="other">%d Dateien offline verfügbar</item>
-    </plurals>
-    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
-        <item quantity="one">Datei aus der offline Verfügbarkeit entfernt</item>
-        <item quantity="other">%d Dateien aus der offline Verfügbarkeit entfernt</item>
     </plurals>
     <plurals name="fileListColorFolderConfirmationSnackbar">
         <item quantity="one">Ordner erfolgreich eingefärbt</item>
@@ -403,6 +395,14 @@
     <plurals name="fileListMultiSelectedTitle">
         <item quantity="one">%d ausgewählt</item>
         <item quantity="other">%d ausgewählt</item>
+    </plurals>
+    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
+        <item quantity="one">Datei erfolgreich aus den Favoriten entfernt</item>
+        <item quantity="other">%d Dateien erfolgreich aus den Favoriten entfernt</item>
+    </plurals>
+    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
+        <item quantity="one">Datei aus der offline Verfügbarkeit entfernt</item>
+        <item quantity="other">%d Dateien aus der offline Verfügbarkeit entfernt</item>
     </plurals>
     <string name="fileListTitle">Dateien</string>
     <string name="filePermissionTitle">Recht auswählen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -375,6 +375,10 @@
         <item quantity="one">Datei offline verfügbar</item>
         <item quantity="other">%d Dateien offline verfügbar</item>
     </plurals>
+    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
+        <item quantity="one">Datei aus der offline Verfügbarkeit entfernt</item>
+        <item quantity="other">%d Dateien aus der offline Verfügbarkeit entfernt</item>
+    </plurals>
     <plurals name="fileListColorFolderConfirmationSnackbar">
         <item quantity="one">Ordner erfolgreich eingefärbt</item>
         <item quantity="other">%d Ordner erfolgreich eingefärbt</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -367,17 +367,9 @@
         <item quantity="one">Un archivo añadido a favoritos correctamente</item>
         <item quantity="other">%d archivos añadidos a favoritos correctamente</item>
     </plurals>
-    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
-        <item quantity="one">Un archivo ha sido eliminado de favoritos correctamente</item>
-        <item quantity="other">%d archivos han sido eliminados de favoritos correctamente</item>
-    </plurals>
     <plurals name="fileListAddOfflineConfirmationSnackbar">
         <item quantity="one">Un archivo disponible sin conexión</item>
         <item quantity="other">%d archivos disponibles sin conexión</item>
-    </plurals>
-    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
-        <item quantity="one">Un archivo eliminado de la disponibilidad sin conexión</item>
-        <item quantity="other">%d archivos eliminados de la disponibilidad sin conexión</item>
     </plurals>
     <plurals name="fileListColorFolderConfirmationSnackbar">
         <item quantity="one">Una carpeta coloreada con éxito</item>
@@ -403,6 +395,14 @@
     <plurals name="fileListMultiSelectedTitle">
         <item quantity="one">%d seleccionado</item>
         <item quantity="other">%d seleccionados</item>
+    </plurals>
+    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
+        <item quantity="one">Un archivo ha sido eliminado de favoritos correctamente</item>
+        <item quantity="other">%d archivos han sido eliminados de favoritos correctamente</item>
+    </plurals>
+    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
+        <item quantity="one">Un archivo eliminado de la disponibilidad sin conexión</item>
+        <item quantity="other">%d archivos eliminados de la disponibilidad sin conexión</item>
     </plurals>
     <string name="fileListTitle">Archivos</string>
     <string name="filePermissionTitle">Seleccionar el derecho</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -375,6 +375,10 @@
         <item quantity="one">Un archivo disponible sin conexión</item>
         <item quantity="other">%d archivos disponibles sin conexión</item>
     </plurals>
+    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
+        <item quantity="one">Un archivo eliminado de la disponibilidad sin conexión</item>
+        <item quantity="other">%d archivos eliminados de la disponibilidad sin conexión</item>
+    </plurals>
     <plurals name="fileListColorFolderConfirmationSnackbar">
         <item quantity="one">Una carpeta coloreada con éxito</item>
         <item quantity="other">%d carpetas coloreadas con éxito</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -363,9 +363,13 @@
     <string name="fileDetailsNoComments">Todavía no hay comentarios</string>
     <string name="fileInfoInputDuplicateFile">Nombre de la copia</string>
     <string name="fileInfoLinkCopiedToClipboard">Enlace copiado en el portapapeles</string>
-    <plurals name="fileListAddFavorisConfirmationSnackbar">
+    <plurals name="fileListAddFavoritesConfirmationSnackbar">
         <item quantity="one">Un archivo añadido a favoritos correctamente</item>
         <item quantity="other">%d archivos añadidos a favoritos correctamente</item>
+    </plurals>
+    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
+        <item quantity="one">Un archivo ha sido eliminado de favoritos correctamente</item>
+        <item quantity="other">%d archivos han sido eliminados de favoritos correctamente</item>
     </plurals>
     <plurals name="fileListAddOfflineConfirmationSnackbar">
         <item quantity="one">Un archivo disponible sin conexión</item>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -363,9 +363,13 @@
     <string name="fileDetailsNoComments">Aucun commentaire pour le moment</string>
     <string name="fileInfoInputDuplicateFile">Nom de la copie</string>
     <string name="fileInfoLinkCopiedToClipboard">Lien copié dans le presse-papiers</string>
-    <plurals name="fileListAddFavorisConfirmationSnackbar">
+    <plurals name="fileListAddFavoritesConfirmationSnackbar">
         <item quantity="one">Un fichier ajouté aux favoris avec succès</item>
         <item quantity="other">%d fichiers ajoutés aux favoris avec succès</item>
+    </plurals>
+    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
+        <item quantity="one">Un fichier retiré des favoris avec succès</item>
+        <item quantity="other">%d fichiers retiré des favoris avec succès</item>
     </plurals>
     <plurals name="fileListAddOfflineConfirmationSnackbar">
         <item quantity="one">Un fichier disponible hors ligne</item>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -375,6 +375,10 @@
         <item quantity="one">Un fichier disponible hors ligne</item>
         <item quantity="other">%d fichiers disponibles hors ligne</item>
     </plurals>
+    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
+        <item quantity="one">Un fichier retiré de la disponibilité hors ligne</item>
+        <item quantity="other">%d fichiers retirés de la disponibilité hors ligne</item>
+    </plurals>
     <plurals name="fileListColorFolderConfirmationSnackbar">
         <item quantity="one">Un dossier coloré avec succès</item>
         <item quantity="other">%d dossiers colorés avec succès</item>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -367,17 +367,9 @@
         <item quantity="one">Un fichier ajouté aux favoris avec succès</item>
         <item quantity="other">%d fichiers ajoutés aux favoris avec succès</item>
     </plurals>
-    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
-        <item quantity="one">Un fichier retiré des favoris avec succès</item>
-        <item quantity="other">%d fichiers retiré des favoris avec succès</item>
-    </plurals>
     <plurals name="fileListAddOfflineConfirmationSnackbar">
         <item quantity="one">Un fichier disponible hors ligne</item>
         <item quantity="other">%d fichiers disponibles hors ligne</item>
-    </plurals>
-    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
-        <item quantity="one">Un fichier retiré de la disponibilité hors ligne</item>
-        <item quantity="other">%d fichiers retirés de la disponibilité hors ligne</item>
     </plurals>
     <plurals name="fileListColorFolderConfirmationSnackbar">
         <item quantity="one">Un dossier coloré avec succès</item>
@@ -403,6 +395,14 @@
     <plurals name="fileListMultiSelectedTitle">
         <item quantity="one">%d sélectionné</item>
         <item quantity="other">%d sélectionnés</item>
+    </plurals>
+    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
+        <item quantity="one">Un fichier retiré des favoris avec succès</item>
+        <item quantity="other">%d fichiers retirés des favoris avec succès</item>
+    </plurals>
+    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
+        <item quantity="one">Un fichier retiré de la disponibilité hors ligne</item>
+        <item quantity="other">%d fichiers retirés de la disponibilité hors ligne</item>
     </plurals>
     <string name="fileListTitle">Fichiers</string>
     <string name="filePermissionTitle">Sélectionner le droit</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -363,9 +363,13 @@
     <string name="fileDetailsNoComments">Al momento non ci sono commenti</string>
     <string name="fileInfoInputDuplicateFile">Nome della copia</string>
     <string name="fileInfoLinkCopiedToClipboard">Link copiato negli Appunti</string>
-    <plurals name="fileListAddFavorisConfirmationSnackbar">
+    <plurals name="fileListAddFavoritesConfirmationSnackbar">
         <item quantity="one">File aggiunto ai preferiti con successo</item>
         <item quantity="other">%d file aggiunti ai preferiti con successo</item>
+    </plurals>
+    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
+        <item quantity="one">File rimosso ai preferiti con successo</item>
+        <item quantity="other">%d file rimosso ai preferiti con successo</item>
     </plurals>
     <plurals name="fileListAddOfflineConfirmationSnackbar">
         <item quantity="one">Un file è disponibile offline</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -375,6 +375,10 @@
         <item quantity="one">Un file è disponibile offline</item>
         <item quantity="other">%d file sono disponibili offline</item>
     </plurals>
+    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
+        <item quantity="one">Un file rimosso dalla disponibilità offline</item>
+        <item quantity="other">%d file rimossi dalla disponibilità offline</item>
+    </plurals>
     <plurals name="fileListColorFolderConfirmationSnackbar">
         <item quantity="one">Una cartella colorata con successo</item>
         <item quantity="other">%d cartelle colorate con successo</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -367,17 +367,9 @@
         <item quantity="one">File aggiunto ai preferiti con successo</item>
         <item quantity="other">%d file aggiunti ai preferiti con successo</item>
     </plurals>
-    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
-        <item quantity="one">File rimosso ai preferiti con successo</item>
-        <item quantity="other">%d file rimosso ai preferiti con successo</item>
-    </plurals>
     <plurals name="fileListAddOfflineConfirmationSnackbar">
         <item quantity="one">Un file è disponibile offline</item>
         <item quantity="other">%d file sono disponibili offline</item>
-    </plurals>
-    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
-        <item quantity="one">Un file rimosso dalla disponibilità offline</item>
-        <item quantity="other">%d file rimossi dalla disponibilità offline</item>
     </plurals>
     <plurals name="fileListColorFolderConfirmationSnackbar">
         <item quantity="one">Una cartella colorata con successo</item>
@@ -403,6 +395,14 @@
     <plurals name="fileListMultiSelectedTitle">
         <item quantity="one">%d selezionato</item>
         <item quantity="other">%d selezionati</item>
+    </plurals>
+    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
+        <item quantity="one">File rimosso ai preferiti con successo</item>
+        <item quantity="other">%d file rimosso ai preferiti con successo</item>
+    </plurals>
+    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
+        <item quantity="one">Un file rimosso dalla disponibilità offline</item>
+        <item quantity="other">%d file rimossi dalla disponibilità offline</item>
     </plurals>
     <string name="fileListTitle">File</string>
     <string name="filePermissionTitle">Seleziona il diritto</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -379,17 +379,9 @@
         <item quantity="one">One file successfully added to favorites</item>
         <item quantity="other">%d files successfully added to favorites</item>
     </plurals>
-    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
-        <item quantity="one">One file successfully removed from favorites</item>
-        <item quantity="other">%d files successfully removed from favorites</item>
-    </plurals>
     <plurals name="fileListAddOfflineConfirmationSnackbar">
         <item quantity="one">One file available offline</item>
         <item quantity="other">%d files available offline</item>
-    </plurals>
-    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
-        <item quantity="one">One file removed from offline availability</item>
-        <item quantity="other">%d files removed from offline availability</item>
     </plurals>
     <plurals name="fileListColorFolderConfirmationSnackbar">
         <item quantity="one">One folder coloured successfully</item>
@@ -415,6 +407,14 @@
     <plurals name="fileListMultiSelectedTitle">
         <item quantity="one">%d selected</item>
         <item quantity="other">%d selected</item>
+    </plurals>
+    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
+        <item quantity="one">One file successfully removed from favorites</item>
+        <item quantity="other">%d files successfully removed from favorites</item>
+    </plurals>
+    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
+        <item quantity="one">One file removed from offline availability</item>
+        <item quantity="other">%d files removed from offline availability</item>
     </plurals>
     <string name="fileListTitle">Files</string>
     <string name="filePermissionTitle">Select the right</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -387,6 +387,10 @@
         <item quantity="one">One file available offline</item>
         <item quantity="other">%d files available offline</item>
     </plurals>
+    <plurals name="fileListRemoveOfflineConfirmationSnackbar">
+        <item quantity="one">One file removed from offline availability</item>
+        <item quantity="other">%d files removed from offline availability</item>
+    </plurals>
     <plurals name="fileListColorFolderConfirmationSnackbar">
         <item quantity="one">One folder coloured successfully</item>
         <item quantity="other">%d folders coloured successfully</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -375,9 +375,13 @@
     <string name="fileDetailsNoComments">No comments at this time</string>
     <string name="fileInfoInputDuplicateFile">Copy name</string>
     <string name="fileInfoLinkCopiedToClipboard">Link copied to the clipboard</string>
-    <plurals name="fileListAddFavorisConfirmationSnackbar">
+    <plurals name="fileListAddFavoritesConfirmationSnackbar">
         <item quantity="one">One file successfully added to favorites</item>
         <item quantity="other">%d files successfully added to favorites</item>
+    </plurals>
+    <plurals name="fileListRemoveFavoritesConfirmationSnackbar">
+        <item quantity="one">One file successfully removed from favorites</item>
+        <item quantity="other">%d files successfully removed from favorites</item>
     </plurals>
     <plurals name="fileListAddOfflineConfirmationSnackbar">
         <item quantity="one">One file available offline</item>


### PR DESCRIPTION
Fixed the behaviors of adding/removing files offline & favorite status in bulk.

Before: It was only possible to add the status, and not remove them.
Now: When only already added files are selected, change the button to its remove version and remove all the selection

Also disabled Multi-Selection after offline bulk action.