### PR TITLE
Remove unsupported sort types

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/models/File.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/File.kt
@@ -430,7 +430,7 @@ open class File(
         // EXTENSION("asc", "extension", R.string.sortExtension); // TODO: Awaiting API
     }
 
-    enum class SortTypeUsage { FILE_LIST, TRASH }
+    enum class SortTypeUsage { FILE_LIST, TRASH, SEARCH }
 
     @Parcelize
     enum class FolderPermission(

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -105,7 +105,7 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
     protected open var hideBackButtonWhenRoot: Boolean = true
     protected open var showPendingFiles = true
     protected open var allowCancellation = true
-    protected open var sortTypeUsage = SortTypeUsage.FILE_LIST
+    protected open val sortTypeUsage = SortTypeUsage.FILE_LIST
 
     private val noItemsFoldersTitle: Int by lazy {
         if (mainViewModel.currentFolder.value?.rights?.canCreateFile == true

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SearchFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SearchFragment.kt
@@ -33,6 +33,7 @@ import androidx.navigation.navGraphViewModels
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.data.models.File.SortType
+import com.infomaniak.drive.data.models.File.SortTypeUsage
 import com.infomaniak.drive.data.models.SearchFilter
 import com.infomaniak.drive.data.models.SearchFilter.FilterKey
 import com.infomaniak.drive.data.models.UiSettings
@@ -53,6 +54,7 @@ class SearchFragment : FileListFragment() {
 
     override val noItemsIcon = R.drawable.ic_search_grey
     override val noItemsTitle = R.string.searchNoFile
+    override val sortTypeUsage = SortTypeUsage.SEARCH
 
     private lateinit var filtersAdapter: SearchFiltersAdapter
     private lateinit var recentSearchesAdapter: RecentSearchesAdapter

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SortFilesBottomSheetAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SortFilesBottomSheetAdapter.kt
@@ -29,38 +29,41 @@ import com.infomaniak.drive.ui.fileList.SortFilesBottomSheetAdapter.SortFilesVie
 
 class SortFilesBottomSheetAdapter(
     private val selectedType: SortType,
-    private val usage: SortTypeUsage,
+    usage: SortTypeUsage,
     private val onItemClicked: (sortType: SortType) -> Unit,
 ) : Adapter<SortFilesViewHolder>() {
+
+    private val types by lazy { usage.types() }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SortFilesViewHolder {
         return SortFilesViewHolder(ItemSelectBottomSheetBinding.inflate(LayoutInflater.from(parent.context), parent, false))
     }
 
     override fun onBindViewHolder(holder: SortFilesViewHolder, position: Int) = with(holder.binding) {
-        usage.types()[position].let { sortType ->
+        types[position].let { sortType ->
             itemSelectText.setText(sortType.translation)
             itemSelectActiveIcon.isVisible = selectedType == sortType
             root.setOnClickListener { onItemClicked(sortType) }
         }
     }
 
-    override fun getItemCount() = usage.types().size
+    override fun getItemCount() = types.size
 
-    private fun SortTypeUsage.types(): Array<SortType> {
+    private fun SortTypeUsage.types(): List<SortType> {
         return when (this) {
-            SortTypeUsage.FILE_LIST -> SortType.values().fileListTypes()
-            SortTypeUsage.TRASH -> SortType.values().trashTypes()
+            SortTypeUsage.FILE_LIST -> SortType.entries.fileListTypes()
+            SortTypeUsage.TRASH -> SortType.entries.trashTypes()
+            SortTypeUsage.SEARCH -> searchTypes()
         }
     }
 
-    private fun Array<SortType>.fileListTypes(): Array<SortType> {
-        return filter { it != SortType.OLDER_TRASHED && it != SortType.RECENT_TRASHED }.toTypedArray()
+    private fun List<SortType>.fileListTypes(): List<SortType> {
+        return filter { it != SortType.OLDER_TRASHED && it != SortType.RECENT_TRASHED }
     }
 
-    private fun Array<SortType>.trashTypes(): Array<SortType> {
-        return filter { it != SortType.OLDER && it != SortType.RECENT }.toTypedArray()
-    }
+    private fun List<SortType>.trashTypes(): List<SortType> = filter { it != SortType.OLDER && it != SortType.RECENT }
+
+    private fun searchTypes(): List<SortType> = listOf(SortType.OLDER, SortType.RECENT)
 
     class SortFilesViewHolder(val binding: ItemSelectBottomSheetBinding) : ViewHolder(binding.root)
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/TrashFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/TrashFragment.kt
@@ -45,7 +45,7 @@ class TrashFragment : FileSubTypeListFragment() {
     val trashViewModel: TrashViewModel by navGraphViewModels(R.id.trashFragment)
 
     override var enabledMultiSelectMode: Boolean = true
-    override var sortTypeUsage = SortTypeUsage.TRASH
+    override val sortTypeUsage = SortTypeUsage.TRASH
 
     override val noItemsRootIcon = R.drawable.ic_delete
     override val noItemsRootTitle = R.string.trashNoFile


### PR DESCRIPTION
Only keep the "older/newer" sort order for the search. Changing amongst them doesn't work for now though