### PR TITLE
Fix Gallery crash

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/menu/MenuGalleryFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/MenuGalleryFragment.kt
@@ -53,22 +53,19 @@ class MenuGalleryFragment : Fragment() {
         setUi(galleryFragment)
     }
 
-    private fun addGalleryFragment(): GalleryFragment {
-        with(childFragmentManager) {
-            (findFragmentByTag(GalleryFragment.TAG) as? GalleryFragment)?.let {
-                return it
-            } ?: run {
-                val galleryFragment = GalleryFragment()
+    private fun addGalleryFragment(): GalleryFragment = with(childFragmentManager) {
+        return@with (findFragmentByTag(GalleryFragment.TAG) as? GalleryFragment) ?: run {
+            GalleryFragment().also {
                 beginTransaction()
-                    .replace(R.id.galleryFragmentView, galleryFragment, GalleryFragment.TAG)
+                    .replace(R.id.galleryFragmentView, it, GalleryFragment.TAG)
                     .commit()
-                return galleryFragment
             }
         }
     }
 
     private fun setUi(galleryFragment: GalleryFragment) = with(binding) {
-        swipeRefreshLayout.setOnRefreshListener { galleryFragment.onRefreshGallery() }
+
+        swipeRefreshLayout.setOnRefreshListener(galleryFragment::onRefreshGallery)
 
         multiSelectLayout.apply {
             selectAllButton.isGone = true
@@ -82,6 +79,7 @@ class MenuGalleryFragment : Fragment() {
         }
 
         adjustFastScrollBarScrollRange(galleryFragment)
+
         observeAndDisplayNetworkAvailability(
             mainViewModel = mainViewModel,
             noNetworkBinding = noNetworkInclude,


### PR DESCRIPTION
When navigating from the MenuGalleryFragment and back, clicking on the multiselect toolbar "move" or "trash" actions would crash the app during a `requireContext()` on the GalleryFragment instance because of poor GalleryFragment instance management