### PR TITLE
Simplify clear of backstack after selecting back item from bottom navigation because there are no more file lists

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
@@ -187,13 +187,7 @@ class MainActivity : BaseActivity() {
             itemIconTintList = ContextCompat.getColorStateList(this@MainActivity, R.color.item_icon_tint_bottom)
             selectedItemId = uiSettings.bottomNavigationSelectedItem
             setOnItemReselectedListener { item ->
-                when (item.itemId) {
-                    R.id.rootFilesFragment, R.id.favoritesFragment -> {
-                        navController.popBackStack(R.id.homeFragment, false)
-                        navController.navigate(item.itemId)
-                    }
-                    else -> navController.popBackStack(item.itemId, false)
-                }
+                navController.popBackStack(item.itemId, false)
             }
         }
     }


### PR DESCRIPTION
This modifies the fix introduced in 5549ad07