### PR TITLE
Fix lifecycle save external orientation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -95,6 +95,7 @@
 
         <activity
             android:name=".ui.SaveExternalFilesActivity"
+            android:configChanges="orientation|screenSize|layoutDirection"
             android:excludeFromRecents="true"
             android:exported="true"
             android:label="@string/saveExternalFileTitle">

--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -35,6 +35,7 @@ import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.observe
 import androidx.navigation.navArgs
 import com.google.android.material.textfield.TextInputEditText
 import com.infomaniak.drive.R
@@ -380,6 +381,7 @@ class SaveExternalFilesActivity : BaseActivity() {
                 val fileName = fileNameEdit.text.toString()
                 val outputFile = getOutputFile(fileName)
                 scope.setExtra("fileName", fileName)
+                scope.setExtra("lifecycleState", lifecycle.currentState.name)
                 scope.setExtra("sharedFolderExists", sharedFolder.exists().toString())
                 scope.setExtra("outputFile", outputFile.toString())
                 scope.level = SentryLevel.WARNING


### PR DESCRIPTION
[Fix Sentry](https://sentry.infomaniak.com/share/issue/2fa7a662694d4638a5c5c53030b5acba/)
```
java.lang.SecurityException: Permission Denial: reading com.google.android.apps.photos.contentprovider.impl.MediaContentProvider uri content://com.google.android.apps.photos.contentprovider/0/1/content%3A%2F%2Fmedia%2Fexternal%2Fimages%2Fmedia%2F63616/ORIGINAL/NONE/image%2Fjpeg/1616920424 from pid=32565, uid=10499 requires the provider be exported, or grantUriPermission()
    at android.os.Parcel.createException(Parcel.java:2074)
    at android.os.Parcel.readException(Parcel.java:2042)
    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:188)
    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:140)
    at android.content.ContentProviderProxy.query(ContentProviderNative.java:423)
    at android.content.ContentResolver.query(ContentResolver.java:944)
    at android.content.ContentResolver.query(ContentResolver.java:880)
    at android.content.ContentResolver.query(ContentResolver.java:836)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity.store(SaveExternalFilesActivity.kt:416)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity.storeFiles(SaveExternalFilesActivity.kt:352)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity.access$storeFiles(SaveExternalFilesActivity.kt:64)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity$setupSaveButton$1$1$1$1.invokeSuspend(SaveExternalFilesActivity.kt:252)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
```