### PR TITLE
Switch duplicate and move to item in multiselect

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/MultiSelectActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/MultiSelectActionsBottomSheetDialog.kt
@@ -60,15 +60,31 @@ abstract class MultiSelectActionsBottomSheetDialog(private val matomoCategory: S
             fileIds.size in 1..BulkOperationsUtils.MIN_SELECTED && !isAllSelected
         }
 
-        configureColoredFolder(areIndividualActionsVisible)
         configureAddFavorites(areIndividualActionsVisible)
+        configureColoredFolder(areIndividualActionsVisible)
         configureAvailableOffline()
         configureDownload()
-        configureDuplicateFile()
         configureMoveFile()
+        configureDuplicateFile()
         configureRestoreFileIn()
         configureRestoreFileToOriginalPlace()
         configureDeletePermanently()
+    }
+
+    protected open fun configureAddFavorites(areIndividualActionsVisible: Boolean) {
+        val (text, action) = with(navigationArgs) {
+            addFavoritesIcon.isEnabled = onlyFavorite
+            if (onlyFavorite) {
+                R.string.buttonRemoveFavorites to SelectDialogAction.REMOVE_FAVORITES
+            } else {
+                R.string.buttonAddFavorites to SelectDialogAction.ADD_FAVORITES
+            }
+        }
+        addFavoritesText.setText(text)
+        addFavorites.apply {
+            setOnClickListener { onActionSelected(action) }
+            isVisible = areIndividualActionsVisible
+        }
     }
 
     protected open fun configureColoredFolder(areIndividualActionsVisible: Boolean) {
@@ -85,22 +101,6 @@ abstract class MultiSelectActionsBottomSheetDialog(private val matomoCategory: S
         return fileIds.any {
             val file = FileController.getFileProxyById(fileId = it, customRealm = mainViewModel.realm)
             file?.isAllowedToBeColored() == true
-        }
-    }
-
-    protected open fun configureAddFavorites(areIndividualActionsVisible: Boolean) {
-        val (text, action) = with(navigationArgs) {
-            addFavoritesIcon.isEnabled = onlyFavorite
-            if (onlyFavorite) {
-                R.string.buttonRemoveFavorites to SelectDialogAction.REMOVE_FAVORITES
-            } else {
-                R.string.buttonAddFavorites to SelectDialogAction.ADD_FAVORITES
-            }
-        }
-        addFavoritesText.setText(text)
-        addFavorites.apply {
-            setOnClickListener { onActionSelected(action) }
-            isVisible = areIndividualActionsVisible
         }
     }
 
@@ -146,12 +146,12 @@ abstract class MultiSelectActionsBottomSheetDialog(private val matomoCategory: S
         }
     }
 
-    protected open fun configureDuplicateFile() {
-        duplicateFile.setOnClickListener { onActionSelected(SelectDialogAction.DUPLICATE) }
-    }
-
     protected open fun configureMoveFile() {
         moveFile.setOnClickListener { onActionSelected(SelectDialogAction.MOVE) }
+    }
+
+    protected open fun configureDuplicateFile() {
+        duplicateFile.setOnClickListener { onActionSelected(SelectDialogAction.DUPLICATE) }
     }
 
     protected open fun configureRestoreFileIn() {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/SharedWithMeMultiSelectActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/SharedWithMeMultiSelectActionsBottomSheetDialog.kt
@@ -25,23 +25,23 @@ class SharedWithMeMultiSelectActionsBottomSheetDialog : MultiSelectActionsBottom
     matomoCategory = SharedWithMeFragment.MATOMO_CATEGORY,
 ) {
 
-    override fun configureColoredFolder(areIndividualActionsVisible: Boolean) {
-        coloredFolder.isGone = true
-    }
-
     override fun configureAddFavorites(areIndividualActionsVisible: Boolean) {
         addFavorites.isGone = true
+    }
+
+    override fun configureColoredFolder(areIndividualActionsVisible: Boolean) {
+        coloredFolder.isGone = true
     }
 
     override fun configureAvailableOffline() {
         availableOffline.isGone = true
     }
 
-    override fun configureDuplicateFile() {
-        duplicateFile.isGone = true
-    }
-
     override fun configureMoveFile() {
         moveFile.isGone = true
+    }
+
+    override fun configureDuplicateFile() {
+        duplicateFile.isGone = true
     }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/TrashMultiSelectActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/TrashMultiSelectActionsBottomSheetDialog.kt
@@ -40,12 +40,12 @@ class TrashMultiSelectActionsBottomSheetDialog : MultiSelectActionsBottomSheetDi
         downloadFile.isGone = true
     }
 
-    override fun configureDuplicateFile() {
-        duplicateFile.isGone = true
-    }
-
     override fun configureMoveFile() {
         moveFile.isGone = true
+    }
+
+    override fun configureDuplicateFile() {
+        duplicateFile.isGone = true
     }
 
     override fun configureRestoreFileIn() {

--- a/app/src/main/res/layout/fragment_bottom_sheet_multi_select_actions.xml
+++ b/app/src/main/res/layout/fragment_bottom_sheet_multi_select_actions.xml
@@ -189,37 +189,6 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/duplicateFile"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/buttonHeight"
-        android:background="?selectableItemBackground">
-
-        <ImageView
-            android:id="@+id/duplicateFileIcon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/marginStandard"
-            android:src="@drawable/ic_duplicate"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:ignore="ContentDescription" />
-
-        <TextView
-            android:id="@+id/duplicateFileText"
-            style="@style/Subtitle1"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/marginStandardMedium"
-            android:layout_marginEnd="@dimen/marginStandard"
-            android:text="@string/buttonDuplicate"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/duplicateFileIcon"
-            app:layout_constraintTop_toTopOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/moveFile"
         android:layout_width="match_parent"
         android:layout_height="@dimen/buttonHeight"
@@ -247,6 +216,37 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/moveFileIcon"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/duplicateFile"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/buttonHeight"
+        android:background="?selectableItemBackground">
+
+        <ImageView
+            android:id="@+id/duplicateFileIcon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/marginStandard"
+            android:src="@drawable/ic_duplicate"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="ContentDescription" />
+
+        <TextView
+            android:id="@+id/duplicateFileText"
+            style="@style/Subtitle1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/marginStandardMedium"
+            android:layout_marginEnd="@dimen/marginStandard"
+            android:text="@string/buttonDuplicate"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/duplicateFileIcon"
             app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
switch the order of the duplicate and move to items in the multiselect action bottomsheet to be consistent with the action on one file, and with iOS