### PR TITLE
Open a remote folder that does not exist in realm

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -686,11 +686,11 @@ object FileController {
         localFolderProxy: File?,
         remoteFolder: File?,
         apiResponse: ApiResponse<List<File>>,
-        page: Int
+        page: Int,
     ) {
         val remoteFiles = apiResponse.data!!
 
-        // Save remote folder if doesn't exists locally
+        // Save remote folder if it doesn't exist locally
         var newLocalFolderProxy: File? = null
         if (localFolderProxy == null && remoteFolder != null) {
             executeTransaction { newLocalFolderProxy = copyToRealm(remoteFolder) }


### PR DESCRIPTION
Fix [Sentry - Null exception when open a remote file that  doesn't exists in realm](https://sentry.infomaniak.com/organizations/infomaniak/issues/25780/?project=3&query=is%3Aunresolved+release%3Acom.infomaniak.drive%404.2.0%2B40200004&statsPeriod=30d)
```
java.lang.NullPointerException: null
    at com.infomaniak.drive.data.cache.FileController.downloadAndSaveFiles(FileController.kt:674)
    at com.infomaniak.drive.data.cache.FileController.access$downloadAndSaveFiles(FileController.kt:44)
    at com.infomaniak.drive.data.cache.FileController$getFilesFromCacheOrDownload$operation$1.invoke(FileController.kt:628)
    at com.infomaniak.drive.data.cache.FileController$getFilesFromCacheOrDownload$operation$1.invoke(FileController.kt:611)
    at com.infomaniak.drive.data.cache.FileController.getFilesFromCacheOrDownload(FileController.kt:642)
    at com.infomaniak.drive.data.cache.FileController.getFilesFromCacheOrDownload$default(FileController.kt:596)
    at com.infomaniak.drive.ui.fileList.FileListViewModel$getFiles$1.invokeSuspend$recursiveDownload(FileListViewModel.kt:67)
    at com.infomaniak.drive.ui.fileList.FileListViewModel$getFiles$1.invokeSuspend(FileListViewModel.kt:90)
    at com.infomaniak.drive.ui.fileList.FileListViewModel$getFiles$1.invoke
    at com.infomaniak.drive.ui.fileList.FileListViewModel$getFiles$1.invoke
    at androidx.lifecycle.BlockRunner$maybeRun$1.invokeSuspend(CoroutineLiveData.kt:176)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:749)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
```