### PR TITLE
fix: Prevent adding folder itself as child + Inherited actions

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
@@ -41,7 +41,9 @@ object ApiRoutes {
             "&actions[]=file_move" +
             "&actions[]=file_move_out" +
             "&actions[]=file_trash" +
+//            "&actions[]=file_trash_inherited" + TODO: Waiting for api fix (Is this really necessary ?)
             "&actions[]=file_restore" +
+//            "&actions[]=file_restore_inherited" + TODO: Waiting for api fix (Is this really necessary ?)
             "&actions[]=file_delete" +
             "&actions[]=file_update" +
             "&actions[]=file_favorite_create" +

--- a/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
@@ -41,9 +41,9 @@ object ApiRoutes {
             "&actions[]=file_move" +
             "&actions[]=file_move_out" +
             "&actions[]=file_trash" +
-//            "&actions[]=file_trash_inherited" + TODO: Waiting for api fix (Is this really necessary ?)
+//            "&actions[]=file_trash_inherited" + TODO: Waiting for api fix (https://infomaniak.kchat.infomaniak.com/infomaniak/pl/9ce13d8b-2e1e-47f1-8a31-f5d95b4798d2)
             "&actions[]=file_restore" +
-//            "&actions[]=file_restore_inherited" + TODO: Waiting for api fix (Is this really necessary ?)
+//            "&actions[]=file_restore_inherited" + TODO: Waiting for api fix (https://infomaniak.kchat.infomaniak.com/infomaniak/pl/9ce13d8b-2e1e-47f1-8a31-f5d95b4798d2)
             "&actions[]=file_delete" +
             "&actions[]=file_update" +
             "&actions[]=file_favorite_create" +

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FolderFilesProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FolderFilesProvider.kt
@@ -408,7 +408,7 @@ object FolderFilesProvider {
                 }
             }
             else -> {
-                if (returnResponse[fileId] == null) {
+                if (returnResponse[fileId] == null && actionFile?.id != currentFolder.id) {
                     upsertAction(realm, currentFolder, actionFile)
                     returnResponse[fileId] = this
                 }

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FolderFilesProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FolderFilesProvider.kt
@@ -399,7 +399,8 @@ object FolderFilesProvider {
         when (action) {
             FileActivityType.FILE_DELETE,
             FileActivityType.FILE_MOVE_OUT,
-            FileActivityType.FILE_TRASH -> {
+            FileActivityType.FILE_TRASH,
+            FileActivityType.FILE_TRASH_INHERITED -> {
                 // We used to have this condition, but it doesn't exist on the ios side, according to commit it was an api fix.
                 // returnResponse[fileId]?.createdAt?.time == createdAt.time
                 if (returnResponse[fileId] == null) {
@@ -408,6 +409,7 @@ object FolderFilesProvider {
                 }
             }
             else -> {
+                // The file has not yet been managed and is not the parent folder.
                 if (returnResponse[fileId] == null && actionFile?.id != currentFolder.id) {
                     upsertAction(realm, currentFolder, actionFile)
                     returnResponse[fileId] = this

--- a/app/src/main/java/com/infomaniak/drive/data/models/FileActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/FileActivity.kt
@@ -86,10 +86,10 @@ open class FileActivity(
         FileActivityType.FILE_MOVE_OUT -> {
             if (isFolder) R.string.fileDetailsActivityFolderMove else R.string.fileDetailsActivityFileMove
         }
-        FileActivityType.FILE_TRASH -> {
+        FileActivityType.FILE_TRASH, FileActivityType.FILE_TRASH_INHERITED -> {
             if (isFolder) R.string.fileDetailsActivityFolderTrash else R.string.fileDetailsActivityFileTrash
         }
-        FileActivityType.FILE_RESTORE -> {
+        FileActivityType.FILE_RESTORE, FileActivityType.FILE_RESTORE_INHERITED -> {
             if (isFolder) R.string.fileDetailsActivityFolderRestore else R.string.fileDetailsActivityFileRestore
         }
         FileActivityType.FILE_DELETE -> {

--- a/app/src/main/java/com/infomaniak/drive/data/models/FileActivityType.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/FileActivityType.kt
@@ -32,8 +32,12 @@ enum class FileActivityType {
     FILE_MOVE_OUT,
     @SerializedName("file_trash")
     FILE_TRASH,
+    @SerializedName("file_trash_inherited")
+    FILE_TRASH_INHERITED,
     @SerializedName("file_restore")
     FILE_RESTORE,
+    @SerializedName("file_restore_inherited")
+    FILE_RESTORE_INHERITED,
     @SerializedName("file_delete")
     FILE_DELETE,
     @SerializedName("file_update")


### PR DESCRIPTION
**Description**
Currently, we have a case where the file is added as a child of itself, which creates a loop and problems.

**Steps**
- Create and rename a folder
- Then navigate in the folder

**Fix**
When in a folder, check that the child is not trying to add the parent as a child
