### PR TITLE
feat: (ApiV3) 5- Add support for thumbnails, onlyoffice and others

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
@@ -28,7 +28,7 @@ object ApiRoutes {
             "external_import,is_favorite,path,sharelink,sorted_name"
     private const val fileExtraWithQuery = "$fileWithQuery,users,version"
     private const val activitiesWithQuery = "with=file,file.capabilities,file.categories,file.conversion_capabilities," +
-            "file.dropbox,file.dropbox.capabilities,file.is_favorite,file.sharelink,file.sorted_name"
+            "file.dropbox,file.dropbox.capabilities,file.is_favorite,file.sharelink,file.sorted_name,file.supported_by"
     private const val listingFilesWithQuery = "with=files,files.capabilities,files.categories,files.conversion_capabilities," +
             "files.dropbox,files.dropbox.capabilities,files.is_favorite,files.sharelink,files.sorted_name,files.supported_by"
     const val activitiesWithExtraQuery = "$activitiesWithQuery,file.external_import"

--- a/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
@@ -28,9 +28,9 @@ object ApiRoutes {
             "external_import,is_favorite,path,sharelink,sorted_name"
     private const val fileExtraWithQuery = "$fileWithQuery,users,version"
     private const val activitiesWithQuery = "with=file,file.capabilities,file.categories,file.conversion_capabilities," +
-            "file.dropbox,file.dropbox.capabilities,file.is_favorite,file.sharelink,file.sorted_name"
+            "file.dropbox,file.dropbox.capabilities,file.is_favorite,file.sharelink,file.sorted_name,files.supported_by"
     private const val listingFilesWithQuery = "with=files,files.capabilities,files.categories,files.conversion_capabilities," +
-            "files.dropbox,files.dropbox.capabilities,files.is_favorite,files.sharelink,files.sorted_name"
+            "files.dropbox,files.dropbox.capabilities,files.is_favorite,files.sharelink,files.sorted_name,files.supported_by"
     const val activitiesWithExtraQuery = "$activitiesWithQuery,file.external_import"
 
     private fun orderQuery(order: SortType) = "order_for[${order.orderBy}]=${order.order}&order_by=${order.orderBy}"

--- a/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
@@ -28,7 +28,7 @@ object ApiRoutes {
             "external_import,is_favorite,path,sharelink,sorted_name"
     private const val fileExtraWithQuery = "$fileWithQuery,users,version"
     private const val activitiesWithQuery = "with=file,file.capabilities,file.categories,file.conversion_capabilities," +
-            "file.dropbox,file.dropbox.capabilities,file.is_favorite,file.sharelink,file.sorted_name,files.supported_by"
+            "file.dropbox,file.dropbox.capabilities,file.is_favorite,file.sharelink,file.sorted_name"
     private const val listingFilesWithQuery = "with=files,files.capabilities,files.categories,files.conversion_capabilities," +
             "files.dropbox,files.dropbox.capabilities,files.is_favorite,files.sharelink,files.sorted_name,files.supported_by"
     const val activitiesWithExtraQuery = "$activitiesWithQuery,file.external_import"

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileMigration.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileMigration.kt
@@ -321,6 +321,17 @@ class FileMigration : RealmMigration {
 
             oldVersionTemp++
         }
+
+        // Migrate to version 8
+        if (oldVersionTemp == 7L) {
+            schema.get(File::class.java.simpleName)?.apply {
+                removeField("hasThumbnail")
+                removeField("hasOnlyoffice")
+                addRealmListField("supportedBy", String::class.java)
+            }
+
+            oldVersionTemp++
+        }
     }
 
     override fun equals(other: Any?): Boolean {
@@ -348,7 +359,7 @@ class FileMigration : RealmMigration {
     }
 
     companion object {
-        const val dbVersion = 7L // Must be bumped when the schema changes
+        const val dbVersion = 8L // Must be bumped when the schema changes
         const val LOGOUT_CURRENT_USER_TAG = "logout_current_user_tag"
     }
 }

--- a/app/src/main/java/com/infomaniak/drive/data/models/File.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/File.kt
@@ -36,8 +36,7 @@ import com.infomaniak.drive.data.models.file.FileExternalImport
 import com.infomaniak.drive.data.models.file.FileExternalImport.FileExternalImportStatus
 import com.infomaniak.drive.data.models.file.FileVersion
 import com.infomaniak.drive.utils.AccountUtils
-import com.infomaniak.drive.utils.RealmListParceler.FileRealmListParceler
-import com.infomaniak.drive.utils.RealmListParceler.IntRealmListParceler
+import com.infomaniak.drive.utils.RealmListParceler.*
 import com.infomaniak.drive.utils.Utils.INDETERMINATE_PROGRESS
 import com.infomaniak.drive.utils.Utils.ROOT_ID
 import com.infomaniak.lib.core.BuildConfig
@@ -102,10 +101,8 @@ open class File(
      * FILE ONLY
      */
     var size: Long? = null,
-    @SerializedName("has_thumbnail")
-    var hasThumbnail: Boolean = false,
-    @SerializedName("has_onlyoffice")
-    var hasOnlyoffice: Boolean = false,
+    @SerializedName("supported_by")
+    var supportedBy: @WriteWith<StringRealmListParceler> RealmList<String>? = null,
     @SerializedName("extension_type")
     var extensionType: String = "",
     var version: FileVersion? = null,
@@ -125,6 +122,9 @@ open class File(
     var versionCode: Int = 0,
 
     ) : RealmObject(), Parcelable {
+
+    val hasThumbnail inline get() = supportedBy?.contains(SupportedByType.THUMBNAIL.apiValue) ?: false
+    val hasOnlyoffice inline get() = supportedBy?.contains(SupportedByType.ONLYOFFICE.apiValue) ?: false
 
     @LinkingObjects("children")
     val localParent: RealmResults<File>? = null
@@ -448,6 +448,12 @@ open class File(
             R.string.allAllDriveUsers,
             R.string.createCommonFolderAllUsersDescription
         )
+    }
+
+    enum class SupportedByType(val apiValue: String) {
+        THUMBNAIL("thumbnail"),
+        ONLYOFFICE("onlyoffice"),
+        KMAIL("kmail")
     }
 
     companion object {

--- a/app/src/main/java/com/infomaniak/drive/utils/RealmListParceler.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/RealmListParceler.kt
@@ -82,4 +82,8 @@ interface RealmListParceler<T> : Parceler<RealmList<T>?> {
     object IntRealmListParceler : RealmListParceler<Int> {
         override var clazz: Class<Int> = Int::class.java
     }
+
+    object StringRealmListParceler : RealmListParceler<String> {
+        override var clazz: Class<String> = String::class.java
+    }
 }


### PR DESCRIPTION
Since api v3, to check whether a file has a thumbnail or is an onlyoffice file, you have to check from the `supported_by` 
field, which is a new field added and received with the query `with=supported_by`.

- [x] Add support for listing
- [x] Add support for home activities

Depends on #1152 