### PR TITLE
Fix open with offline file

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/models/File.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/File.kt
@@ -21,7 +21,7 @@ import android.content.Context
 import android.net.Uri
 import android.os.Parcelable
 import android.webkit.MimeTypeMap
-import androidx.core.content.FileProvider
+import androidx.core.net.toUri
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.google.gson.annotations.SerializedName
@@ -438,7 +438,8 @@ open class File(
             val offlineFile = getOfflineFile(context, userDrive.userId)
 
             return cloudUri to if (isOffline && offlineFile != null) {
-                FileProvider.getUriForFile(context, context.getString(R.string.FILE_AUTHORITY), offlineFile)
+                // We use the uri with scheme file because some apps don't support modifications from a content uri
+                offlineFile.toUri()
             } else cloudUri
         }
 

--- a/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
@@ -242,11 +242,9 @@ object Utils {
         val (cloudUri, uri) = file.getCloudAndFileUris(this, userDrive)
         return Intent().apply {
             action = Intent.ACTION_VIEW
-            addFlags(
-                Intent.FLAG_GRANT_READ_URI_PERMISSION or
-                        Intent.FLAG_GRANT_WRITE_URI_PERMISSION or
-                        Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
-            )
+            flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION or
+                    Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
             setDataAndType(uri, contentResolver.getType(cloudUri))
         }
     }


### PR DESCRIPTION
**Description**
Some applications like office do not support editing from a content uri.

**Fix**
For an offline file we simply send the uri file instead of the uri content

Close https://github.com/Infomaniak/android-kDrive/issues/573

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>