### PR TITLE
Fix refresh activities after an upload

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -187,6 +187,9 @@ class UploadTask(
     }
 
     private suspend fun onFinish(uri: Uri, okHttpClient: OkHttpClient) {
+        with(ApiRepository.finishSession(uploadFile.driveId, uploadFile.uploadToken!!, okHttpClient)) {
+            if (!isSuccess()) manageUploadErrors(okHttpClient)
+        }
         uploadNotification.apply {
             setOngoing(false)
             setContentText("100%")
@@ -195,9 +198,6 @@ class UploadTask(
             notificationManagerCompat.notify(CURRENT_UPLOAD_ID, build())
         }
         shareProgress(100, true)
-        with(ApiRepository.finishSession(uploadFile.driveId, uploadFile.uploadToken!!, okHttpClient)) {
-            if (!isSuccess()) manageUploadErrors(okHttpClient)
-        }
         UploadFile.uploadFinished(uri)
         notificationManagerCompat.cancel(CURRENT_UPLOAD_ID)
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -234,10 +234,8 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
         }
 
         requireContext().trackUploadWorkerSucceeded().observe(viewLifecycleOwner) {
-            if (!isDownloading || isUploading) {
-                if (isUploading) retryLoadingActivities = true
-                activitiesRefreshTimer.start()
-            }
+            if (isUploading) retryLoadingActivities = true
+            if (!isDownloading || isUploading) activitiesRefreshTimer.start()
         }
 
         mainViewModel.refreshActivities.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -234,7 +234,10 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
         }
 
         requireContext().trackUploadWorkerSucceeded().observe(viewLifecycleOwner) {
-            if (!isDownloading || isUploading) activitiesRefreshTimer.start()
+            if (!isDownloading || isUploading) {
+                if (isUploading) retryLoadingActivities = true
+                activitiesRefreshTimer.start()
+            }
         }
 
         mainViewModel.refreshActivities.observe(viewLifecycleOwner) {


### PR DESCRIPTION
**Fix**
- Sometimes when uploading files, the `FileList` was not updated.
> now, the `FileList` is well updated with respect to the upload