### PR TITLE
fix: Don't select a sharedWithMe as main drive

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
@@ -220,7 +220,7 @@ class MainActivity : BaseActivity() {
         navigationArgs?.let {
             if (it.destinationFileId > 0) {
                 clickOnBottomBarFolders()
-                mainViewModel.navigateFileListTo(navController, it.destinationFileId)
+                mainViewModel.navigateFileListTo(navController, it.destinationFileId, it.isDestinationSharedWithMe)
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -167,7 +167,7 @@ class MainViewModel(
         }
     }
 
-    fun navigateFileListTo(navController: NavController, fileId: Int) {
+    fun navigateFileListTo(navController: NavController, fileId: Int, isSharedWithMe: Boolean = false) {
         // Clear FileListFragment stack
         navController.popBackStack(R.id.rootFilesFragment, false)
 
@@ -175,7 +175,10 @@ class MainViewModel(
 
         // Emit destination folder id
         viewModelScope.launch(Dispatchers.IO) {
-            val file = FileController.getFileById(fileId) ?: FileController.getFileDetails(fileId) ?: return@launch
+            val userDrive = UserDrive(sharedWithMe = isSharedWithMe)
+            val file = FileController.getFileById(fileId, userDrive)
+                ?: FileController.getFileDetails(fileId, userDrive)
+                ?: return@launch
             navigateFileListTo.postValue(file)
         }
     }

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -327,6 +327,10 @@
             android:defaultValue="0"
             app:argType="integer" />
         <argument
+            android:name="isDestinationSharedWithMe"
+            android:defaultValue="false"
+            app:argType="boolean" />
+        <argument
             android:name="shortcutId"
             android:defaultValue=""
             app:argType="string" />


### PR DESCRIPTION
**Description**
When deeplinking a `SharedWithMe`, it is selected as the main drive when it shouldn't be.

**Fix**
Now, when deeplinking a sharedWithMe, the deeplink is still performed without selecting the drive.