### PR TITLE
Remove the gap between the bottom sheet and the bottom of the screen

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/utils/PreviewUtils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/PreviewUtils.kt
@@ -49,8 +49,6 @@ fun Activity.setupBottomSheetFileBehavior(
     bottomSheetBehavior.apply {
         isHideable = true
         this.isDraggable = isDraggable
-        // TODO This need to be true for ExternalFileInfoActionsView, otherwise, the BottomSheet can go to the top of the screen
-        //  (see Trello card eUJkzgDU). We need to remove this.
         this.isFitToContents = isFitToContents
         addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
             override fun onStateChanged(bottomSheet: View, newState: Int) {

--- a/app/src/main/res/layout/fragment_preview_slider.xml
+++ b/app/src/main/res/layout/fragment_preview_slider.xml
@@ -47,7 +47,7 @@
         android:id="@+id/bottomSheetFileInfos"
         style="?attr/bottomSheetStyle"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         app:layout_behavior="@string/bottom_sheet_behavior" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
The gap is the result of set 'isFitContent' to false on the bottom sheet behavior but unfortunately it's either the gap or the half state on the bottom sheet.

The only solution that i founded is to fill the gap with 'match_parent' so we have half_state and no gap.