### PR TITLE
Fix tab inserting the toString of objects instead of autocompletion when sharing folder

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
@@ -46,6 +46,7 @@ class AvailableShareableItemsAdapter(
     private var itemList: ArrayList<Shareable>,
     var notShareableIds: ArrayList<Int> = arrayListOf(),
     var notShareableEmails: ArrayList<String> = arrayListOf(),
+    private val getCurrentText: () -> CharSequence,
     private val onItemClick: (item: Shareable) -> Unit,
 ) : ArrayAdapter<Shareable>(context, R.layout.item_user, itemList), Filterable {
 
@@ -154,6 +155,8 @@ class AvailableShareableItemsAdapter(
                 values = finalUserList
                 count = finalUserList.size
             }
+
+            override fun convertResultToString(resultValue: Any?): CharSequence = getCurrentText()
         }
 
         override fun publishResults(constraint: CharSequence?, results: FilterResults) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/AvailableShareableItemsAdapter.kt
@@ -155,8 +155,6 @@ class AvailableShareableItemsAdapter(
                 values = finalUserList
                 count = finalUserList.size
             }
-
-            override fun convertResultToString(resultValue: Any?): CharSequence = getCurrentText()
         }
 
         override fun publishResults(constraint: CharSequence?, results: FilterResults) {
@@ -174,6 +172,8 @@ class AvailableShareableItemsAdapter(
 
             notifyDataSetChanged()
         }
+
+        override fun convertResultToString(resultValue: Any?): CharSequence = getCurrentText()
     }
 
     private fun CharSequence.standardize(): String = this.toString().trim().lowercase()

--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -217,17 +217,18 @@ fun MaterialAutoCompleteTextView.setupAvailableShareableItems(
     itemList: List<Shareable>,
     notShareableIds: ArrayList<Int> = arrayListOf(),
     notShareableEmails: ArrayList<String> = arrayListOf(),
-    onDataPassed: (item: Shareable) -> Unit
+    onDataPassed: (item: Shareable) -> Unit,
 ): AvailableShareableItemsAdapter {
     setDropDownBackgroundResource(R.drawable.background_popup)
     val availableUsersAdapter = AvailableShareableItemsAdapter(
         context = context,
         itemList = ArrayList(itemList),
         notShareableIds = notShareableIds,
-        notShareableEmails = notShareableEmails
-    ) { item ->
-        onDataPassed(item)
-    }
+        getCurrentText = { text },
+        notShareableEmails = notShareableEmails,
+        onItemClick = onDataPassed,
+    )
+
     setAdapter(availableUsersAdapter)
     handleActionDone { if (text.isNotBlank()) !availableUsersAdapter.addFirstAvailableItem() }
 

--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -224,8 +224,8 @@ fun MaterialAutoCompleteTextView.setupAvailableShareableItems(
         context = context,
         itemList = ArrayList(itemList),
         notShareableIds = notShareableIds,
-        getCurrentText = { text },
         notShareableEmails = notShareableEmails,
+        getCurrentText = { text },
         onItemClick = onDataPassed,
     )
 


### PR DESCRIPTION
The problem is mostly solved, pressing tab will not insert the object toString anymore, but it will insert the current text, thus not changing anything. 
A consequence of this is that the UI is refreshed and the list of users that was displayed gets closed.

This is the best solution found that does not require a refactor of the MaterialAutoCompleteTextView.