### PR TITLE
Change downloading strategy of RecentChanges Fragment

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/menu/RecentChangesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/RecentChangesFragment.kt
@@ -37,7 +37,9 @@ class RecentChangesFragment : FileSubTypeListFragment() {
         downloadFiles = DownloadFiles()
         setNoFilesLayout = SetNoFilesLayout()
         folderId = Utils.OTHER_ROOT_ID
-        setupFileAdapter()
+
+        super.onViewCreated(view, savedInstanceState)
+
         fileRecyclerView.apply {
             setPagination({
                 if (!fileAdapter.isComplete && !isDownloadingChanges) {
@@ -46,9 +48,6 @@ class RecentChangesFragment : FileSubTypeListFragment() {
                 }
             })
         }
-        downloadFiles(false, false)
-
-        super.onViewCreated(view, savedInstanceState)
 
         sortButton.isGone = true
         collapsingToolbarLayout.title = getString(R.string.lastEditsTitle)

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/RecentChangesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/RecentChangesViewModel.kt
@@ -50,11 +50,11 @@ class RecentChangesViewModel : ViewModel() {
                     )
                 )
             } else {
-                val isFirstPage = currentPage == 1
                 val apiResponse = ApiRepository.getLastModifiedFiles(driveId, currentPage)
                 when {
                     apiResponse.isSuccess() -> apiResponse.data?.let { data ->
                         val isComplete = data.size < PER_PAGE
+                        val isFirstPage = currentPage == 1
                         emit(FileListFragment.FolderFilesResult(files = data, isComplete = isComplete, page = currentPage))
                         FileController.storeRecentChanges(data, isFirstPage)
                     }


### PR DESCRIPTION
change the downloading strategy of RecentChangesFragment from recursive call to progressive call on scroll
closes #553 