### PR TITLE
We can go back to only checking for OTHER_ROOT_ID because we can't be inside ROOT_ID anymore with v3

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -516,7 +516,7 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
     private fun refreshActivities() {
         val isUploadInProgressNavigation = findNavController().currentDestination?.id == R.id.uploadInProgressFragment
 
-        if (folderId in arrayOf(OTHER_ROOT_ID, ROOT_ID) || isUploadInProgressNavigation || !fileAdapter.isComplete) return
+        if (folderId == OTHER_ROOT_ID || isUploadInProgressNavigation || !fileAdapter.isComplete) return
 
         if (isLoadingActivities) {
             retryLoadingActivities = true


### PR DESCRIPTION
Undo temporary fix that looks to only be needed because we could access the root of a drive inside FileListFragment with the api v3, but this isn't possible anymore

Depends on #1216 