### PR TITLE
Handle null extras in SaveExternalFilesActivity and share sentry logs

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -35,7 +35,6 @@ import androidx.core.widget.addTextChangedListener
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.observe
 import androidx.navigation.navArgs
 import com.google.android.material.textfield.TextInputEditText
 import com.infomaniak.drive.R

--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -92,7 +92,10 @@ class SaveExternalFilesActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_save_external_file)
 
-        if (!isAuth()) return
+        if (!isAuth() || isExtrasNull()) {
+            finish()
+            return
+        }
 
         setupDrivePermissions()
         activeDefaultUser()
@@ -118,10 +121,20 @@ class SaveExternalFilesActivity : BaseActivity() {
     private fun isAuth(): Boolean {
         if (AccountUtils.currentUserId == -1) {
             startActivity(Intent(this, LaunchActivity::class.java))
-            finish()
             return false
         }
         return true
+    }
+
+    private fun isExtrasNull(): Boolean {
+        if (intent?.extras == null) {
+            Sentry.withScope { scope ->
+                scope.level = SentryLevel.WARNING
+                Sentry.captureException(IllegalStateException("Activity $this has null extras in $intent"))
+            }
+            return true
+        }
+        return false
     }
 
     private fun setupDrivePermissions() {


### PR DESCRIPTION
**Fix [Sentry link](https://sentry.infomaniak.com/share/issue/d1d37501d6b94147ad8bb1e74b37f5b8/)**
```
java.lang.IllegalStateException: Activity com.infomaniak.drive.ui.SaveExternalFilesActivity@db63e92 has null extras in Intent { act=android.intent.action.SEND dat=content://downloads/all_downloads/159 typ=application/xml flg=0x13c00001 cmp=com.infomaniak.drive/.ui.SaveExternalFilesActivity mCallingUid=1000 }
    at com.infomaniak.drive.ui.SaveExternalFilesActivity$special$$inlined$navArgs$1.invoke(ActivityNavArgsLazy.kt:44)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity$special$$inlined$navArgs$1.invoke(ActivityNavArgsLazy.kt:41)
    at androidx.navigation.NavArgsLazy.getValue(NavArgsLazy.kt:45)
    at androidx.navigation.NavArgsLazy.getValue(NavArgsLazy.kt:35)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity.getNavigationArgs(SaveExternalFilesActivity.kt:68)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity.canSaveExternalFilesPref(SaveExternalFilesActivity.kt:182)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity.getSelectedFolder(SaveExternalFilesActivity.kt:174)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity.activeDefaultUser(SaveExternalFilesActivity.kt:140)
    at com.infomaniak.drive.ui.SaveExternalFilesActivity.onCreate(SaveExternalFilesActivity.kt:95)
    at android.app.Activity.performCreate(Activity.java:8183)
    at android.app.Activity.performCreate(Activity.java:8167)
    at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1316)
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3751)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3950)
    at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
    at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2377)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:262)
    at android.app.ActivityThread.main(ActivityThread.java:8304)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:632)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1049)

java.lang.RuntimeException: Unable to start activity ComponentInfo{com.infomaniak.drive/com.infomaniak.drive.ui.SaveExternalFilesActivity}: java.lang.IllegalStateException: Activity com.infomaniak.drive.ui.SaveExternalFilesActivity@db63e92 has null extras in Intent { act=android.intent.action.SEND dat=content://downloads/all_downloads/159 typ=application/xml flg=0x13c00001 cmp=com.infomaniak.drive/.ui.SaveExternalFilesActivity mCallingUid=1000 }
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3782)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3950)
    at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
    at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2377)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:262)
    at android.app.ActivityThread.main(ActivityThread.java:8304)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:632)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1049)
```
