### PR TITLE
Remove root check for empty state visibility

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/models/File.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/File.kt
@@ -303,10 +303,6 @@ open class File(
 
     fun isCancelingImport() = externalImport?.status == FileExternalImportStatus.CANCELING.value
 
-    fun isRoot(): Boolean {
-        return id == ROOT_ID
-    }
-
     fun getWorkerTag() = "${id}_$driveId"
 
     fun isPendingOffline(context: Context): Boolean {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FavoritesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FavoritesFragment.kt
@@ -124,11 +124,11 @@ class FavoritesFragment : FileListFragment() {
                             withVisibilitySort = false
                         )
                         fileAdapter.updateFileList(realmFiles)
-                        changeNoFilesLayoutVisibility(realmFiles.isEmpty(), false)
+                        changeNoFilesLayoutVisibility(realmFiles.isEmpty(), changeControlsVisibility = false)
                     }
                     fileAdapter.isComplete = result.isComplete
                 } ?: run {
-                    changeNoFilesLayoutVisibility(fileAdapter.itemCount == 0, false)
+                    changeNoFilesLayoutVisibility(fileAdapter.itemCount == 0, changeControlsVisibility = false)
                     fileAdapter.isComplete = true
                 }
                 showLoadingTimer.cancel()

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -508,7 +508,7 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
     private fun checkIfNoFiles() {
         changeNoFilesLayoutVisibility(
             hideFileList = fileAdapter.itemCount == 0,
-            changeControlsVisibility = !isCurrentFolderRoot(),
+            changeControlsVisibility = true,
             ignoreOffline = true
         )
     }
@@ -638,7 +638,7 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
                         it?.let { (_, files, _) ->
                             changeNoFilesLayoutVisibility(
                                 hideFileList = files.isEmpty(),
-                                changeControlsVisibility = !updatedFolder.isRoot(),
+                                changeControlsVisibility = true,
                             )
                         }
                     },
@@ -765,7 +765,7 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
                         mainViewModel.setCurrentFolder(multiSelectManager.currentFolder)
                         changeNoFilesLayoutVisibility(
                             hideFileList = fileAdapter.fileList.isEmpty(),
-                            changeControlsVisibility = result.parentFolder?.isRoot() == false
+                            changeControlsVisibility = result.parentFolder != null
                         )
                     }
 
@@ -777,7 +777,7 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
                 } ?: run {
                     changeNoFilesLayoutVisibility(
                         hideFileList = fileAdapter.itemCount == 0,
-                        changeControlsVisibility = folderId != ROOT_ID
+                        changeControlsVisibility = true
                     )
                     fileAdapter.isComplete = true
                 }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -805,7 +805,7 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
      */
     internal fun changeNoFilesLayoutVisibility(
         hideFileList: Boolean,
-        changeControlsVisibility: Boolean = true,
+        changeControlsVisibility: Boolean,
         ignoreOffline: Boolean = false
     ) {
         if (_binding == null) return

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SearchFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SearchFragment.kt
@@ -371,7 +371,7 @@ class SearchFragment : FileListFragment() {
         fun displaySearchResult(mode: VisibilityMode) {
             recentSearchesBinding.root.isGone = true
             filtersRecyclerView.isGone = filtersAdapter.filters.isEmpty()
-            changeNoFilesLayoutVisibility(mode == VisibilityMode.NO_RESULTS, false)
+            changeNoFilesLayoutVisibility(mode == VisibilityMode.NO_RESULTS, changeControlsVisibility = false)
         }
 
         when (mode) {


### PR DESCRIPTION
We can't have an empty file list at the root of the drive because we can't go there anyway, so do not adapt the UI according to this info

Depends on #1213 