### PR TITLE
Fix folders that cannot be colored while not being fetch remotely

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/FolderFilesProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FolderFilesProvider.kt
@@ -45,7 +45,7 @@ object FolderFilesProvider {
 
     // Bump this when we want to force-refresh files that are too old.
     // Example: We did it when we added Categories & Colored folders, to automatically display them when updating the app.
-    private const val MIN_VERSION_CODE = 4_03_002_01
+    private const val MIN_VERSION_CODE = 5_00_010_01
 
     private val minDateToIgnoreCache = Calendar.getInstance().apply { add(Calendar.MONTH, -2) }.timeInMillis / 1000 // 3 month
 


### PR DESCRIPTION
We added a api field that tells us when a folder can be colored in #1446, but the Files aren't fetch while the user doesn't force refresh because we display the realm content. This cause the impossibilty to color folder while they were not updated from api because the default local value is "colorable=false"