### PR TITLE
`destinationId` could never be `null` so we don't need to fallback to `ROOT_ID`

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -314,11 +314,11 @@ class MainViewModel(appContext: Application) : AndroidViewModel(appContext) {
 
     fun copyFile(
         file: File,
-        destinationId: Int? = null,
+        destinationId: Int,
         copyName: String?,
         onSuccess: ((apiResponse: ApiResponse<File>) -> Unit)? = null,
     ) = liveData(Dispatchers.IO) {
-        ApiRepository.copyFile(file, copyName, destinationId ?: Utils.ROOT_ID).let { apiResponse ->
+        ApiRepository.copyFile(file, copyName, destinationId).let { apiResponse ->
             if (apiResponse.isSuccess()) onSuccess?.invoke(apiResponse)
             emit(apiResponse)
         }


### PR DESCRIPTION
Remove impossible nullability fallback value

Depends on #1217 