### PR TITLE
ROOT_ID would already be disabled because we can't create files in it

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
@@ -119,7 +119,6 @@ class SyncSettingsActivity : BaseActivity() {
                         userId = selectDriveViewModel.selectedUserId.value!!,
                         driveId = selectDriveViewModel.selectedDrive.value?.id!!,
                         folderId = syncSettingsViewModel.syncFolder.value ?: -1,
-                        disabledFolderId = Utils.ROOT_ID,
                     ).toBundle()
                 )
                 selectFolderResultLauncher.launch(this)


### PR DESCRIPTION
The root of the drive already lacks write permissions now, which will disable it, no need to specify that it should be disabled

Depends on #1218 

