### PR TITLE
fix: Stop logging full deeplink path in Matomo

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/MatomoDrive.kt
+++ b/app/src/main/java/com/infomaniak/drive/MatomoDrive.kt
@@ -64,4 +64,8 @@ object MatomoDrive : MatomoCore {
     fun Activity.trackInAppReview(name: String) {
         trackEvent("inAppReview", name)
     }
+
+    fun Activity.trackDeepLink(name: String) {
+        trackEvent("deepLink", name)
+    }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
@@ -24,7 +24,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.infomaniak.drive.BuildConfig
-import com.infomaniak.drive.MatomoDrive.trackEvent
+import com.infomaniak.drive.MatomoDrive.trackDeepLink
 import com.infomaniak.drive.MatomoDrive.trackScreen
 import com.infomaniak.drive.MatomoDrive.trackUserId
 import com.infomaniak.drive.R
@@ -168,7 +168,7 @@ class LaunchActivity : AppCompatActivity() {
                 message = "DeepLink: $path"
                 level = SentryLevel.INFO
             })
-            trackEvent("deepLink", path)
+            trackDeepLink("internal")
         }
     }
 


### PR DESCRIPTION
This also differenciate each event instead of aggregating all