### PR TITLE
Remove home wide searchbar for the toolbar menu icon

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
@@ -24,7 +24,6 @@ import android.view.ViewGroup
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.isGone
-import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -34,8 +33,8 @@ import com.infomaniak.drive.ui.MainViewModel
 import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.Utils.Shortcuts
 import com.infomaniak.drive.utils.setDriveHeader
+import com.infomaniak.drive.utils.setupDriveToolbar
 import com.infomaniak.drive.utils.setupRootPendingFilesIndicator
-import com.infomaniak.drive.utils.setupSwitchDriveButton
 import com.infomaniak.lib.core.utils.safeBinding
 import com.infomaniak.lib.core.utils.safeNavigate
 
@@ -56,7 +55,7 @@ class HomeFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         mainViewModel.isInternetAvailable.observe(viewLifecycleOwner) { isInternetAvailable ->
             noNetworkCard.root.isGone = isInternetAvailable
         }
-        switchDriveLayout.setupSwitchDriveButton(this@HomeFragment)
+        setupDriveToolbar(collapsingToolbarLayout, switchDriveLayout, appBarLayout)
 
         ViewCompat.requestApplyInsets(homeCoordinator)
 

--- a/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/HomeFragment.kt
@@ -28,6 +28,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.infomaniak.drive.R
 import com.infomaniak.drive.databinding.FragmentHomeBinding
 import com.infomaniak.drive.ui.MainViewModel
 import com.infomaniak.drive.utils.AccountUtils
@@ -57,13 +58,16 @@ class HomeFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener {
         }
         switchDriveLayout.setupSwitchDriveButton(this@HomeFragment)
 
-        searchViewCard.searchView.isGone = true
-        searchViewCard.searchViewText.isVisible = true
         ViewCompat.requestApplyInsets(homeCoordinator)
 
-        searchViewCard.root.setOnClickListener {
-            ShortcutManagerCompat.reportShortcutUsed(requireContext(), Shortcuts.SEARCH.id)
-            safeNavigate(HomeFragmentDirections.actionHomeFragmentToSearchFragment())
+        toolbar.setOnMenuItemClickListener { menuItem ->
+            if (menuItem.itemId == R.id.searchItem) {
+                ShortcutManagerCompat.reportShortcutUsed(requireContext(), Shortcuts.SEARCH.id)
+                safeNavigate(HomeFragmentDirections.actionHomeFragmentToSearchFragment())
+                true
+            } else {
+                false
+            }
         }
 
         mainViewModel.deleteFileFromHome.observe(viewLifecycleOwner) { fileDeleted -> mustRefreshUi = fileDeleted }

--- a/app/src/main/java/com/infomaniak/drive/ui/home/LastActivitiesAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/LastActivitiesAdapter.kt
@@ -26,6 +26,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import androidx.viewbinding.ViewBinding
 import coil.load
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.DriveUser
@@ -34,6 +35,7 @@ import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.data.models.FileActivity
 import com.infomaniak.drive.databinding.CardviewHomeFileActivityBinding
 import com.infomaniak.drive.databinding.EmptyIconLayoutBinding
+import com.infomaniak.drive.databinding.ItemLastActivitiesSubtitleBinding
 import com.infomaniak.drive.utils.loadAny
 import com.infomaniak.drive.utils.loadAvatar
 import com.infomaniak.lib.core.utils.context
@@ -44,13 +46,26 @@ class LastActivitiesAdapter : LoaderAdapter<FileActivity>() {
     var onFileClicked: ((currentFile: File, validPreviewFiles: ArrayList<File>) -> Unit)? = null
     var onMoreFilesClicked: ((fileActivity: FileActivity, validPreviewFiles: ArrayList<File>) -> Unit)? = null
 
+    override fun getItemCount(): Int = super.getItemCount() + 1
+
+    override fun getItemViewType(position: Int): Int = if (position == 0) VIEW_TYPE_SUBTITLE else super.getItemViewType(position)
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LastActivitiesViewHolder {
-        return LastActivitiesViewHolder(
-            CardviewHomeFileActivityBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        )
+        return when (viewType) {
+            VIEW_TYPE_SUBTITLE -> SubtitleViewHolder(
+                ItemLastActivitiesSubtitleBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+            )
+            else -> ActivitiesViewHolder(
+                CardviewHomeFileActivityBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+            )
+        }
     }
 
-    override fun onBindViewHolder(holder: ViewHolder, position: Int): Unit = with((holder as LastActivitiesViewHolder).binding) {
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        if (holder is ActivitiesViewHolder) holder.binding.bindActivity(position)
+    }
+
+    private fun CardviewHomeFileActivityBinding.bindActivity(position: Int) {
         if (getItemViewType(position) == VIEW_TYPE_LOADING) {
             root.startLoading()
             userName.resetLoader()
@@ -180,5 +195,11 @@ class LastActivitiesAdapter : LoaderAdapter<FileActivity>() {
 
     private fun getFileTypeIcon(file: File?) = file?.getFileType()?.icon ?: R.drawable.ic_file
 
-    class LastActivitiesViewHolder(val binding: CardviewHomeFileActivityBinding) : ViewHolder(binding.root)
+    open class LastActivitiesViewHolder(open val binding: ViewBinding) : ViewHolder(binding.root)
+    class SubtitleViewHolder(override val binding: ItemLastActivitiesSubtitleBinding) : LastActivitiesViewHolder(binding)
+    class ActivitiesViewHolder(override val binding: CardviewHomeFileActivityBinding) : LastActivitiesViewHolder(binding)
+
+    companion object {
+        private const val VIEW_TYPE_SUBTITLE = 3
+    }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/home/RootFilesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/RootFilesFragment.kt
@@ -17,8 +17,6 @@
  */
 package com.infomaniak.drive.ui.home
 
-import android.content.res.ColorStateList
-import android.graphics.Color
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -60,7 +58,7 @@ class RootFilesFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) = with(binding) {
         super.onViewCreated(view, savedInstanceState)
 
-        setupDriveToolbar()
+        setupDriveToolbar(collapsingToolbarLayout, switchDriveLayout, appBar)
 
         toolbar.setOnMenuItemClickListener { menuItem ->
             if (menuItem.itemId == R.id.searchItem) {
@@ -84,22 +82,6 @@ class RootFilesFragment : Fragment() {
         )
 
         setupRootPendingFilesIndicator(mainViewModel.pendingUploadsCount, rootFilesUploadFileInProgressView)
-    }
-
-    private fun setupDriveToolbar() = with(binding) {
-        collapsingToolbarLayout.title = AccountUtils.getCurrentDrive()!!.name
-        switchDriveLayout.setupSwitchDriveButton(this@RootFilesFragment)
-
-        appBar.addOnOffsetChangedListener { _, verticalOffset ->
-            val fullyExpanded = verticalOffset == 0
-            switchDriveLayout.root.isVisible = fullyExpanded
-
-            if (fullyExpanded) {
-                collapsingToolbarLayout.setExpandedTitleTextColor(ColorStateList.valueOf(Color.TRANSPARENT))
-            } else {
-                collapsingToolbarLayout.setExpandedTitleTextAppearance(R.style.CollapsingToolbarExpandedTitleTextAppearance)
-            }
-        }
     }
 
     private fun setupItems() = with(binding) {

--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -22,6 +22,7 @@ import android.app.ActivityManager
 import android.content.ContentUris
 import android.content.Context
 import android.content.Intent
+import android.content.res.ColorStateList
 import android.database.Cursor
 import android.graphics.Color
 import android.graphics.Point
@@ -51,6 +52,8 @@ import androidx.navigation.fragment.findNavController
 import androidx.work.OneTimeWorkRequest
 import androidx.work.OutOfQuotaPolicy
 import coil.load
+import com.google.android.material.appbar.AppBarLayout
+import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.textfield.MaterialAutoCompleteTextView
@@ -436,8 +439,7 @@ fun LayoutSwitchDriveBinding.setDriveHeader(currentDrive: Drive) {
     switchDriveButton.text = currentDrive.name
 }
 
-fun LayoutSwitchDriveBinding.setupSwitchDriveButton(fragment: Fragment) {
-
+private fun LayoutSwitchDriveBinding.setupSwitchDriveButton(fragment: Fragment) {
     AccountUtils.getCurrentDrive()?.let(::setDriveHeader)
 
     if (DriveInfosController.hasSingleDrive(AccountUtils.currentUserId)) {
@@ -456,6 +458,26 @@ fun LayoutSwitchDriveBinding.setupSwitchDriveButton(fragment: Fragment) {
             }
         },
     )
+}
+
+fun Fragment.setupDriveToolbar(
+    collapsingToolbarLayout: CollapsingToolbarLayout,
+    switchDriveLayout: LayoutSwitchDriveBinding,
+    appBar: AppBarLayout,
+) {
+    collapsingToolbarLayout.title = AccountUtils.getCurrentDrive()!!.name
+    switchDriveLayout.setupSwitchDriveButton(this)
+
+    appBar.addOnOffsetChangedListener { _, verticalOffset ->
+        val fullyExpanded = verticalOffset == 0
+        switchDriveLayout.root.isVisible = fullyExpanded
+
+        if (fullyExpanded) {
+            collapsingToolbarLayout.setExpandedTitleTextColor(ColorStateList.valueOf(Color.TRANSPARENT))
+        } else {
+            collapsingToolbarLayout.setExpandedTitleTextAppearance(R.style.CollapsingToolbarExpandedTitleTextAppearance)
+        }
+    }
 }
 
 fun Fragment.observeAndDisplayNetworkAvailability(

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -34,6 +34,14 @@
             android:layout_height="wrap_content"
             app:layout_scrollFlags="scroll|snap">
 
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:layout_collapseMode="pin"
+                app:menu="@menu/file_list_menu"
+                app:navigationIcon="@null" />
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -53,15 +61,6 @@
                     android:layout_marginBottom="@dimen/marginStandardSmall"
                     android:visibility="gone"
                     tools:visibility="visible" />
-
-                <include
-                    android:id="@+id/searchViewCard"
-                    layout="@layout/item_search_view"
-                    android:layout_width="match_parent"
-                    android:layout_height="50dp"
-                    android:layout_marginHorizontal="@dimen/marginStandard"
-                    android:layout_marginTop="@dimen/marginStandardMedium"
-                    android:layout_marginBottom="@dimen/marginStandardMedium" />
 
                 <com.infomaniak.drive.views.PendingFilesView
                     android:id="@+id/homeUploadFileInProgressView"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -15,88 +15,99 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/homeCoordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.home.HomeFragment">
 
-    <com.google.android.material.appbar.AppBarLayout
-        android:id="@+id/appBarLayout"
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/homeCoordinator"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
 
-        <com.google.android.material.appbar.CollapsingToolbarLayout
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appBarLayout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_scrollFlags="scroll|snap">
+            android:layout_height="wrap_content">
 
-            <com.google.android.material.appbar.MaterialToolbar
-                android:id="@+id/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                app:layout_collapseMode="pin"
-                app:menu="@menu/file_list_menu"
-                app:navigationIcon="@null" />
-
-            <LinearLayout
+            <com.google.android.material.appbar.CollapsingToolbarLayout
+                android:id="@+id/collapsingToolbarLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                app:layout_scrollFlags="scroll|exitUntilCollapsed|snap">
 
-                <include
-                    android:id="@+id/switchDriveLayout"
-                    layout="@layout/layout_switch_drive" />
+                <com.google.android.material.appbar.MaterialToolbar
+                    android:id="@+id/toolbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="?attr/actionBarSize"
+                    app:layout_collapseMode="pin"
+                    app:menu="@menu/file_list_menu"
+                    app:navigationIcon="@null" />
 
-                <include
-                    android:id="@+id/noNetworkCard"
-                    layout="@layout/view_network_unavailable_home"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="@dimen/marginStandard"
-                    android:layout_marginTop="@dimen/marginStandardMedium"
-                    android:layout_marginBottom="@dimen/marginStandardSmall"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
+                    android:orientation="vertical">
 
-                <com.infomaniak.drive.views.PendingFilesView
-                    android:id="@+id/homeUploadFileInProgressView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_margin="@dimen/marginStandardMedium"
-                    android:visibility="gone"
-                    app:title="@string/uploadInProgressTitle"
-                    tools:visibility="visible" />
+                    <Space
+                        android:layout_width="0dp"
+                        android:layout_height="112.8dp" />
 
-                <com.infomaniak.drive.views.NotEnoughStorageView
-                    android:id="@+id/notEnoughStorage"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/marginStandardMedium"
-                    android:visibility="gone"
-                    tools:visibility="visible" />
+                    <include
+                        android:id="@+id/noNetworkCard"
+                        layout="@layout/view_network_unavailable_home"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="@dimen/marginStandard"
+                        android:layout_marginTop="@dimen/marginStandardMedium"
+                        android:layout_marginBottom="@dimen/marginStandardSmall"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
 
-            </LinearLayout>
+                    <com.infomaniak.drive.views.PendingFilesView
+                        android:id="@+id/homeUploadFileInProgressView"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="@dimen/marginStandardMedium"
+                        android:visibility="gone"
+                        app:title="@string/uploadInProgressTitle"
+                        tools:visibility="visible" />
 
-        </com.google.android.material.appbar.CollapsingToolbarLayout>
+                    <com.infomaniak.drive.views.NotEnoughStorageView
+                        android:id="@+id/notEnoughStorage"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/marginStandardMedium"
+                        android:visibility="gone"
+                        tools:visibility="visible" />
 
-    </com.google.android.material.appbar.AppBarLayout>
+                </LinearLayout>
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        android:id="@+id/homeSwipeRefreshLayout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+            </com.google.android.material.appbar.CollapsingToolbarLayout>
 
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/homeActivitiesFragment"
-            android:name="com.infomaniak.drive.ui.home.HomeActivitiesFragment"
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/homeSwipeRefreshLayout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            tools:layout="@layout/fragment_home_activities" />
+            app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/homeActivitiesFragment"
+                android:name="com.infomaniak.drive.ui.home.HomeActivitiesFragment"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                tools:layout="@layout/fragment_home_activities" />
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
+    <include
+        android:id="@+id/switchDriveLayout"
+        layout="@layout/layout_switch_drive"
+        tools:visibility="gone" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_home_activities.xml
+++ b/app/src/main/res/layout/fragment_home_activities.xml
@@ -16,39 +16,22 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.home.HomeFragment">
 
-    <TextView
-        android:id="@+id/homeTabsTitle"
-        style="@style/H2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/marginStandard"
-        android:layout_marginTop="@dimen/marginStandardMedium"
-        android:text="@string/homeLastActivities"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/homeTabsRecyclerView"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_height="match_parent"
         android:clipToPadding="false"
         android:overScrollMode="never"
         android:paddingHorizontal="20dp"
-        android:paddingTop="@dimen/marginStandardSmall"
         android:paddingBottom="@dimen/recyclerViewPaddingBottom"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/homeTabsTitle"
         tools:itemCount="5"
+        tools:listheader="@layout/item_last_activities_subtitle"
         tools:listitem="@layout/cardview_home_file_activity" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+
+</FrameLayout>

--- a/app/src/main/res/layout/item_last_activities_subtitle.xml
+++ b/app/src/main/res/layout/item_last_activities_subtitle.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Infomaniak kDrive - Android
+  ~ Copyright (C) 2024 Infomaniak Network SA
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/homeTabsTitle"
+    style="@style/H2"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/marginStandardVerySmall"
+    android:layout_marginTop="@dimen/marginStandardMedium"
+    android:paddingBottom="@dimen/marginStandardSmall"
+    android:text="@string/homeLastActivities" />


### PR DESCRIPTION
To match the new design. 

This one is worth reviewing using the "hide whitespace" feature of github for the file fragment_home.xml