### PR TITLE
08 manage password protected share

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/ApiRepository.kt
@@ -313,6 +313,15 @@ object ApiRepository : ApiRepositoryCore() {
         )
     }
 
+    fun submitPublicSharePassword(driveId: Int, linkUuid: String, password: String): ApiResponse<Boolean> {
+        return callApi(
+            url = ApiRoutes.submitPublicSharePassword(driveId, linkUuid),
+            method = POST,
+            body = mapOf("password" to password),
+            okHttpClient = HttpClient.okHttpClientNoTokenInterceptor,
+        )
+    }
+
     fun getPublicShareRootFile(driveId: Int, linkUuid: String, fileId: FileId): ApiResponse<File> {
         return callApi(ApiRoutes.getPublicShareRootFile(driveId, linkUuid, fileId), GET)
     }

--- a/app/src/main/java/com/infomaniak/drive/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/ApiRepository.kt
@@ -306,7 +306,11 @@ object ApiRepository : ApiRepositoryCore() {
     }
 
     fun getPublicShareInfo(driveId: Int, linkUuid: String): ApiResponse<ShareLink> {
-        return callApi(ApiRoutes.getPublicShareInfo(driveId, linkUuid), GET)
+        return callApi(
+            url = ApiRoutes.getPublicShareInfo(driveId, linkUuid),
+            method = GET,
+            okHttpClient = HttpClient.okHttpClientNoTokenInterceptor,
+        )
     }
 
     fun getPublicShareRootFile(driveId: Int, linkUuid: String, fileId: FileId): ApiResponse<File> {
@@ -324,7 +328,7 @@ object ApiRepository : ApiRepositoryCore() {
         return callApiWithCursor(url, GET)
     }
 
-    fun getPublicShareFileCount(driveId: Int, linkUuid: String, fileId: Int): ApiResponse<FileCount>{
+    fun getPublicShareFileCount(driveId: Int, linkUuid: String, fileId: Int): ApiResponse<FileCount> {
         return callApi(ApiRoutes.getPublicShareFileCount(driveId, linkUuid, fileId), GET)
     }
 

--- a/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/ApiRoutes.kt
@@ -257,7 +257,9 @@ object ApiRoutes {
 
     /** Public Share */
     //region Public share
-    fun getPublicShareInfo(driveId: Int, linkUuid: String) = "$SHARE_URL_V2$driveId/share/$linkUuid/init"
+    fun getPublicShareInfo(driveId: Int, linkUuid: String) = "${getPublicShareUrlV2(driveId, linkUuid)}/init"
+
+    fun submitPublicSharePassword(driveId: Int, linkUuid: String) = "${getPublicShareUrlV2(driveId, linkUuid)}/auth"
 
     fun getPublicShareRootFile(driveId: Int, linkUuid: String, fileId: Int): String {
         return "$SHARE_URL_V3$driveId/share/$linkUuid/files/$fileId?$sharedFileWithQuery"
@@ -292,7 +294,7 @@ object ApiRoutes {
     fun importPublicShareFiles(driveId: Int) = "${driveURLV2(driveId)}/imports/sharelink"
 
     fun buildPublicShareArchive(driveId: Int, linkUuid: String): String {
-        return "$SHARE_URL_V2$driveId/share/$linkUuid/archive"
+        return "${getPublicShareUrlV2(driveId, linkUuid)}/archive"
     }
 
     fun downloadPublicShareArchive(driveId: Int, publicShareUuid: String, archiveUuid: String): String {
@@ -300,8 +302,10 @@ object ApiRoutes {
     }
 
     private fun publicShareFile(driveId: Int, linkUuid: String, fileId: Int): String {
-        return "$SHARE_URL_V2$driveId/share/$linkUuid/files/$fileId"
+        return "${getPublicShareUrlV2(driveId, linkUuid)}/files/$fileId"
     }
+
+    private fun getPublicShareUrlV2(driveId: Int, linkUuid: String) = "$SHARE_URL_V2$driveId/share/$linkUuid"
     //endregion
 
     /** External import */

--- a/app/src/main/java/com/infomaniak/drive/data/api/ErrorCode.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/ErrorCode.kt
@@ -28,6 +28,7 @@ object ErrorCode {
     const val DESTINATION_ALREADY_EXISTS = "destination_already_exists"
     const val NO_DRIVE = "no_drive"
     const val SHARE_LINK_ALREADY_EXISTS = "file_share_link_already_exists"
+    const val PASSWORD_NOT_VALID = "password_not_valid"
 
     val apiErrorCodes = listOf(
         ApiErrorCode(CATEGORY_ALREADY_EXISTS, R.string.errorCategoryAlreadyExists),

--- a/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
@@ -30,6 +30,7 @@ import com.infomaniak.drive.MatomoDrive.trackScreen
 import com.infomaniak.drive.MatomoDrive.trackUserId
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.api.ApiRepository
+import com.infomaniak.drive.data.api.ErrorCode
 import com.infomaniak.drive.data.cache.DriveInfosController
 import com.infomaniak.drive.data.cache.FileMigration
 import com.infomaniak.drive.data.models.AppSettings
@@ -44,6 +45,7 @@ import com.infomaniak.lib.applock.LockActivity
 import com.infomaniak.lib.applock.Utils.isKeyguardSecure
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.extensions.setDefaultLocaleIfNeeded
+import com.infomaniak.lib.core.models.ApiError
 import com.infomaniak.lib.core.models.ApiResponseStatus
 import com.infomaniak.lib.core.utils.SentryLog
 import com.infomaniak.lib.core.utils.showToast
@@ -186,16 +188,30 @@ class LaunchActivity : AppCompatActivity() {
                         fileId = shareLink.fileId ?: -1,
                     ).toBundle()
 
-                    trackDeepLink("external")
+                    trackDeepLink("publicShare")
                 }
                 ApiResponseStatus.REDIRECT -> apiResponse.uri?.let(::processInternalLink)
-                else -> {
-                    if (apiResponse.error?.exception is ApiController.NetworkException) {
-                        Dispatchers.Main { showToast(R.string.errorNetwork) }
-                        finishAndRemoveTask()
-                    }
-                    Log.e("TOTO", "downloadSharedFile: ${apiResponse.error?.code}")
-                }
+                else -> handlePublicShareError(apiResponse.error, driveId, publicShareUuid)
+            }
+        }
+    }
+
+    private suspend fun handlePublicShareError(error: ApiError?, driveId: String, publicShareUuid: String) {
+        when {
+            error?.exception is ApiController.NetworkException -> {
+                Dispatchers.Main { showToast(R.string.errorNetwork) }
+                finishAndRemoveTask()
+            }
+            error?.code == ErrorCode.PASSWORD_NOT_VALID -> {
+                publicShareActivityExtras = PublicShareActivityArgs(
+                    driveId = driveId.toInt(),
+                    publicShareUuid = publicShareUuid,
+                    isPasswordNeeded = true,
+                ).toBundle()
+                trackDeepLink("publicShareWithPassword")
+            }
+            else -> {
+                Log.e("TOTO", "downloadSharedFile: ${error?.code}")
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
@@ -38,6 +38,7 @@ import com.infomaniak.drive.data.services.UploadWorker
 import com.infomaniak.drive.ui.login.LoginActivity
 import com.infomaniak.drive.ui.publicShare.PublicShareActivity
 import com.infomaniak.drive.ui.publicShare.PublicShareActivityArgs
+import com.infomaniak.drive.ui.publicShare.PublicShareListFragment.Companion.PUBLIC_SHARE_DEFAULT_ID
 import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.Utils
 import com.infomaniak.drive.utils.Utils.ROOT_ID
@@ -185,7 +186,7 @@ class LaunchActivity : AppCompatActivity() {
                     publicShareActivityExtras = PublicShareActivityArgs(
                         driveId = driveId.toInt(),
                         publicShareUuid = publicShareUuid,
-                        fileId = shareLink.fileId ?: -1,
+                        fileId = shareLink.fileId ?: PUBLIC_SHARE_DEFAULT_ID,
                     ).toBundle()
 
                     trackDeepLink("publicShare")

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PasswordDialogFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PasswordDialogFragment.kt
@@ -71,7 +71,7 @@ class PasswordDialogFragment : DialogFragment() {
         passwordEditText.text?.clear()
         passwordLayout.apply {
             isErrorEnabled = true
-            error = getString(R.string.wrongPdfPassword)
+            error = getString(R.string.errorWrongPassword)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareActivity.kt
@@ -61,4 +61,8 @@ class PublicShareActivity : AppCompatActivity() {
     }
 
     fun getMainButton() = binding.mainPublicShareButton
+
+    companion object {
+        const val PUBLIC_SHARE_TAG = "publicShare"
+    }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
@@ -69,7 +69,7 @@ class PublicShareListFragment : FileListFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (publicShareViewModel.isPasswordNeeded) {
+        if (publicShareViewModel.isPasswordNeeded && !publicShareViewModel.hasBeenAuthenticated) {
             safeNavigate(PublicShareListFragmentDirections.actionPublicShareListFragmentToPublicSharePasswordFragment())
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
@@ -66,6 +66,14 @@ class PublicShareListFragment : FileListFragment() {
 
     override fun initSwipeRefreshLayout(): SwipeRefreshLayout = binding.swipeRefreshLayout
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        if (publicShareViewModel.isPasswordNeeded) {
+            safeNavigate(PublicShareListFragmentDirections.actionPublicShareListFragmentToPublicSharePasswordFragment())
+        }
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         drivePermissions.registerPermissions(this@PublicShareListFragment) { authorized -> if (authorized) downloadAllFiles() }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
@@ -201,10 +201,10 @@ class PublicShareListFragment : FileListFragment() {
     }
 
     private fun onDriveAndFolderSelected(data: Intent?) {
-        val destinationDriveId = data?.getIntExtra(DESTINATION_DRIVE_ID_KEY, DEFAULT_ID) ?: DEFAULT_ID
-        val destinationFolderId = data?.getIntExtra(DESTINATION_FOLDER_ID_KEY, DEFAULT_ID) ?: DEFAULT_ID
+        val destinationDriveId = data?.getIntExtra(DESTINATION_DRIVE_ID_KEY, PUBLIC_SHARE_DEFAULT_ID) ?: PUBLIC_SHARE_DEFAULT_ID
+        val destinationFolderId = data?.getIntExtra(DESTINATION_FOLDER_ID_KEY, PUBLIC_SHARE_DEFAULT_ID) ?: PUBLIC_SHARE_DEFAULT_ID
 
-        if (data == null || destinationDriveId == DEFAULT_ID || destinationFolderId == DEFAULT_ID) {
+        if (data == null || destinationDriveId == PUBLIC_SHARE_DEFAULT_ID || destinationFolderId == PUBLIC_SHARE_DEFAULT_ID) {
             showSnackbar(RCore.string.anErrorHasOccurred)
         } else {
             publicShareViewModel.importFilesToDrive(
@@ -237,7 +237,7 @@ class PublicShareListFragment : FileListFragment() {
     }
 
     companion object {
-        private const val DEFAULT_ID = -1
+        const val PUBLIC_SHARE_DEFAULT_ID = -1
     }
 
     private inner class DownloadFiles : (Boolean, Boolean) -> Unit {

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicSharePasswordFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicSharePasswordFragment.kt
@@ -21,15 +21,80 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import com.infomaniak.drive.R
+import com.infomaniak.drive.data.api.ErrorCode
 import com.infomaniak.drive.databinding.FragmentPublicSharePasswordBinding
-import com.infomaniak.lib.core.utils.safeBinding
+import com.infomaniak.drive.ui.publicShare.PublicShareActivity.Companion.PUBLIC_SHARE_TAG
+import com.infomaniak.lib.core.api.ApiController
+import com.infomaniak.lib.core.models.ApiError
+import com.infomaniak.lib.core.utils.*
+import com.infomaniak.lib.core.utils.SnackbarUtils.showSnackbar
 
 class PublicSharePasswordFragment : Fragment() {
 
     private var binding: FragmentPublicSharePasswordBinding by safeBinding()
+    private val publicShareViewModel: PublicShareViewModel by activityViewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return FragmentPublicSharePasswordBinding.inflate(inflater, container, false).also { binding = it }.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?): Unit = with(binding) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupValidationButton()
+
+        publicSharePasswordEditText.addTextChangedListener { publicSharePasswordLayout.error = null }
+    }
+
+    private fun setupValidationButton() = with(binding.passwordValidateButton) {
+        initProgress(viewLifecycleOwner)
+        setOnClickListener {
+            if (isFieldBlank()) return@setOnClickListener
+
+            showProgressCatching()
+            val password = binding.publicSharePasswordEditText.text?.trim().toString()
+            publicShareViewModel.submitPublicSharePassword(password).observe(viewLifecycleOwner) { isAuthorized ->
+                if (isAuthorized == true) {
+                    publicShareViewModel.hasBeenAuthenticated = true
+                    publicShareViewModel.initPublicShare(::onInitSuccess, ::onInitError)
+                } else {
+                    hideProgressCatching(R.string.buttonValid)
+                    binding.publicSharePasswordEditText.text = null
+                    binding.publicSharePasswordLayout.error = getString(R.string.wrongPdfPassword)
+                }
+            }
+        }
+    }
+
+    private fun onInitSuccess(fileId: Int?) {
+        binding.passwordValidateButton.hideProgressCatching(R.string.buttonValid)
+        safeNavigate(
+            PublicSharePasswordFragmentDirections.actionPublicSharePasswordFragmentToPublicShareListFragment(
+                fileId = fileId ?: -1,
+            )
+        )
+    }
+
+    private fun onInitError(error: ApiError?) = with(binding) {
+        passwordValidateButton.hideProgressCatching(R.string.buttonValid)
+        when {
+            error?.exception is ApiController.NetworkException -> {
+                showSnackbar(R.string.errorNetwork, anchor = passwordValidateButton)
+            }
+            error?.code == ErrorCode.PASSWORD_NOT_VALID -> {
+                showSnackbar(R.string.wrongPdfPassword, anchor = passwordValidateButton)
+            }
+            else -> SentryLog.e(PUBLIC_SHARE_TAG, "downloadSharedFile: ${error?.code}")
+        }
+    }
+
+    private fun isFieldBlank(): Boolean {
+        return binding.publicSharePasswordEditText.text.isNullOrBlank().also { isBlank ->
+            if (isBlank) binding.publicSharePasswordLayout.error = getString(R.string.allEmptyInputError)
+        }
     }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicSharePasswordFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicSharePasswordFragment.kt
@@ -32,6 +32,7 @@ import com.infomaniak.drive.BuildConfig
 import com.infomaniak.drive.R
 import com.infomaniak.drive.databinding.FragmentPublicSharePasswordBinding
 import com.infomaniak.drive.ui.publicShare.PublicShareActivity.Companion.PUBLIC_SHARE_TAG
+import com.infomaniak.drive.ui.publicShare.PublicShareListFragment.Companion.PUBLIC_SHARE_DEFAULT_ID
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.models.ApiError
 import com.infomaniak.lib.core.utils.*
@@ -93,7 +94,7 @@ class PublicSharePasswordFragment : Fragment() {
                 } else {
                     hideProgressCatching(R.string.buttonValid)
                     binding.publicSharePasswordEditText.text = null
-                    binding.publicSharePasswordLayout.error = getString(R.string.wrongPdfPassword)
+                    binding.publicSharePasswordLayout.error = getString(R.string.errorWrongPassword)
                 }
             }
         }
@@ -103,7 +104,7 @@ class PublicSharePasswordFragment : Fragment() {
         binding.passwordValidateButton.hideProgressCatching(R.string.buttonValid)
         safeNavigate(
             PublicSharePasswordFragmentDirections.actionPublicSharePasswordFragmentToPublicShareListFragment(
-                fileId = fileId ?: -1,
+                fileId = fileId ?: PUBLIC_SHARE_DEFAULT_ID,
             )
         )
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicSharePasswordFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicSharePasswordFragment.kt
@@ -25,7 +25,6 @@ import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.infomaniak.drive.R
-import com.infomaniak.drive.data.api.ErrorCode
 import com.infomaniak.drive.databinding.FragmentPublicSharePasswordBinding
 import com.infomaniak.drive.ui.publicShare.PublicShareActivity.Companion.PUBLIC_SHARE_TAG
 import com.infomaniak.lib.core.api.ApiController
@@ -81,15 +80,14 @@ class PublicSharePasswordFragment : Fragment() {
 
     private fun onInitError(error: ApiError?) = with(binding) {
         passwordValidateButton.hideProgressCatching(R.string.buttonValid)
-        when {
-            error?.exception is ApiController.NetworkException -> {
-                showSnackbar(R.string.errorNetwork, anchor = passwordValidateButton)
-            }
-            error?.code == ErrorCode.PASSWORD_NOT_VALID -> {
-                showSnackbar(R.string.wrongPdfPassword, anchor = passwordValidateButton)
-            }
-            else -> SentryLog.e(PUBLIC_SHARE_TAG, "downloadSharedFile: ${error?.code}")
+        val errorRes = if (error?.exception is ApiController.NetworkException) {
+            R.string.errorNetwork
+        } else {
+            SentryLog.i(PUBLIC_SHARE_TAG, "Download init public share: ${error?.code}")
+            R.string.anErrorHasOccurred
         }
+
+        showSnackbar(errorRes, anchor = passwordValidateButton)
     }
 
     private fun isFieldBlank(): Boolean {

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareViewModel.kt
@@ -55,6 +55,9 @@ class PublicShareViewModel(val savedStateHandle: SavedStateHandle) : ViewModel()
     val publicShareUuid: String
         inline get() = savedStateHandle[PublicShareActivityArgs::publicShareUuid.name] ?: ""
 
+    val isPasswordNeeded: Boolean
+        inline get() = savedStateHandle[PublicShareActivityArgs::isPasswordNeeded.name] ?: false
+
     private val fileId: Int
         inline get() = savedStateHandle[PublicShareActivityArgs::fileId.name] ?: ROOT_SHARED_FILE_ID
 

--- a/app/src/main/res/layout/fragment_public_share_password.xml
+++ b/app/src/main/res/layout/fragment_public_share_password.xml
@@ -117,7 +117,6 @@
         style="@style/ButtonInfomaniak"
         android:layout_width="0dp"
         android:layout_marginBottom="@dimen/marginStandardMedium"
-        android:enabled="false"
         android:text="@string/buttonValid"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/end"

--- a/app/src/main/res/layout/fragment_public_share_password.xml
+++ b/app/src/main/res/layout/fragment_public_share_password.xml
@@ -45,7 +45,7 @@
         app:layout_constraintEnd_toStartOf="@id/end"
         app:layout_constraintStart_toEndOf="@id/start"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.33">
+        app:layout_constraintVertical_bias="0.4">
 
         <ImageView
             android:id="@+id/icon"
@@ -82,7 +82,7 @@
         android:layout_marginHorizontal="@dimen/marginStandardMedium"
         android:layout_marginTop="@dimen/marginStandardMedium"
         android:gravity="center"
-        android:text="@string/publicSharePasswordNeededDescription"
+        android:text="@string/publicSharePasswordNotSupportedDescription"
         app:layout_constraintBottom_toTopOf="@id/publicSharePasswordLayout"
         app:layout_constraintEnd_toStartOf="@id/end"
         app:layout_constraintStart_toEndOf="@id/start"
@@ -96,12 +96,14 @@
         android:layout_marginHorizontal="@dimen/marginStandardMedium"
         android:layout_marginTop="@dimen/marginStandard"
         android:hint="@string/allPasswordHint"
+        android:visibility="gone"
         app:errorIconDrawable="@null"
         app:layout_constraintEnd_toStartOf="@id/end"
         app:layout_constraintStart_toEndOf="@id/start"
         app:layout_constraintTop_toBottomOf="@id/passwordNeededDescription"
         app:passwordToggleEnabled="true"
-        app:passwordToggleTint="@color/iconColor">
+        app:passwordToggleTint="@color/iconColor"
+        tools:visibility="visible">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/publicSharePasswordEditText"
@@ -117,7 +119,7 @@
         style="@style/ButtonInfomaniak"
         android:layout_width="0dp"
         android:layout_marginBottom="@dimen/marginStandardMedium"
-        android:text="@string/buttonValid"
+        android:text="@string/buttonOpenInBrowser"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/end"
         app:layout_constraintStart_toEndOf="@id/start" />

--- a/app/src/main/res/layout/fragment_public_share_password.xml
+++ b/app/src/main/res/layout/fragment_public_share_password.xml
@@ -16,31 +16,111 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    tools:context=".ui.publicShare.PublicShareActivity">
 
-    <TextView
-        android:id="@+id/fileSharedPasswordTitle"
-        style="@style/H2"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/start"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="@dimen/marginStandard" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/end"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_end="@dimen/marginStandard" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/iconLayout"
+        android:layout_width="124dp"
+        android:layout_height="124dp"
+        android:background="@drawable/round_empty"
+        app:layout_constraintBottom_toTopOf="@id/passwordValidateButton"
+        app:layout_constraintEnd_toStartOf="@id/end"
+        app:layout_constraintStart_toEndOf="@id/start"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        tools:text="Contenu sécurisé" />
+        app:layout_constraintVertical_bias="0.33">
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:src="@drawable/ic_lock"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHeight_percent="0.42"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintWidth_percent="0.42"
+            tools:ignore="ContentDescription" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
     <TextView
-        android:id="@+id/fileSharedPasswordDescription"
-        style="@style/Subtitle1"
-        android:layout_width="wrap_content"
+        android:id="@+id/passwordNeededTitle"
+        style="@style/H2"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/fileSharedPasswordTitle"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginHorizontal="@dimen/marginStandardMedium"
         android:layout_marginTop="@dimen/marginStandard"
-        tools:text="@tools:sample/lorem" />
+        android:gravity="center"
+        android:text="@string/publicSharePasswordNeededTitle"
+        app:layout_constraintBottom_toTopOf="@id/passwordNeededDescription"
+        app:layout_constraintEnd_toStartOf="@id/end"
+        app:layout_constraintStart_toEndOf="@id/start"
+        app:layout_constraintTop_toBottomOf="@id/iconLayout" />
+
+    <TextView
+        android:id="@+id/passwordNeededDescription"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/marginStandardMedium"
+        android:layout_marginTop="@dimen/marginStandardMedium"
+        android:gravity="center"
+        android:text="@string/publicSharePasswordNeededDescription"
+        app:layout_constraintBottom_toTopOf="@id/publicSharePasswordLayout"
+        app:layout_constraintEnd_toStartOf="@id/end"
+        app:layout_constraintStart_toEndOf="@id/start"
+        app:layout_constraintTop_toBottomOf="@id/passwordNeededTitle" />
+
+    <com.infomaniak.lib.core.views.EndIconTextInputLayout
+        android:id="@+id/publicSharePasswordLayout"
+        style="@style/TextInputLayout.OutlinedBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/marginStandardMedium"
+        android:layout_marginTop="@dimen/marginStandard"
+        android:hint="@string/allPasswordHint"
+        app:errorIconDrawable="@null"
+        app:layout_constraintEnd_toStartOf="@id/end"
+        app:layout_constraintStart_toEndOf="@id/start"
+        app:layout_constraintTop_toBottomOf="@id/passwordNeededDescription"
+        app:passwordToggleEnabled="true"
+        app:passwordToggleTint="@color/iconColor">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/publicSharePasswordEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:imeOptions="actionDone"
+            android:inputType="textPassword" />
+
+    </com.infomaniak.lib.core.views.EndIconTextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/passwordValidateButton"
+        style="@style/ButtonInfomaniak"
+        android:layout_width="0dp"
+        android:layout_marginBottom="@dimen/marginStandardMedium"
+        android:enabled="false"
+        android:text="@string/buttonValid"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/end"
+        app:layout_constraintStart_toEndOf="@id/start" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/public_share_navigation.xml
+++ b/app/src/main/res/navigation/public_share_navigation.xml
@@ -33,7 +33,12 @@
             app:argType="string" />
         <argument
             android:name="fileId"
+            android:defaultValue="-1"
             app:argType="integer" />
+        <argument
+            android:name="isPasswordNeeded"
+            android:defaultValue="false"
+            app:argType="boolean" />
     </activity>
 
     <fragment
@@ -69,6 +74,11 @@
         <action
             android:id="@+id/action_publicShareListFragment_to_publicShareBottomSheetFileActions"
             app:destination="@id/publicShareBottomSheetFileActions" />
+        <action
+            android:id="@+id/action_publicShareListFragment_to_publicSharePasswordFragment"
+            app:destination="@id/publicSharePasswordFragment"
+            app:popUpTo="@id/publicShareListFragment"
+            app:popUpToInclusive="true" />
     </fragment>
 
     <fragment

--- a/app/src/main/res/navigation/public_share_navigation.xml
+++ b/app/src/main/res/navigation/public_share_navigation.xml
@@ -44,7 +44,11 @@
     <fragment
         android:id="@+id/publicSharePasswordFragment"
         android:name="com.infomaniak.drive.ui.publicShare.PublicSharePasswordFragment"
-        tools:layout="@layout/fragment_public_share_password" />
+        tools:layout="@layout/fragment_public_share_password">
+        <action
+            android:id="@+id/action_publicSharePasswordFragment_to_publicShareListFragment"
+            app:destination="@id/publicShareListFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/publicShareListFragment"

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -142,6 +142,7 @@
     <string name="buttonNoDriveAnotherUser">Ein anderes Infomaniak-Profil verwenden</string>
     <string name="buttonNoDriveFreeTest">Kostenlos testen</string>
     <string name="buttonOpenDocument">Dokument öffnen</string>
+    <string name="buttonOpenInBrowser">Im Browser öffnen</string>
     <string name="buttonOpenReadOnly">Im Lese-Modus öffnen</string>
     <string name="buttonPlayerFfwd">Einige Sekunden vorspulen</string>
     <string name="buttonPlayerNext">Weiter</string>
@@ -554,6 +555,7 @@
     <string name="previewVideoSourceError">Videodatei wird vom Videoplayer nicht unterstützt</string>
     <string name="publicSharePasswordNeededDescription">Bitte geben Sie das Passwort ein, das Sie erhalten haben, um auf den Inhalt zuzugreifen.</string>
     <string name="publicSharePasswordNeededTitle">Sicherer Inhalt</string>
+    <string name="publicSharePasswordNotSupportedDescription">Passwortgeschützte Links sind in der mobilen Anwendung noch nicht verfügbar.</string>
     <string name="publicSharedLinkTitle">Öffentlicher Freigabelink</string>
     <string name="recentActivityMeTitle">Durch mich</string>
     <string name="recentActivityMyTeam">Durch mein Team</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -552,6 +552,8 @@
     <string name="previewNoPreview">Es scheint, als ob diese Datei keine Vorschau hat.</string>
     <string name="previewPdfPages">%1$d von %2$d</string>
     <string name="previewVideoSourceError">Videodatei wird vom Videoplayer nicht unterstützt</string>
+    <string name="publicSharePasswordNeededDescription">Bitte geben Sie das Passwort ein, das Sie erhalten haben, um auf den Inhalt zuzugreifen.</string>
+    <string name="publicSharePasswordNeededTitle">Sicherer Inhalt</string>
     <string name="publicSharedLinkTitle">Öffentlicher Freigabelink</string>
     <string name="recentActivityMeTitle">Durch mich</string>
     <string name="recentActivityMyTeam">Durch mein Team</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -274,6 +274,7 @@
     <string name="errorSave">Fehler bei der Speicherung</string>
     <string name="errorShareAddUser">Diese Datei ist bereits für diesen Benutzer freigegeben.</string>
     <string name="errorShareLink">Fehler bei der Erstellung des Links</string>
+    <string name="errorWrongPassword">Falsches Passwort</string>
     <string name="favoritesNoFile">Derzeit keine Favoriten</string>
     <string name="favoritesTitle">Favoriten</string>
     <string name="fileActivityCollaborativeFolderAccess">hat die Briefkasten eingesehen</string>
@@ -738,5 +739,4 @@
     <string name="userPermissionRemove">Der Benutzer hat keinen Zugriff auf diese Datei mehr.</string>
     <string name="userPermissionWrite">Kann ändern</string>
     <string name="userPermissionWriteDescription">Änderung der Datei\nDownload\nHinzufügen eines Kommentars\nHinzufügen und Anlegen einer Datei / eines Ordners\nLöschen der Datei</string>
-    <string name="wrongPdfPassword">Falsches Passwort</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -552,6 +552,8 @@
     <string name="previewNoPreview">Parece que este archivo no tiene vista previa.</string>
     <string name="previewPdfPages">%1$d de %2$d</string>
     <string name="previewVideoSourceError">El archivo de vídeo no es compatible con el lector de vídeo</string>
+    <string name="publicSharePasswordNeededDescription">Introduzca la contraseña que se le ha facilitado para acceder al contenido.</string>
+    <string name="publicSharePasswordNeededTitle">Contenido seguro</string>
     <string name="publicSharedLinkTitle">Enlace de uso compartido público</string>
     <string name="recentActivityMeTitle">Por mí</string>
     <string name="recentActivityMyTeam">Por mi equipo</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -142,6 +142,7 @@
     <string name="buttonNoDriveAnotherUser">Utilizar otro perfil Infomaniak</string>
     <string name="buttonNoDriveFreeTest">Probar gratuitamente</string>
     <string name="buttonOpenDocument">Abrir el documento</string>
+    <string name="buttonOpenInBrowser">Abrir en el navegador</string>
     <string name="buttonOpenReadOnly">Abrir en modo de solo lectura</string>
     <string name="buttonPlayerFfwd">Avanzar unos segundos</string>
     <string name="buttonPlayerNext">Siguiente</string>
@@ -554,6 +555,7 @@
     <string name="previewVideoSourceError">El archivo de vídeo no es compatible con el lector de vídeo</string>
     <string name="publicSharePasswordNeededDescription">Introduzca la contraseña que se le ha facilitado para acceder al contenido.</string>
     <string name="publicSharePasswordNeededTitle">Contenido seguro</string>
+    <string name="publicSharePasswordNotSupportedDescription">Los enlaces protegidos por contraseña aún no están disponibles en la aplicación móvil.</string>
     <string name="publicSharedLinkTitle">Enlace de uso compartido público</string>
     <string name="recentActivityMeTitle">Por mí</string>
     <string name="recentActivityMyTeam">Por mi equipo</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -274,6 +274,7 @@
     <string name="errorSave">Error al guardar</string>
     <string name="errorShareAddUser">Este archivo ya está compartido con este usuario.</string>
     <string name="errorShareLink">Error al crear el enlace</string>
+    <string name="errorWrongPassword">Contraseña incorrecta</string>
     <string name="favoritesNoFile">Todavía no hay favoritos</string>
     <string name="favoritesTitle">Favoritos</string>
     <string name="fileActivityCollaborativeFolderAccess">ha consultado el buzón de depósito</string>
@@ -738,5 +739,4 @@
     <string name="userPermissionRemove">El usuario ya no tendrá acceso a este archivo.</string>
     <string name="userPermissionWrite">Puede modificar</string>
     <string name="userPermissionWriteDescription">Modificar el archivo\nDescargar\nAñadir comentario\nAñadir y crear archivo/carpeta\nEliminar el archivo</string>
-    <string name="wrongPdfPassword">Contraseña incorrecta</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -142,6 +142,7 @@
     <string name="buttonNoDriveAnotherUser">Utiliser un autre profil Infomaniak</string>
     <string name="buttonNoDriveFreeTest">Tester gratuitement</string>
     <string name="buttonOpenDocument">Ouvrir le document</string>
+    <string name="buttonOpenInBrowser">Ouvrir dans le navigateur</string>
     <string name="buttonOpenReadOnly">Ouvrir en lecture seule</string>
     <string name="buttonPlayerFfwd">Avancer de quelques secondes</string>
     <string name="buttonPlayerNext">Suivant</string>
@@ -554,6 +555,7 @@
     <string name="previewVideoSourceError">Fichier vidéo non pris en charge par le lecteur vidéo</string>
     <string name="publicSharePasswordNeededDescription">Veuillez saisir le mot de passe qui vous a été fourni pour accéder au contenu.</string>
     <string name="publicSharePasswordNeededTitle">Contenu sécurisé</string>
+    <string name="publicSharePasswordNotSupportedDescription">Les liens protégés par mot de passe ne sont pas encore disponibles sur l’application mobile.</string>
     <string name="publicSharedLinkTitle">Lien de partage public</string>
     <string name="recentActivityMeTitle">Par moi</string>
     <string name="recentActivityMyTeam">Par mon équipe</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -274,6 +274,7 @@
     <string name="errorSave">Erreur lors de l’enregistrement</string>
     <string name="errorShareAddUser">Ce fichier est déjà partagé avec cet utilisateur.</string>
     <string name="errorShareLink">Erreur lors de la création du lien</string>
+    <string name="errorWrongPassword">Mot de passe incorrect</string>
     <string name="favoritesNoFile">Aucun favori pour le moment</string>
     <string name="favoritesTitle">Favoris</string>
     <string name="fileActivityCollaborativeFolderAccess">a consulté la boîte de dépôt</string>
@@ -738,5 +739,4 @@
     <string name="userPermissionRemove">L’utilisateur n’aura plus accès à ce fichier.</string>
     <string name="userPermissionWrite">Peut modifier</string>
     <string name="userPermissionWriteDescription">Modification du fichier\nTéléchargement\nAjout de commentaire\nAjout et création de fichier / dossier\nSuppression du fichier</string>
-    <string name="wrongPdfPassword">Mot de passe incorrect</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -552,6 +552,8 @@
     <string name="previewNoPreview">Il semblerait que ce fichier n’ait pas d’aperçu.</string>
     <string name="previewPdfPages">%1$d sur %2$d</string>
     <string name="previewVideoSourceError">Fichier vidéo non pris en charge par le lecteur vidéo</string>
+    <string name="publicSharePasswordNeededDescription">Veuillez saisir le mot de passe qui vous a été fourni pour accéder au contenu.</string>
+    <string name="publicSharePasswordNeededTitle">Contenu sécurisé</string>
     <string name="publicSharedLinkTitle">Lien de partage public</string>
     <string name="recentActivityMeTitle">Par moi</string>
     <string name="recentActivityMyTeam">Par mon équipe</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -552,6 +552,8 @@
     <string name="previewNoPreview">Sembra che il file non abbia anteprima.</string>
     <string name="previewPdfPages">%1$d di %2$d</string>
     <string name="previewVideoSourceError">File video non supportato dal lettore</string>
+    <string name="publicSharePasswordNeededDescription">Inserite la password che vi è stata fornita per accedere al contenuto.</string>
+    <string name="publicSharePasswordNeededTitle">Contenuto sicuro</string>
     <string name="publicSharedLinkTitle">Link di condivisione pubblica</string>
     <string name="recentActivityMeTitle">Da parte mia</string>
     <string name="recentActivityMyTeam">Da parte del mio team</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -274,6 +274,7 @@
     <string name="errorSave">Errore durante il salvataggio</string>
     <string name="errorShareAddUser">Questo file è già condiviso con questo utente.</string>
     <string name="errorShareLink">Errore durante la creazione del link</string>
+    <string name="errorWrongPassword">Password errata</string>
     <string name="favoritesNoFile">Al momento non sono disponibili preferiti</string>
     <string name="favoritesTitle">Preferiti</string>
     <string name="fileActivityCollaborativeFolderAccess">ha consultato il deposito file</string>
@@ -738,5 +739,4 @@
     <string name="userPermissionRemove">L’utente non avrà più accesso a questo file.</string>
     <string name="userPermissionWrite">Può modificare</string>
     <string name="userPermissionWriteDescription">Modifica di file\nDownload\nAggiunta di commenti\nAggiunta e creazione di file / cartelle\nEliminazione di file</string>
-    <string name="wrongPdfPassword">Password errata</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -142,6 +142,7 @@
     <string name="buttonNoDriveAnotherUser">Utilizza un altro profilo Infomaniak</string>
     <string name="buttonNoDriveFreeTest">Prova gratuitamente</string>
     <string name="buttonOpenDocument">Aprire documento</string>
+    <string name="buttonOpenInBrowser">Aprire nel browser</string>
     <string name="buttonOpenReadOnly">Aprire in modalità di sola lettura</string>
     <string name="buttonPlayerFfwd">Vai avanti di alcuni secondi</string>
     <string name="buttonPlayerNext">Avanti</string>
@@ -554,6 +555,7 @@
     <string name="previewVideoSourceError">File video non supportato dal lettore</string>
     <string name="publicSharePasswordNeededDescription">Inserite la password che vi è stata fornita per accedere al contenuto.</string>
     <string name="publicSharePasswordNeededTitle">Contenuto sicuro</string>
+    <string name="publicSharePasswordNotSupportedDescription">I link protetti da password non sono ancora disponibili nell’applicazione mobile.</string>
     <string name="publicSharedLinkTitle">Link di condivisione pubblica</string>
     <string name="recentActivityMeTitle">Da parte mia</string>
     <string name="recentActivityMyTeam">Da parte del mio team</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -563,6 +563,8 @@
     <string name="previewNoPreview">This file appears to have no preview.</string>
     <string name="previewPdfPages">%1$d out of %2$d</string>
     <string name="previewVideoSourceError">Video file not supported by the video player</string>
+    <string name="publicSharePasswordNeededDescription">Please enter the password provided to access the content.</string>
+    <string name="publicSharePasswordNeededTitle">Protected content</string>
     <string name="publicSharedLinkTitle">Public sharing link</string>
     <string name="recentActivityMeTitle">By me</string>
     <string name="recentActivityMyTeam">By my team</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -285,6 +285,7 @@
     <string name="errorSave">Save error</string>
     <string name="errorShareAddUser">This file is already shared with this user.</string>
     <string name="errorShareLink">Error when creating link</string>
+    <string name="errorWrongPassword">Wrong password</string>
     <string name="favoritesNoFile">No favorites at this time</string>
     <string name="favoritesTitle">Favorites</string>
     <string name="fileActivityCollaborativeFolderAccess">has accessed the drop box</string>
@@ -749,5 +750,4 @@
     <string name="userPermissionRemove">User will no longer have access to this file.</string>
     <string name="userPermissionWrite">Can change</string>
     <string name="userPermissionWriteDescription">Edit the file\nDownload\nAdd comments\nAdd and create files/folders\nDeleting the file</string>
-    <string name="wrongPdfPassword">Wrong password</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,7 @@
     <string name="buttonNoDriveAnotherUser">Use a different Infomaniak profile</string>
     <string name="buttonNoDriveFreeTest">Free trial</string>
     <string name="buttonOpenDocument">Open document</string>
+    <string name="buttonOpenInBrowser">Open in browser</string>
     <string name="buttonOpenReadOnly">Open in read-only mode</string>
     <string name="buttonPlayerFfwd">Forward a few seconds</string>
     <string name="buttonPlayerNext">Next</string>
@@ -565,6 +566,7 @@
     <string name="previewVideoSourceError">Video file not supported by the video player</string>
     <string name="publicSharePasswordNeededDescription">Please enter the password provided to access the content.</string>
     <string name="publicSharePasswordNeededTitle">Protected content</string>
+    <string name="publicSharePasswordNotSupportedDescription">Password-protected links are not yet available on the mobile application.</string>
     <string name="publicSharedLinkTitle">Public sharing link</string>
     <string name="recentActivityMeTitle">By me</string>
     <string name="recentActivityMyTeam">By my team</string>


### PR DESCRIPTION
Depends on #1402 

Add the management of password protected share link.

As the backend isn't ready for Bearer logic on the public share routes (it only relies on cookies), the current situation is that we redirect the user to the browser for these links