### PR TITLE
05 Add file action bottom sheet

### DIFF
--- a/.idea/navEditor.xml
+++ b/.idea/navEditor.xml
@@ -407,6 +407,18 @@
                       </LayoutPositions>
                     </value>
                   </entry>
+                  <entry key="downloadProgressDialog">
+                    <value>
+                      <LayoutPositions>
+                        <option name="myPosition">
+                          <Point>
+                            <option name="x" value="12" />
+                            <option name="y" value="12" />
+                          </Point>
+                        </option>
+                      </LayoutPositions>
+                    </value>
+                  </entry>
                   <entry key="driveBlockedBottomSheetFragment">
                     <value>
                       <LayoutPositions>
@@ -894,18 +906,6 @@
                       </LayoutPositions>
                     </value>
                   </entry>
-                  <entry key="previewDownloadProgressDialog">
-                    <value>
-                      <LayoutPositions>
-                        <option name="myPosition">
-                          <Point>
-                            <option name="x" value="12" />
-                            <option name="y" value="12" />
-                          </Point>
-                        </option>
-                      </LayoutPositions>
-                    </value>
-                  </entry>
                   <entry key="previewFragment">
                     <value>
                       <LayoutPositions>
@@ -1340,6 +1340,154 @@
                           <Point>
                             <option name="x" value="3718" />
                             <option name="y" value="12" />
+                          </Point>
+                        </option>
+                      </LayoutPositions>
+                    </value>
+                  </entry>
+                </map>
+              </option>
+            </LayoutPositions>
+          </value>
+        </entry>
+        <entry key="public_share_navigation.xml">
+          <value>
+            <LayoutPositions>
+              <option name="myPositions">
+                <map>
+                  <entry key="previewDownloadProgressDialog">
+                    <value>
+                      <LayoutPositions>
+                        <option name="myPosition">
+                          <Point>
+                            <option name="x" value="520" />
+                            <option name="y" value="724" />
+                          </Point>
+                        </option>
+                      </LayoutPositions>
+                    </value>
+                  </entry>
+                  <entry key="previewFragment">
+                    <value>
+                      <LayoutPositions>
+                        <option name="myPosition">
+                          <Point>
+                            <option name="x" value="520" />
+                            <option name="y" value="368" />
+                          </Point>
+                        </option>
+                        <option name="myPositions">
+                          <map>
+                            <entry key="action_previewFragment_to_fileDetailsFragment">
+                              <value>
+                                <LayoutPositions />
+                              </value>
+                            </entry>
+                          </map>
+                        </option>
+                      </LayoutPositions>
+                    </value>
+                  </entry>
+                  <entry key="publicShareActivity">
+                    <value>
+                      <LayoutPositions>
+                        <option name="myPosition">
+                          <Point>
+                            <option name="x" value="12" />
+                            <option name="y" value="12" />
+                          </Point>
+                        </option>
+                      </LayoutPositions>
+                    </value>
+                  </entry>
+                  <entry key="publicShareListFragment">
+                    <value>
+                      <LayoutPositions>
+                        <option name="myPosition">
+                          <Point>
+                            <option name="x" value="32" />
+                            <option name="y" value="474" />
+                          </Point>
+                        </option>
+                        <option name="myPositions">
+                          <map>
+                            <entry key="action_publicShareListFragment_to_publicSharePreviewSliderFragment">
+                              <value>
+                                <LayoutPositions />
+                              </value>
+                            </entry>
+                            <entry key="action_publicShareListFragment_to_sortFilesBottomSheetDialog">
+                              <value>
+                                <LayoutPositions />
+                              </value>
+                            </entry>
+                            <entry key="publicShareListFragmentToPublicShareListFragment">
+                              <value>
+                                <LayoutPositions />
+                              </value>
+                            </entry>
+                          </map>
+                        </option>
+                      </LayoutPositions>
+                    </value>
+                  </entry>
+                  <entry key="publicSharePasswordFragment">
+                    <value>
+                      <LayoutPositions>
+                        <option name="myPosition">
+                          <Point>
+                            <option name="x" value="256" />
+                            <option name="y" value="12" />
+                          </Point>
+                        </option>
+                      </LayoutPositions>
+                    </value>
+                  </entry>
+                  <entry key="publicSharePreviewSliderFragment">
+                    <value>
+                      <LayoutPositions>
+                        <option name="myPosition">
+                          <Point>
+                            <option name="x" value="276" />
+                            <option name="y" value="410" />
+                          </Point>
+                        </option>
+                        <option name="myPositions">
+                          <map>
+                            <entry key="action_publicSharePreviewSliderFragment_to_downloadProgressDialog">
+                              <value>
+                                <LayoutPositions />
+                              </value>
+                            </entry>
+                            <entry key="action_publicSharePreviewSliderFragment_to_previewFragment">
+                              <value>
+                                <LayoutPositions />
+                              </value>
+                            </entry>
+                          </map>
+                        </option>
+                      </LayoutPositions>
+                    </value>
+                  </entry>
+                  <entry key="saveExternalFilesActivity">
+                    <value>
+                      <LayoutPositions>
+                        <option name="myPosition">
+                          <Point>
+                            <option name="x" value="500" />
+                            <option name="y" value="12" />
+                          </Point>
+                        </option>
+                      </LayoutPositions>
+                    </value>
+                  </entry>
+                  <entry key="sortFilesBottomSheetDialog">
+                    <value>
+                      <LayoutPositions>
+                        <option name="myPosition">
+                          <Point>
+                            <option name="x" value="276" />
+                            <option name="y" value="766" />
                           </Point>
                         </option>
                       </LayoutPositions>

--- a/.idea/navEditor.xml
+++ b/.idea/navEditor.xml
@@ -1376,19 +1376,22 @@
                             <option name="y" value="368" />
                           </Point>
                         </option>
-                        <option name="myPositions">
-                          <map>
-                            <entry key="action_previewFragment_to_fileDetailsFragment">
-                              <value>
-                                <LayoutPositions />
-                              </value>
-                            </entry>
-                          </map>
-                        </option>
                       </LayoutPositions>
                     </value>
                   </entry>
                   <entry key="publicShareActivity">
+                    <value>
+                      <LayoutPositions>
+                        <option name="myPosition">
+                          <Point>
+                            <option name="x" value="12" />
+                            <option name="y" value="12" />
+                          </Point>
+                        </option>
+                      </LayoutPositions>
+                    </value>
+                  </entry>
+                  <entry key="publicShareFileActionsBottomSheet">
                     <value>
                       <LayoutPositions>
                         <option name="myPosition">
@@ -1411,6 +1414,11 @@
                         </option>
                         <option name="myPositions">
                           <map>
+                            <entry key="action_publicShareListFragment_to_publicShareBottomSheetFileActions">
+                              <value>
+                                <LayoutPositions />
+                              </value>
+                            </entry>
                             <entry key="action_publicShareListFragment_to_publicSharePreviewSliderFragment">
                               <value>
                                 <LayoutPositions />

--- a/app/src/main/java/com/infomaniak/drive/data/models/File.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/File.kt
@@ -504,7 +504,7 @@ open class File(
 
     suspend fun convertToIOFile(
         context: Context,
-        userDrive: UserDrive,
+        userDrive: UserDrive = UserDrive(),
         shouldBePdf: Boolean = false,
         onProgress: (progress: Int) -> Unit,
         navigateToDownloadDialog: (suspend () -> Unit)? = null,

--- a/app/src/main/java/com/infomaniak/drive/ui/BasePreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/BasePreviewSliderFragment.kt
@@ -72,7 +72,7 @@ abstract class BasePreviewSliderFragment : Fragment(), FileInfoActionsView.OnIte
     override val currentContext by lazy { requireContext() }
     override lateinit var currentFile: File
 
-    var drivePermissions: DrivePermissions = DrivePermissions()
+    val drivePermissions: DrivePermissions = DrivePermissions()
     open val selectFolderResultLauncher = registerForActivityResult(StartActivityForResult()) {}
 
     val previewPDFHandler by lazy {

--- a/app/src/main/java/com/infomaniak/drive/ui/BasePreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/BasePreviewSliderFragment.kt
@@ -64,7 +64,6 @@ abstract class BasePreviewSliderFragment : Fragment(), FileInfoActionsView.OnIte
     protected abstract val bottomSheetView: View
     protected abstract val bottomSheetBehavior: BottomSheetBehavior<View>
 
-    protected lateinit var drivePermissions: DrivePermissions
     protected lateinit var previewSliderAdapter: PreviewSliderAdapter
     protected lateinit var userDrive: UserDrive
     protected abstract val isFileShare: Boolean
@@ -73,6 +72,7 @@ abstract class BasePreviewSliderFragment : Fragment(), FileInfoActionsView.OnIte
     override val currentContext by lazy { requireContext() }
     override lateinit var currentFile: File
 
+    var drivePermissions: DrivePermissions = DrivePermissions()
     open val selectFolderResultLauncher = registerForActivityResult(StartActivityForResult()) {}
 
     val previewPDFHandler by lazy {
@@ -92,8 +92,8 @@ abstract class BasePreviewSliderFragment : Fragment(), FileInfoActionsView.OnIte
 
         setBackActionHandlers()
 
-        drivePermissions = DrivePermissions().apply {
-            registerPermissions(this@BasePreviewSliderFragment) { authorized -> if (authorized) downloadFileClicked() }
+        drivePermissions.registerPermissions(this@BasePreviewSliderFragment) { authorized ->
+            if (authorized) downloadFileClicked()
         }
 
         header.apply {

--- a/app/src/main/java/com/infomaniak/drive/ui/BasePreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/BasePreviewSliderFragment.kt
@@ -72,6 +72,8 @@ abstract class BasePreviewSliderFragment : Fragment(), FileInfoActionsView.OnIte
     override val currentContext by lazy { requireContext() }
     override lateinit var currentFile: File
 
+    // This is not protected, otherwise it won't build because PublicSharePreviewSliderFragment needs it public for the interface
+    // it implements
     val drivePermissions: DrivePermissions = DrivePermissions()
     open val selectFolderResultLauncher = registerForActivityResult(StartActivityForResult()) {}
 

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
@@ -97,8 +97,7 @@ class FileInfoActionsBottomSheetDialog : BottomSheetDialogFragment(), FileInfoAc
                 isSharedWithMe = navigationArgs.userDrive.sharedWithMe,
             )
             updateCurrentFile(currentFile)
-
-            binding.fileInfoActionsView.setPrintVisibility(isGone = !currentFile.isPDF())
+            setPrintVisibility(isGone = !currentFile.isPDF())
         }
 
         setupBackActionHandler()

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/BaseDownloadProgressDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/BaseDownloadProgressDialog.kt
@@ -25,7 +25,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.NavArgs
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.infomaniak.drive.R
@@ -37,7 +36,6 @@ import kotlinx.coroutines.launch
 abstract class BaseDownloadProgressDialog : DialogFragment() {
 
     protected val binding: DialogDownloadProgressBinding by lazy { DialogDownloadProgressBinding.inflate(layoutInflater) }
-    abstract val navigationArgs: NavArgs
 
     abstract val dialogTitle: String
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/BaseDownloadProgressDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/BaseDownloadProgressDialog.kt
@@ -25,8 +25,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavArgs
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.infomaniak.drive.R
 import com.infomaniak.drive.databinding.DialogDownloadProgressBinding
@@ -37,13 +37,17 @@ import kotlinx.coroutines.launch
 abstract class BaseDownloadProgressDialog : DialogFragment() {
 
     protected val binding: DialogDownloadProgressBinding by lazy { DialogDownloadProgressBinding.inflate(layoutInflater) }
-    protected val navigationArgs: DownloadProgressDialogArgs by navArgs()
+    abstract val navigationArgs: NavArgs
+
+    abstract val dialogTitle: String
+
+    abstract fun observeDownloadedFile()
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         isCancelable = false
 
         return MaterialAlertDialogBuilder(requireContext(), R.style.DialogStyle)
-            .setTitle(navigationArgs.fileName)
+            .setTitle(dialogTitle)
             .setView(binding.root)
             .setOnKeyListener { _, keyCode, event ->
                 if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
@@ -62,8 +66,6 @@ abstract class BaseDownloadProgressDialog : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         observeDownloadedFile()
     }
-
-    abstract fun observeDownloadedFile()
 
     protected fun setProgress(progress: Int?, onProgressComplete: suspend () -> Unit) {
         progress?.let {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/DownloadProgressDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/DownloadProgressDialog.kt
@@ -28,7 +28,7 @@ import com.infomaniak.lib.core.utils.setBackNavigationResult
 class DownloadProgressDialog : BaseDownloadProgressDialog() {
 
     private val downloadProgressViewModel: DownloadProgressViewModel by viewModels()
-    override val navigationArgs: DownloadProgressDialogArgs by navArgs()
+    private val navigationArgs: DownloadProgressDialogArgs by navArgs()
 
     override val dialogTitle get() = navigationArgs.fileName
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/DownloadProgressDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/DownloadProgressDialog.kt
@@ -22,11 +22,15 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.*
+import androidx.navigation.fragment.navArgs
 import com.infomaniak.lib.core.utils.setBackNavigationResult
 
 class DownloadProgressDialog : BaseDownloadProgressDialog() {
 
     private val downloadProgressViewModel: DownloadProgressViewModel by viewModels()
+    override val navigationArgs: DownloadProgressDialogArgs by navArgs()
+
+    override val dialogTitle get() = navigationArgs.fileName
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog = with(navigationArgs) {
         downloadProgressViewModel.getLocalFile(fileId, userDrive)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewDownloadProgressDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewDownloadProgressDialog.kt
@@ -20,12 +20,16 @@ package com.infomaniak.drive.ui.fileList.preview
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.distinctUntilChanged
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.infomaniak.drive.ui.fileList.BaseDownloadProgressDialog
 import com.infomaniak.drive.ui.publicShare.PublicShareViewModel
 
 class PreviewDownloadProgressDialog : BaseDownloadProgressDialog() {
 
     private val publicShareViewModel: PublicShareViewModel by activityViewModels()
+    override val navigationArgs: PreviewDownloadProgressDialogArgs by navArgs()
+
+    override val dialogTitle get() = navigationArgs.fileName
 
     override fun observeDownloadedFile() {
         publicShareViewModel.downloadProgressLiveData.apply {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewDownloadProgressDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewDownloadProgressDialog.kt
@@ -27,7 +27,7 @@ import com.infomaniak.drive.ui.publicShare.PublicShareViewModel
 class PreviewDownloadProgressDialog : BaseDownloadProgressDialog() {
 
     private val publicShareViewModel: PublicShareViewModel by activityViewModels()
-    override val navigationArgs: PreviewDownloadProgressDialogArgs by navArgs()
+    private val navigationArgs: PreviewDownloadProgressDialogArgs by navArgs()
 
     override val dialogTitle get() = navigationArgs.fileName
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewDownloadProgressDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewDownloadProgressDialog.kt
@@ -21,13 +21,14 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.distinctUntilChanged
 import androidx.navigation.fragment.findNavController
 import com.infomaniak.drive.ui.fileList.BaseDownloadProgressDialog
+import com.infomaniak.drive.ui.publicShare.PublicShareViewModel
 
 class PreviewDownloadProgressDialog : BaseDownloadProgressDialog() {
 
-    private val previewSliderViewModel: PreviewSliderViewModel by activityViewModels()
+    private val publicShareViewModel: PublicShareViewModel by activityViewModels()
 
     override fun observeDownloadedFile() {
-        previewSliderViewModel.downloadProgressLiveData.apply {
+        publicShareViewModel.downloadProgressLiveData.apply {
             value = 0
             distinctUntilChanged().observe(viewLifecycleOwner) { progress ->
                 setProgress(progress = progress, onProgressComplete = findNavController()::popBackStack)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderViewModel.kt
@@ -17,60 +17,15 @@
  */
 package com.infomaniak.drive.ui.fileList.preview
 
-import android.content.Context
-import android.content.Intent
-import androidx.core.content.FileProvider
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.data.models.UserDrive
-import com.infomaniak.drive.ui.fileList.BaseDownloadProgressDialog.DownloadAction
-import com.infomaniak.drive.utils.Utils.openWith
-import com.infomaniak.drive.utils.printPdf
-import com.infomaniak.drive.utils.saveToKDrive
-import com.infomaniak.drive.utils.shareFile
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 class PreviewSliderViewModel : ViewModel() {
 
-    val downloadProgressLiveData = MutableLiveData(0)
     val pdfIsDownloading = MutableLiveData<Boolean>()
     var currentPreview: File? = null
     var userDrive = UserDrive()
     var publicShareUuid = ""
-
-    fun executeDownloadAction(
-        activityContext: Context,
-        downloadAction: DownloadAction,
-        navigateToDownloadDialog: suspend () -> Unit,
-        onDownloadError: () -> Unit,
-    ) = viewModelScope.launch(Dispatchers.IO) {
-        runCatching {
-            val cacheFile = currentPreview!!.convertToIOFile(
-                context = activityContext,
-                userDrive = userDrive,
-                onProgress = downloadProgressLiveData::postValue,
-                navigateToDownloadDialog = navigateToDownloadDialog,
-            )
-
-            val uri = FileProvider.getUriForFile(activityContext, activityContext.getString(R.string.FILE_AUTHORITY), cacheFile)
-
-            when (downloadAction) {
-                DownloadAction.OPEN_WITH -> {
-                    activityContext.openWith(uri, currentPreview!!.getMimeType(), Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                }
-                DownloadAction.SEND_COPY -> activityContext.shareFile { uri }
-                DownloadAction.SAVE_TO_DRIVE -> activityContext.saveToKDrive(uri)
-                DownloadAction.OPEN_BOOKMARK -> TODO()
-                DownloadAction.PRINT_PDF -> activityContext.printPdf(cacheFile)
-            }
-        }.onFailure { exception ->
-            downloadProgressLiveData.postValue(null)
-            exception.printStackTrace()
-            onDownloadError()
-        }
-    }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/OnPublicShareItemClickListener.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/OnPublicShareItemClickListener.kt
@@ -21,6 +21,7 @@ import androidx.annotation.StringRes
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.ui.fileList.BaseDownloadProgressDialog.DownloadAction
+import com.infomaniak.drive.ui.fileList.preview.PreviewDownloadProgressDialogArgs
 import com.infomaniak.drive.ui.fileList.preview.PreviewPDFHandler
 import com.infomaniak.drive.utils.DrivePermissions
 import com.infomaniak.drive.utils.IOFile
@@ -67,9 +68,10 @@ interface OnPublicShareItemClickListener : FileInfoActionsView.OnItemClickListen
     }
 
     private suspend fun navigateToDownloadDialog() = withContext(Dispatchers.Main) {
-        currentFile?.let {
+        currentFile?.let { file ->
             ownerFragment?.safeNavigate(
                 resId = R.id.previewDownloadProgressDialog,
+                args = PreviewDownloadProgressDialogArgs(file.name).toBundle(),
             )
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/OnPublicShareItemClickListener.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/OnPublicShareItemClickListener.kt
@@ -41,17 +41,11 @@ interface OnPublicShareItemClickListener : FileInfoActionsView.OnItemClickListen
     fun onDownloadSuccess()
     fun onDownloadError(@StringRes errorMessage: Int)
 
-    override fun openWith() {
-        executeActionAndClose(DownloadAction.OPEN_WITH)
-    }
+    override fun openWith() = executeActionAndClose(DownloadAction.OPEN_WITH)
 
-    override fun shareFile() {
-        executeActionAndClose(DownloadAction.SEND_COPY)
-    }
+    override fun shareFile() = executeActionAndClose(DownloadAction.SEND_COPY)
 
-    override fun saveToKDrive() {
-        executeActionAndClose(DownloadAction.SAVE_TO_DRIVE)
-    }
+    override fun saveToKDrive() = executeActionAndClose(DownloadAction.SAVE_TO_DRIVE)
 
     override fun downloadFileClicked() {
         super.downloadFileClicked()

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareFileActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareFileActionsBottomSheetDialog.kt
@@ -1,0 +1,140 @@
+/*
+ * Infomaniak kDrive - Android
+ * Copyright (C) 2024 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.drive.ui.publicShare
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.StringRes
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.infomaniak.drive.R
+import com.infomaniak.drive.data.models.File
+import com.infomaniak.drive.data.models.UserDrive
+import com.infomaniak.drive.databinding.FragmentBottomSheetPublicShareFileActionsBinding
+import com.infomaniak.drive.ui.fileList.BaseDownloadProgressDialog.DownloadAction
+import com.infomaniak.drive.ui.fileList.preview.PreviewDownloadProgressDialogArgs
+import com.infomaniak.drive.ui.fileList.preview.PreviewSliderViewModel
+import com.infomaniak.drive.utils.DrivePermissions
+import com.infomaniak.drive.utils.IOFile
+import com.infomaniak.drive.views.FileInfoActionsView
+import com.infomaniak.drive.views.FileInfoActionsView.OnItemClickListener.Companion.downloadFile
+import com.infomaniak.lib.core.utils.SnackbarUtils.showSnackbar
+import com.infomaniak.lib.core.utils.safeBinding
+import com.infomaniak.lib.core.utils.safeNavigate
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class PublicShareFileActionsBottomSheetDialog : BottomSheetDialogFragment(), FileInfoActionsView.OnItemClickListener {
+
+    private var binding: FragmentBottomSheetPublicShareFileActionsBinding by safeBinding()
+    private val previewSliderViewModel: PreviewSliderViewModel by activityViewModels()
+    private val publicShareViewModel: PublicShareViewModel by activityViewModels()
+
+    override val ownerFragment = this
+    override val currentContext by lazy { requireContext() }
+    override lateinit var currentFile: File
+
+    private val mainButton by lazy { (requireActivity() as PublicShareActivity).getMainButton() }
+    private val drivePermissions = DrivePermissions()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return FragmentBottomSheetPublicShareFileActionsBinding.inflate(inflater, container, false).also { binding = it }.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initBottomSheet()
+
+        drivePermissions.registerPermissions(this@PublicShareFileActionsBottomSheetDialog) { authorized ->
+            if (authorized) downloadFileClicked()
+        }
+    }
+
+    private fun setCurrentFile() {
+        currentFile = publicShareViewModel.fileClicked ?: run {
+            findNavController().popBackStack()
+            return
+        }
+    }
+
+    private fun initBottomSheet() = with(binding.publicShareFileActionsView) {
+        setCurrentFile()
+        updateWithExternalFile(currentFile)
+        initOnClickListener(onItemClickListener = this@PublicShareFileActionsBottomSheetDialog)
+    }
+
+    override fun openWith() {
+        executeActionAndClose(DownloadAction.OPEN_WITH)
+    }
+
+    override fun shareFile() {
+        executeActionAndClose(DownloadAction.SEND_COPY)
+    }
+
+    override fun saveToKDrive() {
+        executeActionAndClose(DownloadAction.SAVE_TO_DRIVE)
+    }
+
+    override fun downloadFileClicked() {
+        super.downloadFileClicked()
+        requireContext().downloadFile(drivePermissions, currentFile) { findNavController().popBackStack() }
+    }
+
+    override fun printClicked() {
+        super.printClicked()
+        executeActionAndClose(DownloadAction.PRINT_PDF, R.string.errorFileNotFound)
+    }
+
+    private suspend fun navigateToDownloadDialog() = withContext(Dispatchers.Main) {
+        safeNavigate(
+            R.id.previewDownloadProgressDialog,
+            PreviewDownloadProgressDialogArgs(
+                fileId = currentFile.id,
+                fileName = currentFile.name,
+                userDrive = UserDrive(),
+                action = DownloadAction.SAVE_TO_DRIVE,
+            ).toBundle(),
+        )
+    }
+
+    private fun executeActionAndClose(action: DownloadAction, @StringRes errorMessageId: Int = R.string.errorDownload) {
+        previewSliderViewModel.executeDownloadAction(
+            activityContext = requireContext(),
+            downloadAction = action,
+            navigateToDownloadDialog = ::navigateToDownloadDialog,
+            onDownloadError = { showSnackbar(errorMessageId, anchor = mainButton) },
+        )
+        findNavController().popBackStack()
+    }
+
+    override fun displayInfoClicked() = Unit
+    override fun fileRightsClicked() = Unit
+    override fun goToFolder() = Unit
+    override fun manageCategoriesClicked(fileId: Int) = Unit
+    override fun onCacheAddedToOffline() = Unit
+    override fun onDeleteFile(onApiResponse: () -> Unit) = Unit
+    override fun onLeaveShare(onApiResponse: () -> Unit) = Unit
+    override fun onDuplicateFile(destinationFolder: File) = Unit
+    override fun onMoveFile(destinationFolder: File) = Unit
+    override fun onRenameFile(newName: String, onApiResponse: () -> Unit) = Unit
+    override fun removeOfflineFile(offlineLocalPath: IOFile, cacheFile: IOFile) = Unit
+}

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareFileActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareFileActionsBottomSheetDialog.kt
@@ -76,5 +76,6 @@ class PublicShareFileActionsBottomSheetDialog : BottomSheetDialogFragment(), OnP
         updateWithExternalFile(currentFile)
         initOnClickListener(onItemClickListener = this@PublicShareFileActionsBottomSheetDialog)
         isPrintingHidden(isGone = currentFile.isPDF())
+        if (currentFile.isFolder()) displayFolderActions()
     }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareFileActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareFileActionsBottomSheetDialog.kt
@@ -125,6 +125,9 @@ class PublicShareFileActionsBottomSheetDialog : BottomSheetDialogFragment(), Fil
                 showSnackbar(errorMessageId, anchor = mainButton)
                 findNavController().popBackStack()
             },
+            onDownloadSuccess = {
+                findNavController().popBackStack(destinationId = R.id.publicShareListFragment, inclusive = false)
+            }
         )
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareFileActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareFileActionsBottomSheetDialog.kt
@@ -31,7 +31,6 @@ import com.infomaniak.drive.data.models.UserDrive
 import com.infomaniak.drive.databinding.FragmentBottomSheetPublicShareFileActionsBinding
 import com.infomaniak.drive.ui.fileList.BaseDownloadProgressDialog.DownloadAction
 import com.infomaniak.drive.ui.fileList.preview.PreviewDownloadProgressDialogArgs
-import com.infomaniak.drive.ui.fileList.preview.PreviewSliderViewModel
 import com.infomaniak.drive.utils.DrivePermissions
 import com.infomaniak.drive.utils.IOFile
 import com.infomaniak.drive.views.FileInfoActionsView
@@ -45,7 +44,6 @@ import kotlinx.coroutines.withContext
 class PublicShareFileActionsBottomSheetDialog : BottomSheetDialogFragment(), FileInfoActionsView.OnItemClickListener {
 
     private var binding: FragmentBottomSheetPublicShareFileActionsBinding by safeBinding()
-    private val previewSliderViewModel: PreviewSliderViewModel by activityViewModels()
     private val publicShareViewModel: PublicShareViewModel by activityViewModels()
 
     override val ownerFragment = this
@@ -80,6 +78,7 @@ class PublicShareFileActionsBottomSheetDialog : BottomSheetDialogFragment(), Fil
         setCurrentFile()
         updateWithExternalFile(currentFile)
         initOnClickListener(onItemClickListener = this@PublicShareFileActionsBottomSheetDialog)
+        isPrintingHidden(isGone = currentFile.isPDF())
     }
 
     override fun openWith() {
@@ -96,7 +95,7 @@ class PublicShareFileActionsBottomSheetDialog : BottomSheetDialogFragment(), Fil
 
     override fun downloadFileClicked() {
         super.downloadFileClicked()
-        requireContext().downloadFile(drivePermissions, currentFile) { findNavController().popBackStack() }
+        requireContext().downloadFile(drivePermissions, currentFile, findNavController()::popBackStack)
     }
 
     override fun printClicked() {
@@ -117,13 +116,16 @@ class PublicShareFileActionsBottomSheetDialog : BottomSheetDialogFragment(), Fil
     }
 
     private fun executeActionAndClose(action: DownloadAction, @StringRes errorMessageId: Int = R.string.errorDownload) {
-        previewSliderViewModel.executeDownloadAction(
+        publicShareViewModel.executeDownloadAction(
             activityContext = requireContext(),
             downloadAction = action,
+            file = currentFile,
             navigateToDownloadDialog = ::navigateToDownloadDialog,
-            onDownloadError = { showSnackbar(errorMessageId, anchor = mainButton) },
+            onDownloadError = {
+                showSnackbar(errorMessageId, anchor = mainButton)
+                findNavController().popBackStack()
+            },
         )
-        findNavController().popBackStack()
     }
 
     override fun displayInfoClicked() = Unit

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareFileActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareFileActionsBottomSheetDialog.kt
@@ -75,7 +75,7 @@ class PublicShareFileActionsBottomSheetDialog : BottomSheetDialogFragment(), OnP
         initCurrentFile()
         updateWithExternalFile(currentFile)
         initOnClickListener(onItemClickListener = this@PublicShareFileActionsBottomSheetDialog)
-        isPrintingHidden(isGone = currentFile.isPDF())
+        isPrintingHidden(isGone = true)
         if (currentFile.isFolder()) displayFolderActions()
     }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
@@ -46,6 +46,7 @@ import com.infomaniak.drive.utils.FilePresenter.openBookmark
 import com.infomaniak.drive.utils.FilePresenter.openFolder
 import com.infomaniak.drive.views.FileInfoActionsView.OnItemClickListener.Companion.downloadFile
 import com.infomaniak.lib.core.utils.SnackbarUtils.showSnackbar
+import com.infomaniak.lib.core.utils.safeNavigate
 import com.infomaniak.lib.core.utils.whenResultIsOk
 import com.infomaniak.lib.core.R as RCore
 
@@ -82,14 +83,21 @@ class PublicShareListFragment : FileListFragment() {
         setToolbarTitle(R.string.sharedWithMeTitle)
         binding.uploadFileInProgressView.isGone = true
 
-        fileAdapter.initAsyncListDiffer()
-        fileAdapter.onFileClicked = { file ->
-            if (file.isUsable()) {
-                publicShareViewModel.fileClicked = file
-                when {
-                    file.isFolder() -> openFolder(file)
-                    file.isBookmark() -> openBookmark(file)
-                    else -> displayFile(file, mainViewModel, fileAdapter, publicShareUuid = publicShareViewModel.publicShareUuid)
+        fileAdapter.apply {
+            initAsyncListDiffer()
+            onMenuClicked = { file ->
+                if (file.isUsable()) {
+                    publicShareViewModel.fileClicked = file
+                    safeNavigate(R.id.publicShareFileActionsBottomSheet)
+                }
+            }
+            onFileClicked = { file ->
+                if (file.isUsable()) {
+                    when {
+                        file.isFolder() -> openFolder(file)
+                        file.isBookmark() -> openBookmark(file)
+                        else -> displayFile(file, mainViewModel, fileAdapter, publicShareViewModel.publicShareUuid)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
@@ -85,6 +85,7 @@ class PublicShareListFragment : FileListFragment() {
         fileAdapter.initAsyncListDiffer()
         fileAdapter.onFileClicked = { file ->
             if (file.isUsable()) {
+                publicShareViewModel.fileClicked = file
                 when {
                     file.isFolder() -> openFolder(file)
                     file.isBookmark() -> openBookmark(file)

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicSharePreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicSharePreviewSliderFragment.kt
@@ -21,6 +21,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.StringRes
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -46,6 +47,7 @@ class PublicSharePreviewSliderFragment : BasePreviewSliderFragment(), FileInfoAc
 
     private val navigationArgs: PublicSharePreviewSliderFragmentArgs by navArgs()
     override val previewSliderViewModel: PreviewSliderViewModel by activityViewModels()
+    private val publicShareViewModel: PublicShareViewModel by activityViewModels()
 
     override val bottomSheetView: ExternalFileInfoActionsView
         get() = binding.publicShareBottomSheetFileActions
@@ -101,36 +103,31 @@ class PublicSharePreviewSliderFragment : BasePreviewSliderFragment(), FileInfoAc
         )
     }
 
+    private fun executeDownloadAction(action: DownloadAction, @StringRes errorMessage: Int = R.string.errorDownload) {
+        publicShareViewModel.executeDownloadAction(
+            activityContext = requireContext(),
+            downloadAction = action,
+            file = previewSliderViewModel.currentPreview,
+            navigateToDownloadDialog = ::navigateToDownloadDialog,
+            onDownloadError = { showSnackbar(errorMessage, anchor = bottomSheetView) },
+        )
+    }
+
     override fun displayInfoClicked() = Unit
     override fun fileRightsClicked() = Unit
     override fun goToFolder() = Unit
     override fun manageCategoriesClicked(fileId: Int) = Unit
 
     override fun openWith() {
-        previewSliderViewModel.executeDownloadAction(
-            activityContext = requireContext(),
-            downloadAction = DownloadAction.OPEN_WITH,
-            navigateToDownloadDialog = ::navigateToDownloadDialog,
-            onDownloadError = { showSnackbar(R.string.errorDownload, anchor = bottomSheetView) },
-        )
+        executeDownloadAction(DownloadAction.OPEN_WITH)
     }
 
     override fun shareFile() {
-        previewSliderViewModel.executeDownloadAction(
-            activityContext = requireContext(),
-            downloadAction = DownloadAction.SEND_COPY,
-            navigateToDownloadDialog = ::navigateToDownloadDialog,
-            onDownloadError = { showSnackbar(R.string.errorDownload, anchor = bottomSheetView) },
-        )
+        executeDownloadAction(DownloadAction.SEND_COPY)
     }
 
     override fun saveToKDrive() {
-        previewSliderViewModel.executeDownloadAction(
-            activityContext = requireContext(),
-            downloadAction = DownloadAction.SAVE_TO_DRIVE,
-            navigateToDownloadDialog = ::navigateToDownloadDialog,
-            onDownloadError = { showSnackbar(R.string.errorDownload, anchor = bottomSheetView) },
-        )
+        executeDownloadAction(DownloadAction.SAVE_TO_DRIVE)
     }
 
     override fun downloadFileClicked() {
@@ -142,15 +139,8 @@ class PublicSharePreviewSliderFragment : BasePreviewSliderFragment(), FileInfoAc
         super<BasePreviewSliderFragment>.printClicked()
         previewPDFHandler.printClicked(
             context = requireContext(),
-            onDefaultCase = {
-                previewSliderViewModel.executeDownloadAction(
-                    activityContext = requireContext(),
-                    downloadAction = DownloadAction.PRINT_PDF,
-                    navigateToDownloadDialog = ::navigateToDownloadDialog,
-                    onDownloadError = { showSnackbar(R.string.errorFileNotFound, anchor = bottomSheetView) },
-                )
-            },
-            onError = { showSnackbar(R.string.errorFileNotFound) },
+            onDefaultCase = { executeDownloadAction(DownloadAction.PRINT_PDF, R.string.errorFileNotFound) },
+            onError = { showSnackbar(R.string.errorFileNotFound, anchor = bottomSheetView) },
         )
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicSharePreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicSharePreviewSliderFragment.kt
@@ -110,6 +110,7 @@ class PublicSharePreviewSliderFragment : BasePreviewSliderFragment(), FileInfoAc
             file = previewSliderViewModel.currentPreview,
             navigateToDownloadDialog = ::navigateToDownloadDialog,
             onDownloadError = { showSnackbar(errorMessage, anchor = bottomSheetView) },
+            onDownloadSuccess = { toggleBottomSheet(shouldShow = true) }
         )
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicSharePreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicSharePreviewSliderFragment.kt
@@ -17,7 +17,6 @@
  */
 package com.infomaniak.drive.ui.publicShare
 
-import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -79,7 +78,6 @@ class PublicSharePreviewSliderFragment : BasePreviewSliderFragment(), FileInfoAc
         return FragmentPreviewSliderBinding.inflate(inflater, container, false).also { _binding = it }.root
     }
 
-    @SuppressLint("ClickableViewAccessibility")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareViewModel.kt
@@ -34,6 +34,7 @@ class PublicShareViewModel(val savedStateHandle: SavedStateHandle) : ViewModel()
 
     var rootSharedFile = SingleLiveEvent<File?>()
     val childrenLiveData = SingleLiveEvent<Pair<List<File>, Boolean>>()
+    var fileClicked: File? = null
 
     private val driveId: Int
         inline get() = savedStateHandle[PublicShareActivityArgs::driveId.name] ?: ROOT_SHARED_FILE_ID

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareViewModel.kt
@@ -131,6 +131,7 @@ class PublicShareViewModel(val savedStateHandle: SavedStateHandle) : ViewModel()
         file: File?,
         navigateToDownloadDialog: suspend () -> Unit,
         onDownloadError: () -> Unit,
+        onDownloadSuccess: () -> Unit,
     ) = viewModelScope.launch(Dispatchers.IO) {
         runCatching {
             val cacheFile = file!!.convertToIOFile(
@@ -150,6 +151,8 @@ class PublicShareViewModel(val savedStateHandle: SavedStateHandle) : ViewModel()
                 DownloadAction.OPEN_BOOKMARK -> TODO()
                 DownloadAction.PRINT_PDF -> activityContext.printPdf(cacheFile)
             }
+
+            withContext(Dispatchers.Main) { onDownloadSuccess() }
         }.onFailure { exception ->
             downloadProgressLiveData.postValue(null)
             exception.printStackTrace()

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareViewModel.kt
@@ -17,15 +17,25 @@
  */
 package com.infomaniak.drive.ui.publicShare
 
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.infomaniak.drive.R
 import com.infomaniak.drive.data.api.ApiRepository
 import com.infomaniak.drive.data.api.CursorApiResponse
 import com.infomaniak.drive.data.cache.FolderFilesProvider.FolderFilesProviderArgs
 import com.infomaniak.drive.data.cache.FolderFilesProvider.FolderFilesProviderResult
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.data.models.File.SortType
+import com.infomaniak.drive.ui.fileList.BaseDownloadProgressDialog.DownloadAction
+import com.infomaniak.drive.utils.Utils.openWith
+import com.infomaniak.drive.utils.printPdf
+import com.infomaniak.drive.utils.saveToKDrive
+import com.infomaniak.drive.utils.shareFile
 import com.infomaniak.lib.core.utils.SentryLog
 import com.infomaniak.lib.core.utils.SingleLiveEvent
 import kotlinx.coroutines.*
@@ -35,6 +45,7 @@ class PublicShareViewModel(val savedStateHandle: SavedStateHandle) : ViewModel()
     var rootSharedFile = SingleLiveEvent<File?>()
     val childrenLiveData = SingleLiveEvent<Pair<List<File>, Boolean>>()
     var fileClicked: File? = null
+    val downloadProgressLiveData = MutableLiveData(0)
 
     private val driveId: Int
         inline get() = savedStateHandle[PublicShareActivityArgs::driveId.name] ?: ROOT_SHARED_FILE_ID
@@ -112,6 +123,38 @@ class PublicShareViewModel(val savedStateHandle: SavedStateHandle) : ViewModel()
         )
 
         // TODO: Manage apiResponse when the backend will be done
+    }
+
+    fun executeDownloadAction(
+        activityContext: Context,
+        downloadAction: DownloadAction,
+        file: File?,
+        navigateToDownloadDialog: suspend () -> Unit,
+        onDownloadError: () -> Unit,
+    ) = viewModelScope.launch(Dispatchers.IO) {
+        runCatching {
+            val cacheFile = file!!.convertToIOFile(
+                context = activityContext,
+                onProgress = downloadProgressLiveData::postValue,
+                navigateToDownloadDialog = navigateToDownloadDialog,
+            )
+
+            val uri = FileProvider.getUriForFile(activityContext, activityContext.getString(R.string.FILE_AUTHORITY), cacheFile)
+
+            when (downloadAction) {
+                DownloadAction.OPEN_WITH -> {
+                    activityContext.openWith(uri, file.getMimeType(), Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                DownloadAction.SEND_COPY -> activityContext.shareFile { uri }
+                DownloadAction.SAVE_TO_DRIVE -> activityContext.saveToKDrive(uri)
+                DownloadAction.OPEN_BOOKMARK -> TODO()
+                DownloadAction.PRINT_PDF -> activityContext.printPdf(cacheFile)
+            }
+        }.onFailure { exception ->
+            downloadProgressLiveData.postValue(null)
+            exception.printStackTrace()
+            withContext(Dispatchers.Main) { onDownloadError() }
+        }
     }
 
     private fun loadFromRemote(folderFilesProviderArgs: FolderFilesProviderArgs): FolderFilesProviderResult? {

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareViewModel.kt
@@ -130,8 +130,8 @@ class PublicShareViewModel(val savedStateHandle: SavedStateHandle) : ViewModel()
         downloadAction: DownloadAction,
         file: File?,
         navigateToDownloadDialog: suspend () -> Unit,
-        onDownloadError: () -> Unit,
         onDownloadSuccess: () -> Unit,
+        onDownloadError: () -> Unit,
     ) = viewModelScope.launch(Dispatchers.IO) {
         runCatching {
             val cacheFile = file!!.convertToIOFile(

--- a/app/src/main/java/com/infomaniak/drive/views/ExternalFileInfoActionsView.kt
+++ b/app/src/main/java/com/infomaniak/drive/views/ExternalFileInfoActionsView.kt
@@ -22,6 +22,7 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
 import androidx.core.view.isGone
+import androidx.core.view.isVisible
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.databinding.ViewExternalFileInfoActionsBinding
 import com.infomaniak.drive.utils.AccountUtils
@@ -50,6 +51,15 @@ class ExternalFileInfoActionsView @JvmOverloads constructor(
 
     fun isDownloadHidden(isGone: Boolean) {
         binding.downloadFile.isGone = isGone
+    }
+
+    fun displayFolderActions() = with(binding) {
+        openWith.isGone = true
+        shareFile.isGone = true
+        saveToKDrive.isGone = true
+        print.isGone = true
+
+        downloadFile.isVisible = true
     }
 
     fun initOnClickListener(onItemClickListener: OnItemClickListener) = with(binding) {

--- a/app/src/main/res/layout/fragment_bottom_sheet_public_share_file_actions.xml
+++ b/app/src/main/res/layout/fragment_bottom_sheet_public_share_file_actions.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Infomaniak kDrive - Android
+  ~ Copyright (C) 2024 Infomaniak Network SA
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<com.infomaniak.drive.views.ExternalFileInfoActionsView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/publicShareFileActionsView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/layout/view_external_file_info_actions.xml
+++ b/app/src/main/res/layout/view_external_file_info_actions.xml
@@ -15,7 +15,6 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"

--- a/app/src/main/res/navigation/public_share_navigation.xml
+++ b/app/src/main/res/navigation/public_share_navigation.xml
@@ -137,5 +137,9 @@
         android:id="@+id/previewDownloadProgressDialog"
         android:name="com.infomaniak.drive.ui.fileList.preview.PreviewDownloadProgressDialog"
         android:label="PreviewDownloadProgressDialog"
-        tools:layout="@layout/dialog_download_progress" />
+        tools:layout="@layout/dialog_download_progress">
+        <argument
+            android:name="fileName"
+            app:argType="string" />
+    </dialog>
 </navigation>

--- a/app/src/main/res/navigation/public_share_navigation.xml
+++ b/app/src/main/res/navigation/public_share_navigation.xml
@@ -117,8 +117,7 @@
         android:id="@+id/publicShareFileActionsBottomSheet"
         android:name="com.infomaniak.drive.ui.publicShare.PublicShareFileActionsBottomSheetDialog"
         android:label="PublicShareFileActionsBottomSheet"
-        tools:layout="@layout/fragment_bottom_sheet_public_share_file_actions">
-    </dialog>
+        tools:layout="@layout/fragment_bottom_sheet_public_share_file_actions" />
 
     <dialog
         android:id="@+id/sortFilesBottomSheetDialog"
@@ -138,19 +137,5 @@
         android:id="@+id/previewDownloadProgressDialog"
         android:name="com.infomaniak.drive.ui.fileList.preview.PreviewDownloadProgressDialog"
         android:label="PreviewDownloadProgressDialog"
-        tools:layout="@layout/dialog_download_progress">
-        <argument
-            android:name="fileId"
-            app:argType="integer" />
-        <argument
-            android:name="fileName"
-            app:argType="string" />
-        <argument
-            android:name="userDrive"
-            app:argType="com.infomaniak.drive.data.models.UserDrive" />
-        <argument
-            android:name="action"
-            android:defaultValue="OPEN_WITH"
-            app:argType="com.infomaniak.drive.ui.fileList.BaseDownloadProgressDialog$DownloadAction" />
-    </dialog>
+        tools:layout="@layout/dialog_download_progress" />
 </navigation>

--- a/app/src/main/res/navigation/public_share_navigation.xml
+++ b/app/src/main/res/navigation/public_share_navigation.xml
@@ -66,6 +66,9 @@
         <action
             android:id="@+id/action_publicShareListFragment_to_publicSharePreviewSliderFragment"
             app:destination="@id/publicSharePreviewSliderFragment" />
+        <action
+            android:id="@+id/action_publicShareListFragment_to_publicShareBottomSheetFileActions"
+            app:destination="@id/publicShareBottomSheetFileActions" />
     </fragment>
 
     <fragment
@@ -108,10 +111,14 @@
             android:name="publicShareUuid"
             android:defaultValue=""
             app:argType="string" />
-        <action
-            android:id="@+id/action_previewFragment_to_fileDetailsFragment"
-            app:destination="@id/fileDetailsFragment" />
     </fragment>
+
+    <dialog
+        android:id="@+id/publicShareFileActionsBottomSheet"
+        android:name="com.infomaniak.drive.ui.publicShare.PublicShareFileActionsBottomSheetDialog"
+        android:label="PublicShareFileActionsBottomSheet"
+        tools:layout="@layout/fragment_bottom_sheet_public_share_file_actions">
+    </dialog>
 
     <dialog
         android:id="@+id/sortFilesBottomSheetDialog"


### PR DESCRIPTION
Depends on #1393 

- Add a `PublicShareFileActionsBottomSheet` to execute actions on file without having to go to the preview
- Create an interface `OnPublicShareItemClicked` inheriting from `OnItemClicked` to factorize file action from the preview and the bottomsheet