### PR TITLE
Get file last modified date from URI when coming from kMail attachment

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -23,6 +23,7 @@ import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
+import android.provider.MediaStore.MediaColumns
 import android.text.InputFilter
 import android.text.Spanned
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
@@ -42,7 +43,7 @@ import com.infomaniak.drive.data.cache.DriveInfosController
 import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.data.models.UiSettings
-import com.infomaniak.drive.data.models.UiSettings.*
+import com.infomaniak.drive.data.models.UiSettings.SaveExternalFilesData
 import com.infomaniak.drive.data.models.UploadFile
 import com.infomaniak.drive.data.models.UserDrive
 import com.infomaniak.drive.data.models.drive.Drive
@@ -466,7 +467,8 @@ class SaveExternalFilesActivity : BaseActivity() {
     private fun store(uri: Uri, fileName: String?, userId: Int, driveId: Int, folderId: Int): Boolean {
         contentResolver.query(uri, null, null, null, null)?.use { cursor ->
             if (cursor.moveToFirst()) {
-                val (fileCreatedAt, fileModifiedAt) = SyncUtils.getFileDates(cursor)
+                val lastModifiedDateFromUri = intent.getLongExtra(MediaColumns.DATE_MODIFIED, -1L)
+                val (fileCreatedAt, fileModifiedAt) = SyncUtils.getFileDates(cursor, lastModifiedDateFromUri)
 
                 try {
                     if (fileName == null) return false
@@ -516,5 +518,6 @@ class SaveExternalFilesActivity : BaseActivity() {
 
     companion object {
         const val SHARED_FILE_FOLDER = "shared_files"
+        const val LAST_MODIFIED_URI_KEY = "last_modified"
     }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -23,7 +23,7 @@ import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
-import android.provider.MediaStore.MediaColumns
+import android.provider.MediaStore.Files.FileColumns
 import android.text.InputFilter
 import android.text.Spanned
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
@@ -467,7 +467,7 @@ class SaveExternalFilesActivity : BaseActivity() {
     private fun store(uri: Uri, fileName: String?, userId: Int, driveId: Int, folderId: Int): Boolean {
         contentResolver.query(uri, null, null, null, null)?.use { cursor ->
             if (cursor.moveToFirst()) {
-                val lastModifiedDateFromUri = intent.getLongExtra(MediaColumns.DATE_MODIFIED, -1L)
+                val lastModifiedDateFromUri = intent.getLongExtra(FileColumns.DATE_MODIFIED, -1L)
                 val (fileCreatedAt, fileModifiedAt) = SyncUtils.getFileDates(cursor, lastModifiedDateFromUri)
 
                 try {

--- a/app/src/main/java/com/infomaniak/drive/utils/SyncUtils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/SyncUtils.kt
@@ -45,7 +45,7 @@ object SyncUtils {
 
     private val TAG = SyncUtils::class.java.simpleName
 
-    fun getFileDates(cursor: Cursor): Pair<Date?, Date> {
+    fun getFileDates(cursor: Cursor, lastModifiedDateFromUri : Long? = null): Pair<Date?, Date> {
         val dateTakenIndex = cursor.getColumnIndex(DATE_TAKEN)
         val dateAddedIndex = cursor.getColumnIndex(MediaStore.MediaColumns.DATE_ADDED)
 
@@ -55,6 +55,7 @@ object SyncUtils {
         val fileCreatedAt = when {
             cursor.isValidDate(dateTakenIndex) -> Date(cursor.getLong(dateTakenIndex))
             cursor.isValidDate(dateAddedIndex) -> Date(cursor.getLong(dateAddedIndex) * 1000)
+            lastModifiedDateFromUri.isValidDate() -> Date(lastModifiedDateFromUri!!)
             else -> null
         }
 
@@ -74,6 +75,8 @@ object SyncUtils {
     }
 
     private fun Cursor.isValidDate(index: Int) = index != -1 && this.getLong(index) > 0
+
+    private fun Long?.isValidDate() = this != null && this > 0
 
     fun FragmentActivity.launchAllUpload(drivePermissions: DrivePermissions) {
         if (AccountUtils.isEnableAppSync() &&


### PR DESCRIPTION
Before the date wasn't in the URI when coming from kMail, the date corresponds to when the file has been set in cache on kMail.

Depends on https://github.com/Infomaniak/android-kMail/pull/1931