### PR TITLE
fix: SharedWithMe folder not always displayed

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
@@ -44,11 +44,14 @@ import com.infomaniak.drive.data.cache.FolderFilesProvider
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.data.models.UploadFile
 import com.infomaniak.drive.data.models.UserDrive
-import com.infomaniak.drive.utils.*
+import com.infomaniak.drive.utils.AccountUtils
+import com.infomaniak.drive.utils.DownloadOfflineFileManager
+import com.infomaniak.drive.utils.IOFile
 import com.infomaniak.drive.utils.NotificationUtils.buildGeneralNotification
 import com.infomaniak.drive.utils.NotificationUtils.cancelNotification
 import com.infomaniak.drive.utils.NotificationUtils.notifyCompat
 import com.infomaniak.drive.utils.SyncUtils.syncImmediately
+import com.infomaniak.drive.utils.Utils
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.models.ApiResponse
 import com.infomaniak.lib.core.utils.NotificationUtilsCore
@@ -182,15 +185,15 @@ class CloudStorageProvider : DocumentsProvider() {
             isRootFolder -> {
                 cursor.addRootDrives(userId, isRootFolder = true)
 
+                // Show MyShares folder
                 var documentId = parentDocumentId + SEPARATOR + MY_SHARES_FOLDER_ID
                 var name = context?.getString(R.string.mySharesTitle) ?: "My Shares"
                 cursor.addFile(null, documentId, name)
 
-                if (DriveInfosController.getDrivesCount(userId = userId, sharedWithMe = true).isPositive()) {
-                    documentId = parentDocumentId + SEPARATOR + SHARED_WITHME_FOLDER_ID
-                    name = context?.getString(R.string.sharedWithMeTitle) ?: "Shared with me"
-                    cursor.addFile(null, documentId, name)
-                }
+                // Show SharedWithMe folder
+                documentId = parentDocumentId + SEPARATOR + SHARED_WITHME_FOLDER_ID
+                name = context?.getString(R.string.sharedWithMeTitle) ?: "Shared with me"
+                cursor.addFile(null, documentId, name)
             }
             isSharedWithMeFolder -> {
                 cloudScope.launch(cursor.job) {

--- a/app/src/main/java/com/infomaniak/drive/ui/home/RootFilesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/RootFilesFragment.kt
@@ -22,21 +22,22 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.pm.ShortcutManagerCompat
-import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.infomaniak.drive.R
-import com.infomaniak.drive.data.cache.DriveInfosController
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.databinding.FragmentRootFilesBinding
 import com.infomaniak.drive.ui.MainViewModel
 import com.infomaniak.drive.ui.fileList.FileListViewModel
-import com.infomaniak.drive.utils.*
+import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.FilePresenter.displayFile
 import com.infomaniak.drive.utils.FilePresenter.openFolder
 import com.infomaniak.drive.utils.Utils.Shortcuts
+import com.infomaniak.drive.utils.observeAndDisplayNetworkAvailability
+import com.infomaniak.drive.utils.setupDriveToolbar
+import com.infomaniak.drive.utils.setupRootPendingFilesIndicator
 import com.infomaniak.lib.core.utils.safeBinding
 import com.infomaniak.lib.core.utils.safeNavigate
 
@@ -104,12 +105,8 @@ class RootFilesFragment : Fragment() {
             safeNavigate(RootFilesFragmentDirections.actionFilesFragmentToRecentChangesFragment())
         }
 
-        sharedWithMeFiles.apply {
-            if (DriveInfosController.getDrivesCount(userId = AccountUtils.currentUserId, sharedWithMe = true).isPositive()) {
-                setOnClickListener { safeNavigate(RootFilesFragmentDirections.actionFilesFragmentToSharedWithMeFragment()) }
-            } else {
-                isGone = true
-            }
+        sharedWithMeFiles.setOnClickListener {
+            safeNavigate(RootFilesFragmentDirections.actionFilesFragmentToSharedWithMeFragment())
         }
 
         myShares.setOnClickListener {


### PR DESCRIPTION
*Solution*: 
Do as on `iOS` and always display the share folders from the root drive, so you're also iso with `iOS` and the `webApp`.