### PR TITLE
Enable landscape mode in onboarding on big enough screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -122,7 +122,6 @@
 
         <activity
             android:name=".ui.login.LoginActivity"
-            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.Login"
             tools:ignore="LockedOrientationActivity" />
 

--- a/app/src/main/java/com/infomaniak/drive/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/login/LoginActivity.kt
@@ -17,6 +17,7 @@
  */
 package com.infomaniak.drive.ui.login
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
@@ -80,8 +81,7 @@ class LoginActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        lockScreenForTablets()
-
+        lockLandscapeForSmallScreens()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
 
@@ -120,7 +120,8 @@ class LoginActivity : AppCompatActivity() {
         }
     }
 
-    private fun lockScreenForTablets() {
+    @SuppressLint("SourceLockedOrientationActivity")
+    private fun lockLandscapeForSmallScreens() {
         val displayMetrics = resources.displayMetrics
         val screenHeightInches = (displayMetrics.heightPixels / displayMetrics.ydpi)
         val screenWidthInches = (displayMetrics.widthPixels / displayMetrics.xdpi)
@@ -128,7 +129,7 @@ class LoginActivity : AppCompatActivity() {
         val aspectRatio = resources.configuration.screenLayout and Configuration.SCREENLAYOUT_LONG_MASK
         val isLongScreen = aspectRatio != Configuration.SCREENLAYOUT_LONG_NO
 
-        val isScreenTooSmall = isLongScreen && min(screenHeightInches, screenWidthInches) < FOUR_INCHES
+        val isScreenTooSmall = isLongScreen && min(screenHeightInches, screenWidthInches) < MIN_HEIGHT_FOR_LANDSCAPE
 
         if (isScreenTooSmall) requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
     }
@@ -187,7 +188,7 @@ class LoginActivity : AppCompatActivity() {
     }
 
     companion object {
-        const val FOUR_INCHES = 4
+        const val MIN_HEIGHT_FOR_LANDSCAPE = 4
 
         suspend fun authenticateUser(context: Context, apiToken: ApiToken): Any {
 

--- a/app/src/main/java/com/infomaniak/drive/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/login/LoginActivity.kt
@@ -19,6 +19,8 @@ package com.infomaniak.drive.ui.login
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ActivityInfo
+import android.content.res.Configuration
 import android.os.Bundle
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.annotation.StringRes
@@ -54,6 +56,7 @@ import kotlinx.android.synthetic.main.activity_login.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.math.min
 
 class LoginActivity : AppCompatActivity() {
 
@@ -79,6 +82,8 @@ class LoginActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
+
+        lockScreenForTablets()
 
         infomaniakLogin = InfomaniakLogin(context = this, appUID = BuildConfig.APPLICATION_ID, clientID = BuildConfig.CLIENT_ID)
 
@@ -113,6 +118,19 @@ class LoginActivity : AppCompatActivity() {
             trackAccountEvent("openCreationWebview")
             openUrl(ApiRoutes.orderDrive())
         }
+    }
+
+    private fun lockScreenForTablets() {
+        val displayMetrics = resources.displayMetrics
+        val screenHeightInches = (displayMetrics.heightPixels / displayMetrics.ydpi)
+        val screenWidthInches = (displayMetrics.widthPixels / displayMetrics.xdpi)
+
+        val aspectRatio = resources.configuration.screenLayout and Configuration.SCREENLAYOUT_LONG_MASK
+        val isLongScreen = aspectRatio != Configuration.SCREENLAYOUT_LONG_NO
+
+        val isScreenTooSmall = isLongScreen && min(screenHeightInches, screenWidthInches) < TEN_CENTIMETERS
+
+        if (isScreenTooSmall) requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
     }
 
     private fun authenticateUser(authCode: String) {
@@ -169,6 +187,8 @@ class LoginActivity : AppCompatActivity() {
     }
 
     companion object {
+        const val TEN_CENTIMETERS = 3.93701 // in 'inches' unit
+
         suspend fun authenticateUser(context: Context, apiToken: ApiToken): Any {
 
             AccountUtils.getUserById(apiToken.userId)?.let {

--- a/app/src/main/java/com/infomaniak/drive/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/login/LoginActivity.kt
@@ -80,10 +80,10 @@ class LoginActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        lockScreenForTablets()
+
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_login)
-
-        lockScreenForTablets()
 
         infomaniakLogin = InfomaniakLogin(context = this, appUID = BuildConfig.APPLICATION_ID, clientID = BuildConfig.CLIENT_ID)
 
@@ -128,7 +128,7 @@ class LoginActivity : AppCompatActivity() {
         val aspectRatio = resources.configuration.screenLayout and Configuration.SCREENLAYOUT_LONG_MASK
         val isLongScreen = aspectRatio != Configuration.SCREENLAYOUT_LONG_NO
 
-        val isScreenTooSmall = isLongScreen && min(screenHeightInches, screenWidthInches) < TEN_CENTIMETERS
+        val isScreenTooSmall = isLongScreen && min(screenHeightInches, screenWidthInches) < FOUR_INCHES
 
         if (isScreenTooSmall) requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
     }
@@ -187,7 +187,7 @@ class LoginActivity : AppCompatActivity() {
     }
 
     companion object {
-        const val TEN_CENTIMETERS = 3.93701 // in 'inches' unit
+        const val FOUR_INCHES = 4
 
         suspend fun authenticateUser(context: Context, apiToken: ApiToken): Any {
 

--- a/app/src/main/java/com/infomaniak/drive/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/login/LoginActivity.kt
@@ -122,9 +122,7 @@ class LoginActivity : AppCompatActivity() {
 
     @SuppressLint("SourceLockedOrientationActivity")
     private fun lockLandscapeForSmallScreens() {
-        val displayMetrics = resources.displayMetrics
-        val screenHeightInches = (displayMetrics.heightPixels / displayMetrics.ydpi)
-        val screenWidthInches = (displayMetrics.widthPixels / displayMetrics.xdpi)
+        val (screenHeightInches, screenWidthInches) = with(resources.displayMetrics) { (heightPixels / ydpi) to (widthPixels / xdpi) }
 
         val aspectRatio = resources.configuration.screenLayout and Configuration.SCREENLAYOUT_LONG_MASK
         val isLongScreen = aspectRatio != Configuration.SCREENLAYOUT_LONG_NO


### PR DESCRIPTION
Closes #555 

Only prevents landscape mode if the screen aspect ratio is very long and that the real physical size of the screen is smaller than 10 centimeters.