### PR TITLE
Remove unnecessary root check to display drive name in FileListFragment

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -145,7 +145,7 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         folderId = navigationArgs.folderId
-        folderName = if (folderId == ROOT_ID) AccountUtils.getCurrentDrive()?.name ?: "/" else navigationArgs.folderName
+        folderName = navigationArgs.folderName
         _binding = FragmentFileListBinding.inflate(inflater, container, false)
 
         return binding.root


### PR DESCRIPTION
Since we can't open the root in the filelist, there's no need to display a custom name

Depends on #1211 