### PR TITLE
limit upload process to available memory in the heap

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -226,7 +226,7 @@ class UploadTask(
 
         val availableHeapMemory = getAvailableHalfHeapMemory()
         if (chunkSize >= availableHeapMemory) {
-            chunkSize = (availableHeapMemory / limitParallelRequest).toInt()
+            chunkSize = ceil(availableHeapMemory.toDouble() / limitParallelRequest).toInt()
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -211,7 +211,7 @@ class UploadTask(
         }
 
         val availableHeapMemory = getAvailableHalfHeapMemory()
-        if (chunkSize > availableHeapMemory) {
+        if (chunkSize >= availableHeapMemory) {
             chunkSize = (availableHeapMemory / limitParallelRequest).toInt()
         }
     }
@@ -323,7 +323,7 @@ class UploadTask(
     }
 
     private fun checkLimitParallelRequest() = getAvailableHalfHeapMemory().let { availableHalfMemory ->
-        if (chunkSize * limitParallelRequest >= availableHalfMemory * 2) {
+        if (chunkSize * limitParallelRequest >= availableHalfMemory) {
             limitParallelRequest = (availableHalfMemory / chunkSize).toInt()
         }
     }


### PR DESCRIPTION
To improve the upload service and reduce the risk of `OutOfMemoryError`, we limit the upload to use only half of the available memory in the heap. 

Signed-off-by: Abdourahamane BOINAIDI <abdourahamane.boinaidi@infomaniak.com>