### PR TITLE
Adding logs to get more information in sync media folders

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
@@ -355,11 +355,7 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
             }
         }
 
-        try {
-            jobs.joinAll()
-        } catch (exception: Exception) {
-            Log.e("sisi", exception.message ?: "")
-        }
+        jobs.joinAll()
     }
 
     private fun CoroutineScope.getLocalLastMediasAsync(

--- a/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
@@ -410,14 +410,18 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
                     }
                 }
         }.onFailure { exception ->
-            // Catch Api>=29 for exception {Volume external_primary not found}, Adding logs to get more information
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && exception is IllegalArgumentException) {
-                Sentry.withScope { scope ->
-                    val volumeNames = MediaStore.getExternalVolumeNames(applicationContext).joinToString()
-                    scope.setExtra("uri", contentUri.toString())
-                    scope.setExtra("folder", mediaFolder.name)
-                    scope.setExtra("volume names", volumeNames)
-                }
+            syncMediaFolderFailure(exception, contentUri, mediaFolder)
+        }
+    }
+
+    private fun syncMediaFolderFailure(exception: Throwable, contentUri: Uri, mediaFolder: MediaFolder) {
+        // Catch Api>=29 for exception {Volume external_primary not found}, Adding logs to get more information
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && exception is IllegalArgumentException) {
+            Sentry.withScope { scope ->
+                val volumeNames = MediaStore.getExternalVolumeNames(applicationContext).joinToString()
+                scope.setExtra("uri", contentUri.toString())
+                scope.setExtra("folder", mediaFolder.name)
+                scope.setExtra("volume names", volumeNames)
             }
         }
     }


### PR DESCRIPTION
- Adding logs to get more information
- Ignore the errors encountered when synchronizing media folders

**Exception** [Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/3484/events/44a05d4a892a481aa716fe2119abf193/?project=3)
```
java.lang.IllegalArgumentException: Volume external_primary not found
    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:172)
    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:142)
    at android.content.ContentProviderProxy.query(ContentProviderNative.java:481)
    at android.content.ContentResolver.query(ContentResolver.java:1226)
    at android.content.ContentResolver.query(ContentResolver.java:1158)
    at android.content.ContentResolver.query(ContentResolver.java:1114)
    at com.infomaniak.drive.data.services.UploadWorker$getLocalLastMediasAsync$1.invokeSuspend(UploadWorker.kt:348)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>