### PR TITLE
Fix: (ApiV3) - After the root you lose folder data

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -640,12 +640,13 @@ object FileController {
     }
 
     private fun keepSubFolderChildren(localFolderChildren: List<File>?, remoteFolderChildren: List<File>) {
-        val oldChildren = localFolderChildren?.filter { it.children.isNotEmpty() || it.isOffline }?.associateBy { it.id }
+        val oldChildren = localFolderChildren?.filter { it.isFolder() || it.isOffline }?.associateBy { it.id }
         remoteFolderChildren.forEach { newFile ->
             oldChildren?.get(newFile.id)?.let { oldFile ->
                 newFile.apply {
-                    if (oldFile.isFolder()) children = oldFile.children
+                    if (oldFile.isFolder()) keepOldLocalFilesData(oldFile, newFile)
                     isOffline = oldFile.isOffline
+
                 }
             }
 
@@ -753,6 +754,7 @@ object FileController {
     private fun keepOldLocalFilesData(oldFile: File, newFile: File) {
         newFile.apply {
             children = oldFile.children
+            cursor = oldFile.cursor
             isComplete = oldFile.isComplete
             isOffline = oldFile.isOffline
             responseAt = oldFile.responseAt

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -267,7 +267,7 @@ object FileController {
         moreTransaction: (() -> Unit)? = null
     ) {
         realm.executeTransaction {
-            if (oldFile?.isUsable() == true) keepOldLocalFilesData(oldFile, newFile)
+            if (oldFile?.isUsable() == true) newFile.keepOldLocalFilesData(oldFile)
             moreTransaction?.invoke()
             it.insertOrUpdate(newFile)
         }
@@ -316,7 +316,7 @@ object FileController {
         }
     }
 
-    fun saveFiles(
+    private fun saveFiles(
         folder: File,
         files: List<File>,
         replaceOldData: Boolean = false,
@@ -519,7 +519,7 @@ object FileController {
                 }
                 files.forEach { file ->
                     realm.where(File::class.java).equalTo(File::id.name, file.id).findFirst()?.let { realmFile ->
-                        keepOldLocalFilesData(realmFile, file)
+                        file.keepOldLocalFilesData(realmFile)
                     }
                     folder.children.add(file)
                 }
@@ -535,7 +535,7 @@ object FileController {
                 fileActivity.file?.let { file ->
                     realm.where(File::class.java).equalTo(File::id.name, file.id).findFirst()
                 }?.let { localFile ->
-                    fileActivity.file?.let { keepOldLocalFilesData(localFile, it) }
+                    fileActivity.file?.keepOldLocalFilesData(localFile)
                 }
                 realm.insertOrUpdate(fileActivity)
             }
@@ -558,7 +558,7 @@ object FileController {
     private fun RealmList<File>.addAll(realm: Realm, files: List<File>) {
         files.forEach { file ->
             realm.where(File::class.java).equalTo(File::id.name, file.id).findFirst()?.also { managedFile ->
-                keepOldLocalFilesData(managedFile, file)
+                file.keepOldLocalFilesData(managedFile)
             }
             add(file)
         }
@@ -644,9 +644,8 @@ object FileController {
         remoteFolderChildren.forEach { newFile ->
             oldChildren?.get(newFile.id)?.let { oldFile ->
                 newFile.apply {
-                    if (oldFile.isFolder()) keepOldLocalFilesData(oldFile, newFile)
+                    if (oldFile.isFolder()) newFile.keepOldLocalFilesData(oldFile)
                     isOffline = oldFile.isOffline
-
                 }
             }
 
@@ -751,15 +750,13 @@ object FileController {
         return ApiRepository.createTeamFolder(okHttpClient, driveId, name, forAllUsers)
     }
 
-    private fun keepOldLocalFilesData(oldFile: File, newFile: File) {
-        newFile.apply {
-            children = oldFile.children
-            cursor = oldFile.cursor
-            isComplete = oldFile.isComplete
-            isOffline = oldFile.isOffline
-            responseAt = oldFile.responseAt
-            versionCode = oldFile.versionCode
-        }
+    private fun File.keepOldLocalFilesData(oldFile: File) {
+        children = oldFile.children
+        cursor = oldFile.cursor
+        isComplete = oldFile.isComplete
+        isOffline = oldFile.isOffline
+        responseAt = oldFile.responseAt
+        versionCode = oldFile.versionCode
     }
 
     private fun RealmQuery<File>.getSortQueryByOrder(order: SortType): RealmQuery<File> {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
@@ -54,7 +54,7 @@ class FileListViewModel(application: Application) : AndroidViewModel(application
     fun sortTypeIsInitialized() = ::sortType.isInitialized
 
     fun getFiles(
-        parentId: Int,
+        folderId: Int,
         order: SortType,
         sourceRestrictionType: FolderFilesProvider.SourceRestrictionType,
         userDrive: UserDrive? = null,
@@ -64,12 +64,12 @@ class FileListViewModel(application: Application) : AndroidViewModel(application
         getFolderActivitiesJob.cancel()
         getFilesJob = Job()
         return liveData(Dispatchers.IO + getFilesJob) {
-            tailrec suspend fun recursiveDownload(parentId: Int, isFirstPage: Boolean) {
+            tailrec suspend fun recursiveDownload(folderId: Int, isFirstPage: Boolean) {
                 getFilesJob.ensureActive()
 
                 val folderFilesProviderResult = FolderFilesProvider.getFiles(
                     FolderFilesProvider.FolderFilesProviderArgs(
-                        folderId = parentId,
+                        folderId = folderId,
                         isFirstPage = isFirstPage,
                         order = order,
                         sourceRestrictionType = sourceRestrictionType,
@@ -102,11 +102,11 @@ class FileListViewModel(application: Application) : AndroidViewModel(application
                                 )
                             )
                         }
-                        recursiveDownload(parentId, isFirstPage = false)
+                        recursiveDownload(folderId, isFirstPage = false)
                     }
                 }
             }
-            recursiveDownload(parentId, isFirstPage = true)
+            recursiveDownload(folderId, isFirstPage = true)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/home/RootFilesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/RootFilesFragment.kt
@@ -147,7 +147,7 @@ class RootFilesFragment : Fragment() {
         val isNetworkUnavailable = mainViewModel.isInternetAvailable.value == false
 
         fileListViewModel.getFiles(
-            parentId = Utils.ROOT_ID,
+            folderId = Utils.ROOT_ID,
             order = File.SortType.NAME_AZ,
             sourceRestrictionType = if (isNetworkUnavailable) ONLY_FROM_LOCAL else ONLY_FROM_REMOTE,
             isNewSort = false,


### PR DESCRIPTION
When you return to the root of the files, the data is downloaded again even though the folders are complete.
Depends on #1263 