### PR TITLE
Fixed multi select wrong number of selected items bug

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
@@ -284,7 +284,7 @@ open class FileAdapter(
 
             setupFileChecked(file)
             setupMenuButton(file)
-            setupCardClicksListeners(file)
+            setupCardClicksListeners(file, position)
         }
     }
 
@@ -297,7 +297,7 @@ open class FileAdapter(
 
     private fun MaterialCardView.displayFileChecked(file: File, isGrid: Boolean) = with(multiSelectManager) {
         fileChecked.apply {
-            isChecked = if (isSelectAllOn) !exceptedItemsIds.contains(file.id) else isSelectedFile(file)
+            isChecked = isSelectedFile(file)
             isVisible = true
         }
         filePreview.isVisible = isGrid
@@ -324,11 +324,12 @@ open class FileAdapter(
         }
     }
 
-    private fun MaterialCardView.setupCardClicksListeners(file: File) = with(multiSelectManager) {
+    private fun MaterialCardView.setupCardClicksListeners(file: File, position: Int) = with(multiSelectManager) {
 
         fun MaterialCheckBox.selectFile() {
-            isChecked = !isChecked
-            onFileSelected(file, isChecked)
+            onFileSelected(file, !isSelectedFile(file))
+            isChecked = isSelectedFile(file)
+            notifyItemChanged(position)
         }
 
         setOnClickListener {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
@@ -27,7 +27,6 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.card.MaterialCardView
-import com.google.android.material.checkbox.MaterialCheckBox
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.AppSettings
 import com.infomaniak.drive.data.models.File
@@ -242,16 +241,17 @@ open class FileAdapter(
         }
     }
 
-    override fun onBindViewHolder(holder: FileViewHolder, position: Int, payloads: List<Any>) {
+    override fun onBindViewHolder(holder: FileViewHolder, position: Int, payloads: List<Any>) = with(holder.itemView) {
         if (payloads.firstOrNull() is Int && getItemViewType(position) != VIEW_TYPE_LOADING) {
             val progress = payloads.first() as Int
             val file = getFile(position).apply { currentProgress = progress }
             if (progress != Utils.INDETERMINATE_PROGRESS || !file.isPendingOffline(holder.itemView.context)) {
-                holder.itemView.apply {
-                    setupFileProgress(file, true)
-                    checkIfEnableFile(file)
-                }
+                setupFileProgress(file, true)
+                checkIfEnableFile(file)
             }
+        } else if (payloads.firstOrNull() is Boolean) {
+            val isChecked = payloads.first() as Boolean
+            fileChecked.isChecked = isChecked
         } else {
             super.onBindViewHolder(holder, position, payloads)
         }
@@ -326,15 +326,14 @@ open class FileAdapter(
 
     private fun MaterialCardView.setupCardClicksListeners(file: File, position: Int) = with(multiSelectManager) {
 
-        fun MaterialCheckBox.selectFile() {
+        fun selectFile() {
             onFileSelected(file, !isSelectedFile(file))
-            isChecked = isSelectedFile(file)
-            notifyItemChanged(position)
+            notifyItemChanged(position, isSelectedFile(file))
         }
 
         setOnClickListener {
             if (isMultiSelectOn) {
-                fileChecked.selectFile()
+                selectFile()
             } else {
                 onFileClicked?.invoke(file)
             }
@@ -346,7 +345,7 @@ open class FileAdapter(
                     fileChecked.isChecked = false
                     openMultiSelect?.invoke()
                 }
-                fileChecked.selectFile()
+                selectFile()
                 true
             } else {
                 false

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/MultiSelectManager.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/MultiSelectManager.kt
@@ -57,7 +57,8 @@ class MultiSelectManager {
         }
     }
 
-    fun isSelectedFile(file: File): Boolean = file.isUsable() && selectedItemsIds.contains(file.id)
+    fun isSelectedFile(file: File): Boolean =
+        file.isUsable() && ((selectedItemsIds.contains(file.id) && !isSelectAllOn) || (!exceptedItemsIds.contains(file.id) && isSelectAllOn))
 
     fun performCancellableBulkOperation(bulkOperation: BulkOperation): LiveData<ApiResponse<CancellableAction>> {
         return liveData(Dispatchers.IO) { emit(ApiRepository.performCancellableBulkOperation(bulkOperation)) }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/MultiSelectManager.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/MultiSelectManager.kt
@@ -57,8 +57,11 @@ class MultiSelectManager {
         }
     }
 
-    fun isSelectedFile(file: File): Boolean =
-        file.isUsable() && ((selectedItemsIds.contains(file.id) && !isSelectAllOn) || (!exceptedItemsIds.contains(file.id) && isSelectAllOn))
+    fun isSelectedFile(file: File): Boolean {
+        return if (file.isUsable()) {
+            if (isSelectAllOn) !exceptedItemsIds.contains(file.id) else selectedItemsIds.contains(file.id)
+        } else false
+    }
 
     fun performCancellableBulkOperation(bulkOperation: BulkOperation): LiveData<ApiResponse<CancellableAction>> {
         return liveData(Dispatchers.IO) { emit(ApiRepository.performCancellableBulkOperation(bulkOperation)) }


### PR DESCRIPTION
When clicking very quickly on a checkmark you could bug the multiselection. The displayed checkmark wasn't always reflecting the state of the selected items.

<img width="526" alt="image" src="https://user-images.githubusercontent.com/32095402/171123468-14333a1c-551d-4916-8a8b-61b956592fb2.png">
