### PR TITLE
We cannot be in the root folder anymore therefore remove multiselect check

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/models/drive/Drive.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/drive/Drive.kt
@@ -18,9 +18,6 @@
 package com.infomaniak.drive.data.models.drive
 
 import com.google.gson.annotations.SerializedName
-import com.infomaniak.drive.data.models.File
-import com.infomaniak.drive.data.models.Rights
-import com.infomaniak.drive.utils.Utils
 import io.realm.RealmList
 import io.realm.RealmObject
 import io.realm.annotations.PrimaryKey
@@ -95,17 +92,6 @@ open class Drive(
     inline val isFreePack get() = pack == DrivePack.FREE.value
 
     inline val isTechnicalMaintenance get() = maintenanceReason == MaintenanceReason.TECHNICAL.value
-
-    fun convertToFile(rootName: String? = null): File {
-        return File(
-            id = if (rootName == null) id else Utils.ROOT_ID,
-            driveId = id,
-            name = rootName ?: name,
-            type = File.Type.DRIVE.value,
-            lastModifiedAt = createdAt,
-            rights = Rights(canCreateFile = true)
-        ).apply { driveColor = preferences.color }
-    }
 
     fun isUserAdmin(): Boolean = role == "admin"
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -760,11 +760,7 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
                             realm = mainViewModel.realm
                         ).apply { fileAdapter.updateFileList(this) }
 
-                        multiSelectManager.currentFolder = if (result.parentFolder?.id == ROOT_ID) {
-                            AccountUtils.getCurrentDrive()?.convertToFile(Utils.getRootName(requireContext()))
-                        } else {
-                            result.parentFolder
-                        }
+                        multiSelectManager.currentFolder = result.parentFolder
 
                         mainViewModel.setCurrentFolder(multiSelectManager.currentFolder)
                         changeNoFilesLayoutVisibility(

--- a/app/src/main/java/com/infomaniak/drive/utils/FileItemUtils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/FileItemUtils.kt
@@ -51,7 +51,6 @@ import com.infomaniak.drive.databinding.CardviewFolderGridBinding
 import com.infomaniak.drive.databinding.ItemCategoriesLayoutBinding
 import com.infomaniak.drive.databinding.ItemFileBinding
 import com.infomaniak.drive.ui.fileList.FileListFragment.Companion.MAX_DISPLAYED_CATEGORIES
-import com.infomaniak.drive.utils.Utils.ROOT_ID
 import com.infomaniak.drive.views.CategoryIconView
 import com.infomaniak.drive.views.ProgressLayoutView
 import com.infomaniak.lib.core.utils.context
@@ -92,7 +91,6 @@ fun CardviewFileGridBinding.setFileItem(file: File, isGrid: Boolean = false) {
 
 
 private fun ItemFileBinding.displayDate(file: File) = fileDate.apply {
-    isVisible = file.id != ROOT_ID
     text = if (file.deletedAt.isPositive()) {
         file.getDeletedAt().format(context.getString(R.string.allDeletedFilePattern))
     } else {


### PR DESCRIPTION
This also lets us remove the method that converts a drive to a file that was only used there and since we can't display a drive as a file anymore, the isVisible check is not needed anymore either

Depends on #1207 