### PR TITLE
Avoid filling up save state bundle endlessly because of the ViewPager2

### DIFF
--- a/app/src/main/res/layout/fragment_preview_slider.xml
+++ b/app/src/main/res/layout/fragment_preview_slider.xml
@@ -30,10 +30,13 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <!-- Setting saveEnabled to false prevents the ViewPager2 from filling up endlessly the save state bundle, as the user
+        scrolls through the view pager, up to the point where it crashes the app -->
         <androidx.viewpager2.widget.ViewPager2
             android:id="@+id/viewPager"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            android:saveEnabled="false" />
 
         <com.infomaniak.drive.views.PreviewHeaderView
             android:id="@+id/header"


### PR DESCRIPTION
As you scroll the preview viewpager a lot, the bundle that stores its state for when the view is recreated due to a configuration change increases endlessly. At some point the bundle can become too large and trigger a TransactionTooLargeException. 

To avoid this, we can ask the ViewPager2 to not save its state for recreation and instead start over from a blank slate. This apparently doesn't remove any feature in our case and seems to be fixing the issue

