### PR TITLE
Fix NPE in PreviewSliderFragment

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
@@ -80,7 +80,7 @@ class PreviewSliderFragment : Fragment(), FileInfoActionsView.OnItemClickListene
     val previewPDFHandler by lazy {
         PreviewPDFHandler(
             context = requireContext(),
-            setPrintVisibility = binding.bottomSheetFileInfos::setPrintVisibility,
+            setPrintVisibility = { _binding?.bottomSheetFileInfos?.setPrintVisibility(it) },
         )
     }
 


### PR DESCRIPTION
There was an NPE occuring in PreviewSliderFragment because of the PreviewPDFHandler's `setPrintVisibility` callback which was called after the view was destroyed