### PR TITLE
Leave the method early if we're navigating to ROOT_ID anyway

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -86,12 +86,12 @@ class MainViewModel(appContext: Application) : AndroidViewModel(appContext) {
         // Clear FileListFragment stack
         navController.popBackStack(R.id.rootFilesFragment, false)
 
-        if (fileId == Utils.ROOT_ID) return
+        if (fileId <= Utils.ROOT_ID) return // Deeplinks could lead us to navigating to the true root
 
         // Emit destination folder id
         viewModelScope.launch(Dispatchers.IO) {
             val file = FileController.getFileById(fileId) ?: FileController.getFileDetails(fileId) ?: return@launch
-            if (fileId > Utils.ROOT_ID) navigateFileListTo.postValue(file)
+            navigateFileListTo.postValue(file)
         }
     }
 


### PR DESCRIPTION
Keep ROOT_ID check but skip the coroutine and the realm read when unnecessary

Depends on #1215 