### PR TITLE
Stop capturing mqtt connection lost errors to sentry

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/services/MqttClientWrapper.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/services/MqttClientWrapper.kt
@@ -145,7 +145,7 @@ object MqttClientWrapper : MqttCallback, LiveData<MqttNotification>() {
     }
 
     override fun connectionLost(cause: Throwable?) {
-        SentryLog.e("MQTT Error", "Connection has been lost. Stacktrace below.")
+        SentryLog.i("MQTT Error", "Connection has been lost. Stacktrace below.")
         cause?.printStackTrace()
     }
 

--- a/app/src/main/java/com/infomaniak/drive/data/services/MqttClientWrapper.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/services/MqttClientWrapper.kt
@@ -145,7 +145,7 @@ object MqttClientWrapper : MqttCallback, LiveData<MqttNotification>() {
     }
 
     override fun connectionLost(cause: Throwable?) {
-        SentryLog.i("MQTT Error", "Connection has been lost. Stacktrace below.")
+        SentryLog.i("MQTT Error", "Connection has been lost. Stacktrace below.", cause)
         cause?.printStackTrace()
     }
 


### PR DESCRIPTION
This line was a simple Android log until we introduced SentryLog where it became an exception that got captured. But this case looks very common, no need to spam Sentry with this. This PR stops capturing it into Sentry and only adds it as a breadcrumb like the other mqtt logs.