### PR TITLE
Remove external import selected drive display name

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -251,12 +251,7 @@ class SaveExternalFilesActivity : BaseActivity() {
             }
 
             folder?.let {
-                val folderName = if (folder.isRoot()) {
-                    getString(R.string.allRootName, selectedDrive.value?.name)
-                } else {
-                    folder.name
-                }
-                binding.pathName.text = folderName
+                binding.pathName.text = folder.name
                 checkEnabledSaveButton()
             } ?: run {
                 binding.pathName.setText(R.string.selectFolderTitle)


### PR DESCRIPTION
External imports can't select the root file anymore, no need to have logic to display a custom UI for it

Depends on #1212 