### PR TITLE
Fix bug where we show the password dialog on a PDF when we have an error to download the file

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewPDFFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewPDFFragment.kt
@@ -34,6 +34,7 @@ import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.data.models.UserDrive
 import com.infomaniak.drive.databinding.FragmentPreviewPdfBinding
+import com.infomaniak.drive.ui.fileList.preview.PreviewSliderFragment.Companion.openWithClicked
 import com.infomaniak.drive.ui.fileList.preview.PreviewSliderFragment.Companion.setPageNumber
 import com.infomaniak.drive.ui.fileList.preview.PreviewSliderFragment.Companion.setPageNumberChipVisibility
 import com.infomaniak.drive.ui.fileList.preview.PreviewSliderFragment.Companion.toggleFullscreen
@@ -109,7 +110,9 @@ class PreviewPDFFragment : PreviewFragment() {
 
         bigOpenWithButton.apply {
             isGone = true
-            setOnClickListener { showPasswordDialog() }
+            setOnClickListener {
+                if (isPasswordProtected) showPasswordDialog() else openWithClicked()
+            }
         }
     }
 


### PR DESCRIPTION

https://github.com/Infomaniak/android-kDrive/assets/149579879/7c6ed254-e8d6-45a6-9ea8-fbc1dbea4888

