### PR TITLE
Add lost default visibility of bottom sheet items

### DIFF
--- a/app/src/main/res/layout/fragment_bottom_sheet_multi_select_actions.xml
+++ b/app/src/main/res/layout/fragment_bottom_sheet_multi_select_actions.xml
@@ -28,8 +28,10 @@
         android:id="@+id/manageCategories"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:visibility="gone"
         app:icon="@drawable/ic_category"
-        app:text="@string/manageCategoriesTitle" />
+        app:text="@string/manageCategoriesTitle"
+        tools:visibility="visible" />
 
     <com.infomaniak.drive.views.BottomSheetItemView
         android:id="@+id/addFavorites"
@@ -43,8 +45,10 @@
         android:id="@+id/coloredFolder"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:visibility="gone"
         app:icon="@drawable/ic_color_bucket"
-        app:text="@string/buttonChangeFolderColor" />
+        app:text="@string/buttonChangeFolderColor"
+        tools:visibility="visible" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/availableOffline"

--- a/app/src/main/res/layout/view_file_info_actions.xml
+++ b/app/src/main/res/layout/view_file_info_actions.xml
@@ -299,8 +299,10 @@
                 android:id="@+id/manageCategories"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:visibility="gone"
                 app:icon="@drawable/ic_category"
-                app:text="@string/manageCategoriesTitle" />
+                app:text="@string/manageCategoriesTitle"
+                tools:visibility="visible" />
 
             <com.infomaniak.drive.views.BottomSheetItemView
                 android:id="@+id/addFavorites"
@@ -438,8 +440,10 @@
                 android:id="@+id/leaveShare"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:visibility="gone"
                 app:icon="@drawable/ic_link_broken"
-                app:text="@string/buttonLeaveShare" />
+                app:text="@string/buttonLeaveShare"
+                tools:visibility="visible" />
 
             <com.infomaniak.drive.views.BottomSheetItemView
                 android:id="@+id/deleteFile"
@@ -452,9 +456,11 @@
                 android:id="@+id/cancelExternalImport"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:visibility="gone"
                 app:icon="@drawable/ic_remove"
                 app:iconTint="@color/red_error"
-                app:text="@string/buttonCancelImport" />
+                app:text="@string/buttonCancelImport"
+                tools:visibility="visible" />
 
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/view_file_info_actions.xml
+++ b/app/src/main/res/layout/view_file_info_actions.xml
@@ -314,8 +314,10 @@
                 android:id="@+id/coloredFolder"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:visibility="gone"
                 app:icon="@drawable/ic_color_bucket"
-                app:text="@string/buttonChangeFolderColor" />
+                app:text="@string/buttonChangeFolderColor"
+                tools:visibility="visible" />
 
             <com.infomaniak.drive.views.BottomSheetItemView
                 android:id="@+id/dropBox"
@@ -398,11 +400,11 @@
                 android:id="@+id/print"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:visibility="gone"
                 app:icon="@drawable/ic_print"
                 app:iconTint="@color/iconColor"
                 app:text="@string/actionPrint"
-                android:visibility="gone"
-                tools:visibility="visible"/>
+                tools:visibility="visible" />
 
             <com.infomaniak.drive.views.BottomSheetItemView
                 android:id="@+id/downloadFile"


### PR DESCRIPTION
#1245 removed by mistake some visibility `gone` inside the xml during the refactor. This PR adds them back because they're still needed for the rest of the code to work properly. This PR englobes #1370 which was missing some fixes