### PR TITLE
fix mediastore file size in SaveExternalFilesActivity

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -416,7 +416,6 @@ class SaveExternalFilesActivity : BaseActivity() {
         contentResolver.query(uri, null, null, null, null)?.use { cursor ->
             if (cursor.moveToFirst()) {
                 val (fileCreatedAt, fileModifiedAt) = SyncUtils.getFileDates(cursor)
-                val fileSize = SyncUtils.getFileSize(cursor)
 
                 try {
                     if (fileName == null) return false
@@ -437,7 +436,7 @@ class SaveExternalFilesActivity : BaseActivity() {
                             driveId = driveId,
                             remoteFolder = folderId,
                             type = UploadFile.Type.SHARED_FILE.name,
-                            fileSize = fileSize,
+                            fileSize = outputFile.length(),
                             fileName = fileName,
                             fileCreatedAt = fileCreatedAt,
                             fileModifiedAt = fileModifiedAt


### PR DESCRIPTION
[Sentry link](https://sentry.infomaniak.com/organizations/infomaniak/issues/12399/?project=3&referrer=regression_activity-email)
```
java.lang.IllegalArgumentException: column '_size' does not exist. Available columns: [_id, _data]
    at android.database.AbstractCursor.getColumnIndexOrThrow(AbstractCursor.java:351)
    at android.database.CursorWrapper.getColumnIndexOrThrow(CursorWrapper.java:91)
    at com.infomaniak.drive.utils.SyncUtils.getFileSize(SyncUtils.kt:55)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity.store(SaveExternalFilesActivity.kt:407)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity.storeFiles(SaveExternalFilesActivity.kt:352)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity.access$storeFiles(SaveExternalFilesActivity.kt:63)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity$setupSaveButton$1$1$1$1.invokeSuspend(SaveExternalFilesActivity.kt:247)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
```