### PR TITLE
Fixed missing month label in gallery on rare occasions

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/menu/PicturesAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/PicturesAdapter.kt
@@ -180,6 +180,7 @@ class PicturesAdapter(
     fun clearPictures() {
         itemList.clear()
         pictureList.clear()
+        lastSectionTitle = ""
         notifyDataSetChanged()
     }
 


### PR DESCRIPTION
When manually refreshing images the variable that records the last month label was not reset. This had for an issue to not recreate the very first month label if all loaded images in memory were from the same first month.