### PR TITLE
Fix: (ApiV3) Move a file throw a NullPointerException

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -512,7 +512,7 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
 
             val driveName = AccountUtils.getCurrentDrive()?.driveAccount?.name
             Dispatchers.Main {
-                binding.publicFolderSubtitle.apply {
+                _binding?.publicFolderSubtitle?.apply {
                     isVisible = shouldDisplaySubtitle && driveName != null
                     if (isVisible) text = getString(R.string.commonDocumentsDescription, driveName)
                 }


### PR DESCRIPTION
Sometimes SelectFolderFragment is called twice and throw a NullPointerException for the first call in the binding. 