### PR TITLE
Modify SwitchAccount button so it doesn't overlap with Search menu in RootFilesFragment

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -30,10 +30,7 @@ import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.provider.MediaStore
 import android.text.format.Formatter
-import android.transition.AutoTransition
-import android.transition.TransitionManager
-import android.transition.TransitionSet
-import android.util.DisplayMetrics
+import android.transition.*
 import android.util.Patterns
 import android.view.ViewGroup
 import android.view.animation.Animation
@@ -46,7 +43,7 @@ import androidx.core.view.children
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.*
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
@@ -405,7 +402,8 @@ fun LayoutSwitchDriveBinding.setDriveHeader(currentDrive: Drive) {
 }
 
 fun LayoutSwitchDriveBinding.setupSwitchDriveButton(fragment: Fragment) {
-    AccountUtils.getCurrentDrive()?.let { setDriveHeader(it) }
+
+    AccountUtils.getCurrentDrive()?.let(::setDriveHeader)
 
     if (DriveInfosController.hasSingleDrive(AccountUtils.currentUserId)) {
         switchDriveButton.apply {
@@ -418,8 +416,8 @@ fun LayoutSwitchDriveBinding.setupSwitchDriveButton(fragment: Fragment) {
 
     fragment.viewLifecycleOwner.lifecycle.addObserver(
         object : LifecycleEventObserver {
-            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
-                if (event == Lifecycle.Event.ON_RESUME) AccountUtils.getCurrentDrive()?.let { setDriveHeader(it) }
+            override fun onStateChanged(source: LifecycleOwner, event: Event) {
+                if (event == Event.ON_RESUME) AccountUtils.getCurrentDrive()?.let(::setDriveHeader)
             }
         },
     )

--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -405,15 +405,15 @@ fun LayoutSwitchDriveBinding.setDriveHeader(currentDrive: Drive) {
 }
 
 fun LayoutSwitchDriveBinding.setupSwitchDriveButton(fragment: Fragment) {
-    switchDriveButton.apply {
-        AccountUtils.getCurrentDrive()?.let { setDriveHeader(it) }
+    AccountUtils.getCurrentDrive()?.let { setDriveHeader(it) }
 
-        if (DriveInfosController.hasSingleDrive(AccountUtils.currentUserId)) {
+    if (DriveInfosController.hasSingleDrive(AccountUtils.currentUserId)) {
+        switchDriveButton.apply {
             icon = null
             isEnabled = false
-        } else {
-            setOnClickListener { fragment.safeNavigate(R.id.switchDriveDialog) }
         }
+    } else {
+        offsetOverlayedRipple.setOnClickListener { fragment.safeNavigate(R.id.switchDriveDialog) }
     }
 
     fragment.viewLifecycleOwner.lifecycle.addObserver(

--- a/app/src/main/res/layout/layout_switch_drive.xml
+++ b/app/src/main/res/layout/layout_switch_drive.xml
@@ -15,12 +15,13 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="120.8dp"
-    android:gravity="bottom"
+    android:paddingStart="16dp"
+    android:paddingEnd="@dimen/marginStandard"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent">
@@ -30,8 +31,7 @@
         style="@style/TextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="@dimen/marginStandard"
+        android:clickable="false"
         android:contentDescription="@string/buttonSwitchDrive"
         android:ellipsize="end"
         android:fontFamily="@font/suisseintl_bold"
@@ -45,6 +45,49 @@
         app:iconGravity="end"
         app:iconSize="28dp"
         app:iconTint="@color/iconColor"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toStartOf="parent"
         tools:text="Drive de test dev infomaniak" />
 
-</LinearLayout>
+    <!--  To prevent the button from overlapping the toolbar search button in the RootFilesFragment we do all of this complex
+    computations with views -->
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/offsetOverlayedRipple"
+        style="@style/TextButton"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:backgroundTint="@android:color/transparent"
+        app:layout_constraintBottom_toBottomOf="@id/switchDriveButton"
+        app:layout_constraintEnd_toEndOf="@id/maxRippleEnd"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toStartOf="@id/switchDriveButton"
+        app:layout_constraintTop_toTopOf="@id/switchDriveButton" />
+
+    <View
+        android:id="@+id/switchDriveButtonEndView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/switchDriveButton"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <View
+        android:id="@+id/buttonNegativeInset"
+        android:layout_width="16dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/maxRippleEnd"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:barrierDirection="start"
+        app:constraint_referenced_ids="switchDriveButtonEndView,buttonNegativeInset" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_switch_drive.xml
+++ b/app/src/main/res/layout/layout_switch_drive.xml
@@ -51,8 +51,8 @@
         app:layout_constraintStart_toStartOf="parent"
         tools:text="Drive de test dev infomaniak" />
 
-    <!--  To prevent the button from overlapping the toolbar search button in the RootFilesFragment we do all of this complex
-    computations with views -->
+    <!-- To prevent the button from overlapping the toolbar Search button in the
+        RootFilesFragment, we do all of this complex computations with views. -->
     <com.google.android.material.button.MaterialButton
         android:id="@+id/offsetOverlayedRipple"
         style="@style/TextButton"


### PR DESCRIPTION
The text below the transparent button needs to still be displayed the exact same way, so we overlay a transparent button to reduce its size independently. By limiting its size we prevent wide switch drive buttons from overlapping with the search menu from the toolbar in RootFilesFragment blocking some clicks that were aimed at the search menu button