### PR TITLE
Feat: (RootFiles) ApiV3 - Move root files to MainViewModel

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -35,9 +35,11 @@ import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.networking.HttpClient
 import io.realm.*
 import io.realm.kotlin.oneOf
+import io.realm.kotlin.toFlow
 import io.sentry.Sentry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import java.util.Calendar
 
@@ -138,6 +140,13 @@ object FileController {
                 .equalTo(File::isOffline.name, true)
                 .count()
         }
+    }
+
+    fun getFolderFilesFlow(realm: Realm, folderId: Int): Flow<RealmResults<File>> {
+        return realm.where(File::class.java)
+            .equalTo(File::parentId.name, folderId)
+            .findAllAsync()
+            .toFlow()
     }
 
     fun removeFile(

--- a/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
@@ -187,6 +187,11 @@ class MainActivity : BaseActivity() {
         observeCurrentFolder()
     }
 
+    override fun onStart() {
+        super.onStart()
+        mainViewModel.loadRootFiles()
+    }
+
     private fun getNavHostFragment() = supportFragmentManager.findFragmentById(R.id.hostFragment) as NavHostFragment
 
     private fun setupNavController(): NavController {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
@@ -33,6 +33,8 @@ import com.infomaniak.drive.utils.Position
 import com.infomaniak.drive.utils.Utils
 import com.infomaniak.lib.core.utils.SingleLiveEvent
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.cancellable
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -54,31 +56,11 @@ class FileListViewModel(application: Application) : AndroidViewModel(application
 
     fun sortTypeIsInitialized() = ::sortType.isInitialized
 
-    private val _rootFiles = MutableLiveData<Map<File.VisibilityType, File>>()
-    val rootFiles: LiveData<Map<File.VisibilityType, File>> = _rootFiles
-
-    fun loadRootFiles(
-        order: SortType,
-        sourceRestrictionType: FolderFilesProvider.SourceRestrictionType,
-    ) {
-        getFilesJob.cancel()
-        getFolderActivitiesJob.cancel()
-        getFilesJob = Job()
-        viewModelScope.launch(Dispatchers.IO) {
-
-            val files = FolderFilesProvider.getFiles(
-                FolderFilesProvider.FolderFilesProviderArgs(
-                    folderId = Utils.ROOT_ID,
-                    isFirstPage = true,
-                    order = order,
-                    sourceRestrictionType = sourceRestrictionType,
-                    userDrive = UserDrive(),
-                )
-            )?.folderFiles
-
-            _rootFiles.postValue(files?.associateBy(File::getVisibilityType))
-        }
-    }
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val rootFiles = FileController.getFolderFilesFlow(realm, Utils.ROOT_ID)
+        .mapLatest { it.associateBy(File::getVisibilityType) }
+        .cancellable()
+        .asLiveData(viewModelScope.coroutineContext)
 
     fun getFiles(
         folderId: Int,
@@ -291,6 +273,7 @@ class FileListViewModel(application: Application) : AndroidViewModel(application
 
     override fun onCleared() {
         super.onCleared()
+        runCatching { realm.close() }
         cancelDownloadFiles()
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/home/RootFilesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/RootFilesFragment.kt
@@ -29,8 +29,6 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.cache.DriveInfosController
-import com.infomaniak.drive.data.cache.FolderFilesProvider.SourceRestrictionType.ONLY_FROM_LOCAL
-import com.infomaniak.drive.data.cache.FolderFilesProvider.SourceRestrictionType.ONLY_FROM_REMOTE
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.databinding.FragmentRootFilesBinding
 import com.infomaniak.drive.ui.MainViewModel
@@ -72,7 +70,6 @@ class RootFilesFragment : Fragment() {
 
         setupItems()
 
-        loadFiles()
         observeFiles()
         observeNavigateFileListTo()
         observeAndDisplayNetworkAvailability(
@@ -124,15 +121,6 @@ class RootFilesFragment : Fragment() {
         trashbin.setOnClickListener {
             safeNavigate(RootFilesFragmentDirections.actionFilesFragmentToTrashFragment())
         }
-    }
-
-    private fun loadFiles() {
-        val isNetworkUnavailable = mainViewModel.isInternetAvailable.value == false
-
-        fileListViewModel.loadRootFiles(
-            order = File.SortType.NAME_AZ,
-            sourceRestrictionType = if (isNetworkUnavailable) ONLY_FROM_LOCAL else ONLY_FROM_REMOTE,
-        )
     }
 
     private fun observeFiles() {


### PR DESCRIPTION
We need to load the rootFiles in advance, so we move them to the MainViewModel