### PR TITLE
Fix share files success and failed in UploadWorker

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/sync/UploadNotifications.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/sync/UploadNotifications.kt
@@ -37,7 +37,7 @@ import io.sentry.Sentry
 
 object UploadNotifications {
 
-    private const val FAILED_FILES_LIMIT = 5
+    const val NOTIFICATION_FILES_LIMIT = 5
 
     const val INTENT_DESTINATION_USER_ID = "intent_destination_user_id"
     const val INTENT_DESTINATION_DRIVE_ID = "intent_destination_drive_id"
@@ -134,11 +134,11 @@ object UploadNotifications {
 
     fun UploadFile.showUploadedFilesNotification(
         context: Context,
+        successCount: Int,
         successNames: MutableList<String>,
+        failedCount: Int,
         failedNames: MutableList<String>
     ) {
-        val failedCount = failedNames.count()
-        val successCount = successNames.count()
         val total = successCount + failedCount
         val description = when {
             failedCount > 0 -> {
@@ -154,8 +154,8 @@ object UploadNotifications {
                 val desc = context.resources.getQuantityString(R.plurals.allUploadFinishedDescription, successCount, successCount)
                 StringBuilder().apply {
                     appendLine(desc)
-                    for (file in successNames.take(FAILED_FILES_LIMIT)) appendLine(file)
-                    val otherCount = successCount - FAILED_FILES_LIMIT
+                    for (file in successNames.take(NOTIFICATION_FILES_LIMIT)) appendLine(file)
+                    val otherCount = successCount - NOTIFICATION_FILES_LIMIT
                     if (otherCount > 0) {
                         appendLine(
                             context.resources.getQuantityString(


### PR DESCRIPTION
Fix [Sentry](https://sentry.infomaniak.com/organizations/infomaniak/issues/27041/?project=3&query=is%3Aunresolved+dist%3A40200011&statsPeriod=14d)
```
java.lang.IllegalStateException: Data cannot occupy more than 10240 bytes when serialized
    at androidx.work.Data.toByteArrayInternal(Data.java:407)
    at androidx.work.Data$Builder.build(Data.java:957)
    at com.infomaniak.drive.data.services.UploadWorker.checkIfNeedReSync(UploadWorker.kt:163)
    at com.infomaniak.drive.data.services.UploadWorker.access$checkIfNeedReSync(UploadWorker.kt:58)
    at com.infomaniak.drive.data.services.UploadWorker$checkIfNeedReSync$1.invokeSuspend
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
```