### PR TITLE
Add Camera permission

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/addFiles/AddFileBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/addFiles/AddFileBottomSheetDialog.kt
@@ -58,7 +58,8 @@ class AddFileBottomSheetDialog : BottomSheetDialogFragment() {
     private lateinit var currentFolderFile: File
     private val mainViewModel: MainViewModel by activityViewModels()
 
-    private lateinit var openCameraPermissions: DrivePermissions
+    private lateinit var openCameraWritePermissions: DrivePermissions
+    private lateinit var openCameraPermissions: CameraPermissions
     private lateinit var uploadFilesPermissions: DrivePermissions
 
     private var mediaPhotoPath = ""
@@ -88,7 +89,10 @@ class AddFileBottomSheetDialog : BottomSheetDialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         currentFolder.setFileItem(currentFolderFile)
 
-        openCameraPermissions = DrivePermissions().apply {
+        openCameraWritePermissions = DrivePermissions().apply {
+            registerPermissions(this@AddFileBottomSheetDialog) { authorized -> if (authorized) openCamera() }
+        }
+        openCameraPermissions = CameraPermissions().apply {
             registerPermissions(this@AddFileBottomSheetDialog) { authorized -> if (authorized) openCamera() }
         }
         uploadFilesPermissions = DrivePermissions().apply {
@@ -114,7 +118,7 @@ class AddFileBottomSheetDialog : BottomSheetDialogFragment() {
     }
 
     private fun openCamera() {
-        if (openCameraPermissions.checkSyncPermissions()) {
+        if (openCameraWritePermissions.checkSyncPermissions() && openCameraPermissions.checkCameraPermission()) {
             trackNewElement("takePhotoOrVideo")
             openCamera.isEnabled = false
             try {

--- a/app/src/main/java/com/infomaniak/drive/utils/CameraPermissions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/CameraPermissions.kt
@@ -1,0 +1,59 @@
+/*
+ * Infomaniak kDrive - Android
+ * Copyright (C) 2022 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.drive.utils
+
+import android.Manifest
+import android.os.Build
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts.RequestMultiplePermissions
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import com.infomaniak.drive.R
+import com.infomaniak.drive.utils.DrivePermissions.Companion.resultPermissions
+import com.infomaniak.lib.core.utils.hasPermissions
+
+class CameraPermissions {
+
+    companion object {
+        val cameraPermission = arrayOf(Manifest.permission.CAMERA)
+    }
+
+    private lateinit var registerForActivityResult: ActivityResultLauncher<Array<String>>
+    private lateinit var activity: FragmentActivity
+
+    fun registerPermissions(fragment: Fragment, onPermissionResult: ((authorized: Boolean) -> Unit)? = null) {
+        activity = fragment.requireActivity()
+        registerForActivityResult =
+            fragment.registerForActivityResult(RequestMultiplePermissions()) { authorizedPermissions ->
+                val authorized = authorizedPermissions.values.all { it }
+                onPermissionResult?.invoke(authorized)
+                activity.resultPermissions(authorized, cameraPermission, R.string.allPermissionNeeded)
+            }
+    }
+
+    fun checkCameraPermission(requestPermission: Boolean = true): Boolean {
+        return when {
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.M -> true
+            activity.hasPermissions(cameraPermission) -> true
+            else -> {
+                if (requestPermission) registerForActivityResult.launch(cameraPermission)
+                false
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -168,6 +168,7 @@
     <string name="buttonUpgradeOffer">Mein Angebot erweitern</string>
     <string name="buttonUpload">Vom Telefon importieren</string>
     <string name="buttonValid">Validieren</string>
+    <string name="cameraAccessDeniedDescription">Der Zugang zu Ihrer Kamera ist deaktiviert, Sie können diesen Parameter unter Einstellungen ändern.</string>
     <string name="categoriesFilterTitle">Kategorien</string>
     <string name="categoryBanking">Bank</string>
     <string name="categoryBill">Rechnung</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -168,6 +168,7 @@
     <string name="buttonUpgradeOffer">Mejorar mi oferta</string>
     <string name="buttonUpload">Importar desde el teléfono</string>
     <string name="buttonValid">Validar</string>
+    <string name="cameraAccessDeniedDescription">El acceso a tu cámara está desactivado. Puedes cambiar este parámetro en los ajustes.</string>
     <string name="categoriesFilterTitle">Categorías</string>
     <string name="categoryBanking">Banco</string>
     <string name="categoryBill">Factura</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -168,6 +168,7 @@
     <string name="buttonUpgradeOffer">Mettre à niveau mon offre</string>
     <string name="buttonUpload">Importer depuis le téléphone</string>
     <string name="buttonValid">Valider</string>
+    <string name="cameraAccessDeniedDescription">L’accès à votre caméra est désactivé, vous pouvez changer ce paramètre dans les réglages.</string>
     <string name="categoriesFilterTitle">Catégories</string>
     <string name="categoryBanking">Banque</string>
     <string name="categoryBill">Facture</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -168,6 +168,7 @@
     <string name="buttonUpgradeOffer">Fai evolvere la tua offerta</string>
     <string name="buttonUpload">Importa dal telefono</string>
     <string name="buttonValid">Convalida</string>
+    <string name="cameraAccessDeniedDescription">L’accesso alla tua fotocamera è disattivato. Puoi modificare questo parametro dalle impostazioni.</string>
     <string name="categoriesFilterTitle">Categorie</string>
     <string name="categoryBanking">Banca</string>
     <string name="categoryBill">Fattura</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,6 +179,7 @@
     <string name="buttonUpgradeOffer">Upgrade my plan</string>
     <string name="buttonUpload">Upload from phone</string>
     <string name="buttonValid">Validate</string>
+    <string name="cameraAccessDeniedDescription">Access to your camera is disabled: you can change this in the Settings.</string>
     <string name="categoriesFilterTitle">Categories</string>
     <string name="categoryBanking">Banking</string>
     <string name="categoryBill">Bill</string>


### PR DESCRIPTION
This lib `gssdk-scanflow` add `<uses-permission android:name="android.permission.CAMERA" />` in the manifest.

The `MediaStore.ACTION_IMAGE_CAPTURE` Intent does not require an authorization request, unless it is in the manifest 🤷‍♀️
See: https://stackoverflow.com/a/59187440/2389197