### PR TITLE
fix: Syncing a file from an external app via cloud storage doesn't work

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
@@ -259,8 +259,7 @@ class CloudStorageProvider : DocumentsProvider() {
         val context = context ?: return null
 
         fun getRemoteFile(localFile: File?, fileId: Int, driveId: Int): File? {
-            val userId = getUserId(documentId)
-            val okHttpClient = runBlocking { AccountUtils.getHttpClient(userId.toInt()) }
+            val okHttpClient = runBlocking { AccountUtils.getHttpClient(getUserId(documentId).toInt()) }
             return ApiRepository.getFileDetails(localFile ?: File(id = fileId, driveId = driveId), okHttpClient).data
         }
 

--- a/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
@@ -552,6 +552,7 @@ class CloudStorageProvider : DocumentsProvider() {
 
     private fun writeDataFile(context: Context, file: File, userDrive: UserDrive, accessMode: Int): ParcelFileDescriptor? {
         val tempFile = createTempFile(file.parentId, file.name)
+        val cacheFile = file.getCacheFile(context, userDrive)
         val handler = Handler(context.mainLooper)
 
         return ParcelFileDescriptor.open(tempFile, accessMode, handler) { exception: IOException? ->
@@ -568,6 +569,7 @@ class CloudStorageProvider : DocumentsProvider() {
                         userId = userDrive.userId,
                     ).store()
                     context.syncImmediately()
+                    cacheFile.delete() // Delete old cache
                 }
             } else {
                 exception.printStackTrace()


### PR DESCRIPTION
**Description**
When you open a file from an external application via cloud storage, the file is saved during editing, but when you close and open the file, it opens the old file in the cloud storage cache.

**Fixes**
- Ensure that file metadata is always up to date
- Manage cache to facilitate renewal