### PR TITLE
Fix gallery multiselect actions

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -354,7 +354,7 @@ object FileController {
     fun addChild(localFolderId: Int, newFile: File, realm: Realm) {
         getFileById(realm, localFolderId)?.let { localFolder ->
             if (!localFolder.children.contains(newFile)) {
-                realm.executeTransaction { localFolder.children.add(newFile) }
+                realm.executeTransaction { runCatching { localFolder.children.add(newFile) } }
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
@@ -390,10 +390,13 @@ class FileInfoActionsBottomSheetDialog : BottomSheetDialogFragment(), FileInfoAc
 
     companion object {
 
-        fun Fragment.openManageCategoriesBottomSheetDialog(filesIds: IntArray, userDrive: UserDrive? = null) {
+        fun Fragment.openManageCategoriesBottomSheetDialog(
+            filesIds: IntArray,
+            userDrive: UserDrive? = null,
+            currentClassName: String? = null,
+        ) {
             val args = SelectCategoriesFragmentArgs(CategoriesUsageMode.MANAGED_CATEGORIES, filesIds, userDrive = userDrive)
-
-            safeNavigate(R.id.selectCategoriesFragment, args.toBundle())
+            safeNavigate(R.id.selectCategoriesFragment, args.toBundle(), currentClassName = currentClassName)
         }
 
         fun Fragment.openColorFolderBottomSheetDialog(color: String?) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/GalleryMultiSelectActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/GalleryMultiSelectActionsBottomSheetDialog.kt
@@ -25,4 +25,10 @@ class GalleryMultiSelectActionsBottomSheetDialog : MultiSelectActionsBottomSheet
     override fun configureColoredFolder(areIndividualActionsVisible: Boolean) {
         binding.coloredFolder.isGone = true
     }
+
+    // We hide this action because the gallery doesn't rely on realm to display its file.
+    // This make the offline action buggy because we cannot update the UI responsively, and the setting offline doesn't work
+    override fun configureAvailableOffline() {
+        binding.availableOffline.isGone = true
+    }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/MultiSelectActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/MultiSelectActionsBottomSheetDialog.kt
@@ -233,7 +233,9 @@ abstract class MultiSelectActionsBottomSheetDialog(private val matomoCategory: S
                 closeMultiSelect()
             } else {
                 when (finalType) {
-                    BulkOperationType.MANAGE_CATEGORIES -> openManageCategoriesBottomSheetDialog(navigationArgs.fileIds)
+                    BulkOperationType.MANAGE_CATEGORIES -> {
+                        openManageCategoriesBottomSheetDialog(navigationArgs.fileIds, currentClassName = this::class.java.name)
+                    }
                     BulkOperationType.COLOR_FOLDER -> openColorFolderBottomSheetDialog(null)
                     BulkOperationType.COPY -> duplicateFiles()
                     BulkOperationType.MOVE -> {


### PR DESCRIPTION
The offline action has been hidden, because the logic of the gallery fragment doesn't rely on realm, so it would need a refactor to fully work.

The move action was crashing

The manage categories action wasn't working