### PR TITLE
Remove shared with me ROOT_ID usage

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/menu/SharedWithMeFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/SharedWithMeFragment.kt
@@ -107,7 +107,7 @@ class SharedWithMeFragment : FileSubTypeListFragment() {
     private fun File.openSharedWithMeFolder() {
         safeNavigate(
             SharedWithMeFragmentDirections.actionSharedWithMeFragmentSelf(
-                folderId = if (isDrive()) ROOT_ID else id,
+                folderId = id,
                 folderName = name,
                 driveId = driveId,
             )


### PR DESCRIPTION
In shared with me files, the files can't be drives anymore