### PR TITLE
Change actions visibility to be iso with iOS and webApp

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
+++ b/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
@@ -132,7 +132,7 @@ class FileInfoActionsView @JvmOverloads constructor(
                     disabledSendCopy.isGone = sendCopyEnabled
                 }
 
-                addFavorites.isVisible = rights?.canUseFavorite == true
+                addFavorites.isVisible = rights?.canUseFavorite == true && !isSharedWithMe
                 availableOffline.isGone = isSharedWithMe || currentFile.getOfflineFile(context) == null
                 deleteFile.isVisible = rights?.canDelete == true
                 downloadFile.isVisible = rights?.canRead == true
@@ -163,7 +163,7 @@ class FileInfoActionsView @JvmOverloads constructor(
                 sendCopyText.setText(R.string.buttonAdd)
                 availableOffline.isGone = true
                 openWith.isGone = true
-                coloredFolder.isVisible = currentFile.isAllowedToBeColored()
+                coloredFolder.isVisible = currentFile.isAllowedToBeColored() && !isSharedWithMe
             }
         }
     }


### PR DESCRIPTION
Hide color Folder and add Favorite in the FileInfoActionsBottomsheet for external files as it is already done in iOS and web, because coloring an external folder is not possible and favorite external file are not retrieved in FavoritesFragment
