### PR TITLE
Use showProgressCatching() and hideProgressCatching() to avoid crashes

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -269,7 +269,7 @@ class SaveExternalFilesActivity : BaseActivity() {
         binding.saveButton.apply {
             initProgress(this@SaveExternalFilesActivity)
             setOnClickListener {
-                showProgress()
+                showProgressCatching()
                 if (drivePermissions.checkSyncPermissions()) {
                     val userId = selectedUserId.value!!
                     val driveId = selectedDrive.value?.id!!
@@ -283,7 +283,7 @@ class SaveExternalFilesActivity : BaseActivity() {
                             finish()
                         } else {
                             withContext(Dispatchers.Main) {
-                                hideProgress(R.string.buttonSave)
+                                hideProgressCatching(R.string.buttonSave)
                                 showSnackbar(R.string.errorSave)
                             }
                         }

--- a/app/src/main/java/com/infomaniak/drive/ui/addFiles/CreateCommonFolderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/addFiles/CreateCommonFolderFragment.kt
@@ -34,9 +34,9 @@ import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.showSnackbar
 import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.lib.core.utils.hideKeyboard
-import com.infomaniak.lib.core.utils.hideProgress
+import com.infomaniak.lib.core.utils.hideProgressCatching
 import com.infomaniak.lib.core.utils.safeNavigate
-import com.infomaniak.lib.core.utils.showProgress
+import com.infomaniak.lib.core.utils.showProgressCatching
 
 class CreateCommonFolderFragment : CreateFolderFragment() {
 
@@ -65,7 +65,7 @@ class CreateCommonFolderFragment : CreateFolderFragment() {
 
     private fun createCommonFolder() = with(binding) {
         folderNameValueInput.hideKeyboard()
-        createFolderButton.showProgress()
+        createFolderButton.showProgressCatching()
         trackNewElementEvent("createCommonFolder")
 
         newFolderViewModel.createCommonFolder(
@@ -81,7 +81,7 @@ class CreateCommonFolderFragment : CreateFolderFragment() {
                 showSnackbar(apiResponse.translateError())
             }
 
-            createFolderButton.hideProgress(R.string.createFolderTitle)
+            createFolderButton.hideProgressCatching(R.string.createFolderTitle)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/addFiles/CreateFolderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/addFiles/CreateFolderFragment.kt
@@ -41,9 +41,9 @@ import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.showSnackbar
 import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.lib.core.utils.hideKeyboard
-import com.infomaniak.lib.core.utils.hideProgress
+import com.infomaniak.lib.core.utils.hideProgressCatching
 import com.infomaniak.lib.core.utils.initProgress
-import com.infomaniak.lib.core.utils.showProgress
+import com.infomaniak.lib.core.utils.showProgressCatching
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 
@@ -129,7 +129,7 @@ open class CreateFolderFragment : Fragment() {
         onFolderCreated: (file: File?, redirectToShareDetails: Boolean) -> Unit,
     ) = with(binding) {
         folderNameValueInput.hideKeyboard()
-        createFolderButton.showProgress()
+        createFolderButton.showProgressCatching()
         newFolderViewModel.currentFolderId.value?.let { parentId ->
             newFolderViewModel.createFolder(
                 folderNameValueInput.text.toString().trim(),
@@ -145,7 +145,7 @@ open class CreateFolderFragment : Fragment() {
                     }
                     showSnackbar(apiResponse.translateError())
                 }
-                createFolderButton.hideProgress(R.string.createFolderTitle)
+                createFolderButton.hideProgressCatching(R.string.createFolderTitle)
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/AccessDeniedBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/AccessDeniedBottomSheetDialog.kt
@@ -57,7 +57,7 @@ class AccessDeniedBottomSheetDialog : InformationBottomSheetDialog() {
                 setText(R.string.buttonConfirmNotify)
                 setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.red_error))
                 setOnClickListener {
-                    showProgress()
+                    showProgressCatching()
                     informationBottomSheetViewModel.forceFolderAccess(navigationArgs.folderId)
                         .observe(viewLifecycleOwner) { apiResponse ->
                             if (apiResponse.data == null) {
@@ -67,7 +67,7 @@ class AccessDeniedBottomSheetDialog : InformationBottomSheetDialog() {
                                     if (hasAccess) navigateToTargetFolder() else closeAndShowRightError()
                                 }
                             }
-                            hideProgress(R.string.buttonConfirmNotify)
+                            hideProgressCatching(R.string.buttonConfirmNotify)
                         }
                 }
             }

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/NotSupportedExtensionBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/NotSupportedExtensionBottomSheetDialog.kt
@@ -29,7 +29,7 @@ import com.infomaniak.drive.utils.showSnackbar
 import com.infomaniak.lib.core.models.ApiResponseStatus
 import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
 import com.infomaniak.lib.core.utils.initProgress
-import com.infomaniak.lib.core.utils.showProgress
+import com.infomaniak.lib.core.utils.showProgressCatching
 import com.infomaniak.lib.core.utils.toPx
 
 class NotSupportedExtensionBottomSheetDialog : InformationBottomSheetDialog() {
@@ -63,7 +63,7 @@ class NotSupportedExtensionBottomSheetDialog : InformationBottomSheetDialog() {
                 initProgress(this@NotSupportedExtensionBottomSheetDialog)
                 text = getString(R.string.buttonCreateOnlyOfficeCopy, currentFile.conversion?.onlyofficeExtension)
                 setOnClickListener {
-                    showProgress()
+                    showProgressCatching()
                     mainViewModel.convertFile(currentFile).observe(viewLifecycleOwner) { apiResponse ->
                         when (apiResponse?.result) {
                             ApiResponseStatus.SUCCESS -> apiResponse.data?.let { newFile ->

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/SelectPermissionBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/SelectPermissionBottomSheetDialog.kt
@@ -151,7 +151,7 @@ class SelectPermissionBottomSheetDialog : FullScreenBottomSheetDialog() {
 
     private fun updateShareLinkOfficePermission(file: File, permission: Permission?) = with(binding) {
         saveButton.initProgress(viewLifecycleOwner)
-        saveButton.showProgress()
+        saveButton.showProgressCatching()
         selectPermissionViewModel.editFileShareLinkOfficePermission(
             file, canEdit = (permission as EditPermission).apiValue
         ).observe(viewLifecycleOwner) { apiResponse ->
@@ -162,7 +162,7 @@ class SelectPermissionBottomSheetDialog : FullScreenBottomSheetDialog() {
 
     private fun updatePermission(file: File, shareableItem: Shareable?, permission: ShareablePermission? = null) = with(binding) {
         saveButton.initProgress(viewLifecycleOwner)
-        saveButton.showProgress()
+        saveButton.showProgressCatching()
         shareableItem?.let { shareable ->
             if (permission == ShareablePermission.DELETE || permission == null) {
                 trackShareRightsEvent("deleteUser")
@@ -199,7 +199,7 @@ class SelectPermissionBottomSheetDialog : FullScreenBottomSheetDialog() {
         } else {
             SnackbarUtils.showSnackbar(requireView(), errorMessage)
         }
-        binding.saveButton.hideProgress(R.string.buttonSave)
+        binding.saveButton.hideProgressCatching(R.string.buttonSave)
     }
 
     internal class SelectPermissionViewModel : ViewModel() {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/ConvertToDropBoxFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/ConvertToDropBoxFragment.kt
@@ -27,9 +27,9 @@ import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.utils.Utils
 import com.infomaniak.drive.utils.showSnackbar
 import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
-import com.infomaniak.lib.core.utils.hideProgress
+import com.infomaniak.lib.core.utils.hideProgressCatching
 import com.infomaniak.lib.core.utils.initProgress
-import com.infomaniak.lib.core.utils.showProgress
+import com.infomaniak.lib.core.utils.showProgressCatching
 
 class ConvertToDropBoxFragment : ManageDropboxFragment() {
 
@@ -58,7 +58,7 @@ class ConvertToDropBoxFragment : ManageDropboxFragment() {
                     } else {
                         null
                     }
-                    saveButton.showProgress()
+                    saveButton.showProgressCatching()
                     mainViewModel.createDropBoxFolder(
                         file = file,
                         emailWhenFinished = emailWhenFinishedSwitch.isChecked,
@@ -72,7 +72,7 @@ class ConvertToDropBoxFragment : ManageDropboxFragment() {
                         } else {
                             showSnackbar(apiResponse.translateError())
                         }
-                        saveButton.hideProgress(R.string.buttonSave)
+                        saveButton.hideProgressCatching(R.string.buttonSave)
                     }
                 }
             }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -129,7 +129,7 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
 
     private val selectAllTimer: CountDownTimer by lazy {
         createRefreshTimer {
-            multiSelectLayout?.selectAllButton?.showProgress(ContextCompat.getColor(requireContext(), R.color.primary))
+            multiSelectLayout?.selectAllButton?.showProgressCatching(ContextCompat.getColor(requireContext(), R.color.primary))
         }
     }
 
@@ -648,7 +648,7 @@ open class FileListFragment : MultiSelectFragment(MATOMO_CATEGORY), SwipeRefresh
                 if (isSelectAllOn && exceptedItemsIds.isEmpty()) R.string.buttonDeselectAll else R.string.buttonSelectAll
             }
 
-            if (isClickable) setText(textId) else hideProgress(textId)
+            if (isClickable) setText(textId) else hideProgressCatching(textId)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/ManageDropboxFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/ManageDropboxFragment.kt
@@ -43,10 +43,10 @@ import com.infomaniak.drive.utils.showOrHideEmptyError
 import com.infomaniak.drive.utils.showSnackbar
 import com.infomaniak.lib.core.MatomoCore.TrackerAction
 import com.infomaniak.lib.core.utils.ApiErrorCode.Companion.translateError
-import com.infomaniak.lib.core.utils.hideProgress
+import com.infomaniak.lib.core.utils.hideProgressCatching
 import com.infomaniak.lib.core.utils.initProgress
 import com.infomaniak.lib.core.utils.safeBinding
-import com.infomaniak.lib.core.utils.showProgress
+import com.infomaniak.lib.core.utils.showProgressCatching
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import java.util.Date
@@ -171,14 +171,14 @@ open class ManageDropboxFragment : Fragment() {
             initProgress(this@ManageDropboxFragment)
             setOnClickListener {
                 trackDropboxEvent("convertToFolder")
-                showProgress(ContextCompat.getColor(requireContext(), R.color.title))
+                showProgressCatching(ContextCompat.getColor(requireContext(), R.color.title))
                 mainViewModel.deleteDropBox(file).observe(viewLifecycleOwner) { apiResponse ->
                     if (apiResponse.isSuccess()) {
                         findNavController().popBackStack()
                     } else {
                         showSnackbar(R.string.errorDelete)
                     }
-                    hideProgress(R.string.buttonDisableDropBox)
+                    hideProgressCatching(R.string.buttonDisableDropBox)
                 }
             }
         }
@@ -196,14 +196,14 @@ open class ManageDropboxFragment : Fragment() {
                     null
                 }
                 currentDropBox?.let {
-                    showProgress()
+                    showProgressCatching()
                     mainViewModel.updateDropBox(file, it).observe(viewLifecycleOwner) { apiResponse ->
                         if (apiResponse.isSuccess()) {
                             findNavController().popBackStack()
                         } else {
                             showSnackbar(R.string.errorModification)
                         }
-                        hideProgress(R.string.buttonSave)
+                        hideProgressCatching(R.string.buttonSave)
                     }
                 }
             }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/CreateOrEditCategoryFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/CreateOrEditCategoryFragment.kt
@@ -97,7 +97,7 @@ class CreateOrEditCategoryFragment : Fragment() {
             initProgress(this@CreateOrEditCategoryFragment)
             isEnabled = categoryIsPredefined || !isCreateCategory || categoryName.isNotEmpty()
             setOnClickListener {
-                showProgress()
+                showProgressCatching()
                 if (categoryId == CREATE_CATEGORY_ID) {
                     trackCategoriesEvent("add")
                     createCategory()
@@ -133,7 +133,7 @@ class CreateOrEditCategoryFragment : Fragment() {
                 if (isSuccess()) {
                     data?.id?.let(::addCategory)
                 } else {
-                    saveButton.hideProgress(R.string.buttonSave)
+                    saveButton.hideProgressCatching(R.string.buttonSave)
                     SnackbarUtils.showSnackbar(requireView(), translateError())
                 }
             }
@@ -150,7 +150,7 @@ class CreateOrEditCategoryFragment : Fragment() {
                 if (isSuccess()) {
                     findNavController().popBackStack()
                 } else {
-                    binding.saveButton.hideProgress(R.string.buttonSave)
+                    binding.saveButton.hideProgressCatching(R.string.buttonSave)
                     SnackbarUtils.showSnackbar(requireView(), translateError())
                 }
             }
@@ -167,7 +167,7 @@ class CreateOrEditCategoryFragment : Fragment() {
                 if (isSuccess()) {
                     findNavController().popBackStack()
                 } else {
-                    saveButton.hideProgress(R.string.buttonSave)
+                    saveButton.hideProgressCatching(R.string.buttonSave)
                     SnackbarUtils.showSnackbar(requireView(), translateError())
                 }
             }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareAddUserDialog.kt
@@ -111,7 +111,7 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
         shareButton.apply {
             initProgress(this@FileShareAddUserDialog)
             setOnClickListener {
-                showProgress()
+                showProgressCatching()
                 trackShareRightsEvent("inviteUser")
                 checkShare(selectedPermission) { file, body ->
                     createShareAndCloseDialog(file, body)
@@ -200,7 +200,7 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
             } else {
                 SnackbarUtils.showSnackbar(requireView(), apiResponse.translateError())
             }
-            binding.shareButton.hideProgress(R.string.buttonShare)
+            binding.shareButton.hideProgressCatching(R.string.buttonShare)
         }
     }
 
@@ -231,7 +231,7 @@ class FileShareAddUserDialog : FullScreenBottomSheetDialog() {
                     }
                 } else {
                     SnackbarUtils.showSnackbar(requireView(), apiResponse.translateError())
-                    shareButton.hideProgress(R.string.buttonShare)
+                    shareButton.hideProgressCatching(R.string.buttonShare)
                 }
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareLinkSettingsFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareLinkSettingsFragment.kt
@@ -135,7 +135,7 @@ class FileShareLinkSettingsFragment : Fragment() {
         saveButton.apply {
             initProgress(this@FileShareLinkSettingsFragment)
             setOnClickListener {
-                showProgress()
+                showProgressCatching()
                 trackShareRightsEvents(
                     protectWithPassword = addPasswordSwitch.isChecked,
                     expirationDate = addExpirationDateSwitch.isChecked,
@@ -143,7 +143,7 @@ class FileShareLinkSettingsFragment : Fragment() {
                 )
                 val isValid = checkPasswordStatus()
                 if (!isValid) {
-                    hideProgress(R.string.buttonSave)
+                    hideProgressCatching(R.string.buttonSave)
                 } else {
                     val file = File(id = navigationArgs.fileId, driveId = navigationArgs.driveId)
                     shareViewModel.editFileShareLink(file, shareLink).observe(viewLifecycleOwner) { apiResponse ->
@@ -152,7 +152,7 @@ class FileShareLinkSettingsFragment : Fragment() {
                         } else {
                             showSnackbar(R.string.errorModification)
                         }
-                        saveButton.hideProgress(R.string.buttonSave)
+                        saveButton.hideProgressCatching(R.string.buttonSave)
                     }
                 }
             }

--- a/app/src/main/java/com/infomaniak/drive/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/login/LoginActivity.kt
@@ -76,7 +76,7 @@ class LoginActivity : AppCompatActivity() {
                     else -> showError(getString(R.string.anErrorHasOccurred))
                 }
             } else {
-                binding.connectButton.hideProgress(R.string.connect)
+                binding.connectButton.hideProgressCatching(R.string.connect)
                 binding.signInButton.isEnabled = true
             }
         }
@@ -112,7 +112,7 @@ class LoginActivity : AppCompatActivity() {
             initProgress(this@LoginActivity)
             setOnClickListener {
                 signInButton.isEnabled = false
-                showProgress()
+                showProgressCatching()
                 trackAccountEvent("openLoginWebview")
                 infomaniakLogin.startWebViewLogin(webViewLoginResultLauncher)
             }
@@ -188,7 +188,7 @@ class LoginActivity : AppCompatActivity() {
 
     private fun showError(error: String) = with(binding) {
         showSnackbar(error)
-        connectButton.hideProgress(R.string.connect)
+        connectButton.hideProgressCatching(R.string.connect)
         signInButton.isEnabled = true
         if (!connectButton.isEnabled) connectButton.isEnabled = true
     }
@@ -199,7 +199,7 @@ class LoginActivity : AppCompatActivity() {
 
     private fun launchNoDriveActivity() = with(binding) {
         Intent(this@LoginActivity, NoDriveActivity::class.java).apply { startActivity(this) }
-        connectButton.hideProgress(R.string.connect)
+        connectButton.hideProgressCatching(R.string.connect)
         signInButton.isEnabled = true
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
@@ -345,7 +345,7 @@ class SyncSettingsActivity : BaseActivity() {
     }
 
     private fun saveSettings() = with(binding) {
-        saveButton.showProgress()
+        saveButton.showProgressCatching()
         lifecycleScope.launch(Dispatchers.IO) {
             val date = when (syncSettingsViewModel.saveOldPictures.value!!) {
                 SavePicturesDate.SINCE_NOW -> Date()


### PR DESCRIPTION
The methods showProgress() and hideProgress() keep crashing on many occasions despite our best efforts to do things correctly. This PR uses showProgressCatching() and showProgressCatching() to avoid crashing

Depends on https://github.com/Infomaniak/android-core/pull/201