### PR TITLE
fix: Select syncFolder sometimes doesn't work

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SelectIntervalTypeBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SelectIntervalTypeBottomSheetDialog.kt
@@ -25,7 +25,7 @@ import com.infomaniak.drive.views.SelectBottomSheetDialog
 
 class SelectIntervalTypeBottomSheetDialog : SelectBottomSheetDialog() {
 
-    private val syncSettingsViewModel: SyncSettingsActivity.SyncSettingsViewModel by activityViewModels()
+    private val syncSettingsViewModel: SyncSettingsViewModel by activityViewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) = with(binding) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
@@ -92,10 +92,7 @@ class SyncSettingsActivity : BaseActivity() {
 
         oldSyncSettings = UploadFile.getAppSyncSettings()
 
-        selectDriveViewModel.apply {
-            selectedUserId.value = oldSyncSettings?.userId ?: AccountUtils.currentUserId
-            selectedDrive.value = oldSyncSettings?.run { DriveInfosController.getDrive(userId, driveId) }
-        }
+        initUserAndDrive()
 
         val oldIntervalTypeValue = oldSyncSettings?.getIntervalType() ?: IntervalType.IMMEDIATELY
         val oldSyncVideoValue = oldSyncSettings?.syncVideo ?: true
@@ -175,6 +172,15 @@ class SyncSettingsActivity : BaseActivity() {
         saveButton.initProgress(this@SyncSettingsActivity)
         saveButton.setOnClickListener {
             if (permission.checkSyncPermissions()) saveSettings()
+        }
+    }
+
+    private fun initUserAndDrive() {
+        selectDriveViewModel.apply {
+            val userId = oldSyncSettings?.userId ?: AccountUtils.currentUserId
+            val drive = oldSyncSettings?.run { DriveInfosController.getDrive(userId, driveId) }
+            if (selectedUserId.value != userId) selectedUserId.value = userId
+            if (selectedDrive.value != drive) selectedDrive.value = drive
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
@@ -70,7 +70,7 @@ class SyncSettingsActivity : BaseActivity() {
     private val selectFolderResultLauncher = registerForActivityResult(StartActivityForResult()) {
         it.whenResultIsOk { data ->
             data?.extras?.let { bundle ->
-                syncSettingsViewModel.syncFolder.value = SelectFolderActivityArgs.fromBundle(bundle).folderId
+                syncSettingsViewModel.syncFolderId.value = SelectFolderActivityArgs.fromBundle(bundle).folderId
             }
         }
     }
@@ -183,7 +183,7 @@ class SyncSettingsActivity : BaseActivity() {
                     SelectFolderActivityArgs(
                         userId = selectDriveViewModel.selectedUserId.value!!,
                         driveId = selectDriveViewModel.selectedDrive.value?.id!!,
-                        folderId = syncSettingsViewModel.syncFolder.value ?: -1,
+                        folderId = syncSettingsViewModel.syncFolderId.value ?: -1,
                     ).toBundle()
                 )
                 selectFolderResultLauncher.launch(this)
@@ -238,16 +238,16 @@ class SyncSettingsActivity : BaseActivity() {
             }
             if (selectDriveViewModel.selectedUserId.value != oldSyncSettings?.userId ||
                 selectDriveViewModel.selectedDrive.value?.id != oldSyncSettings?.driveId ||
-                syncSettingsViewModel.syncFolder.value != oldSyncSettings?.syncFolder
+                syncSettingsViewModel.syncFolderId.value != oldSyncSettings?.syncFolder
             ) {
-                syncSettingsViewModel.syncFolder.value = null
+                syncSettingsViewModel.syncFolderId.value = null
             }
             changeSaveButtonStatus()
         }
     }
 
     private fun observeSyncFolder() = with(binding) {
-        syncSettingsViewModel.syncFolder.observe(this@SyncSettingsActivity) { syncFolderId ->
+        syncSettingsViewModel.syncFolderId.observe(this@SyncSettingsActivity) { syncFolderId ->
 
             val selectedUserId = selectDriveViewModel.selectedUserId.value
             val selectedDriveId = selectDriveViewModel.selectedDrive.value?.id
@@ -314,7 +314,7 @@ class SyncSettingsActivity : BaseActivity() {
     }
 
     private fun saveSettingVisibility(isVisible: Boolean) = with(binding) {
-        mediaFoldersSettingsVisibility(isVisible && syncSettingsViewModel.syncFolder.value != null)
+        mediaFoldersSettingsVisibility(isVisible && syncSettingsViewModel.syncFolderId.value != null)
         saveSettingsTitle.isVisible = isVisible
         saveSettingsLayout.isVisible = isVisible
     }
@@ -335,7 +335,7 @@ class SyncSettingsActivity : BaseActivity() {
         val isEdited = (editNumber > 0)
                 || (selectDriveViewModel.selectedUserId.value != oldSyncSettings?.userId)
                 || (selectDriveViewModel.selectedDrive.value?.id != oldSyncSettings?.driveId)
-                || (syncSettingsViewModel.syncFolder.value != oldSyncSettings?.syncFolder)
+                || (syncSettingsViewModel.syncFolderId.value != oldSyncSettings?.syncFolder)
                 || (syncSettingsViewModel.saveOldPictures.value != SavePicturesDate.SINCE_NOW)
                 || allSyncedFoldersCount > 0
         saveButton.isVisible = isEdited
@@ -345,7 +345,7 @@ class SyncSettingsActivity : BaseActivity() {
 
         saveButton.isEnabled = isEdited && (selectDriveViewModel.selectedUserId.value != null)
                 && (selectDriveViewModel.selectedDrive.value != null)
-                && (syncSettingsViewModel.syncFolder.value != null)
+                && (syncSettingsViewModel.syncFolderId.value != null)
                 && allSyncedFoldersCount > 0
     }
 
@@ -395,7 +395,7 @@ class SyncSettingsActivity : BaseActivity() {
             userId = selectDriveViewModel.selectedUserId.value!!,
             driveId = selectDriveViewModel.selectedDrive.value!!.id,
             lastSync = date,
-            syncFolder = syncSettingsViewModel.syncFolder.value!!,
+            syncFolder = syncSettingsViewModel.syncFolderId.value!!,
             syncVideo = syncVideoSwitch.isChecked,
             createDatedSubFolders = createDatedSubFoldersSwitch.isChecked,
             deleteAfterSync = deletePicturesAfterSyncSwitch.isChecked

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
@@ -183,12 +183,18 @@ class SyncSettingsActivity : BaseActivity() {
             if (users.size > 1) {
                 activeSelectDrive()
             } else {
-                val currentUserDrives = DriveInfosController.getDrives(AccountUtils.currentUserId)
+                val currentUserId = AccountUtils.currentUserId
+                val currentUserDrives = DriveInfosController.getDrives(currentUserId)
                 if (currentUserDrives.size > 1) {
                     activeSelectDrive()
                 } else {
-                    selectDriveViewModel.selectedUserId.value = AccountUtils.currentUserId
-                    selectDriveViewModel.selectedDrive.value = currentUserDrives.firstOrNull()
+                    val firstDrive = currentUserDrives.firstOrNull()
+                    if (selectDriveViewModel.selectedUserId.value != currentUserId) {
+                        selectDriveViewModel.selectedUserId.value = currentUserId
+                    }
+                    if (selectDriveViewModel.selectedDrive.value != firstDrive) {
+                        selectDriveViewModel.selectedDrive.value = firstDrive
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
@@ -414,13 +414,6 @@ class SyncSettingsActivity : BaseActivity() {
             }
     }
 
-    class SyncSettingsViewModel : ViewModel() {
-        val customDate = MutableLiveData<Date>()
-        val saveOldPictures = MutableLiveData<SavePicturesDate>()
-        val syncIntervalType = MutableLiveData<IntervalType>()
-        val syncFolder = MutableLiveData<Int?>()
-    }
-
     private fun trackPhotoSyncEvent(name: String, value: Boolean? = null) {
         trackEvent("photoSync", name, value = value?.toFloat())
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsViewModel.kt
@@ -17,24 +17,21 @@
  */
 package com.infomaniak.drive.ui.menu.settings
 
-import android.os.Bundle
-import android.view.View
-import androidx.fragment.app.activityViewModels
-import com.infomaniak.drive.R
-import com.infomaniak.drive.views.SelectBottomSheetDialog
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.infomaniak.drive.data.models.SyncSettings.IntervalType
+import com.infomaniak.drive.data.models.SyncSettings.SavePicturesDate
+import java.util.Date
 
-class SelectSaveDateBottomSheetDialog : SelectBottomSheetDialog() {
+class SyncSettingsViewModel : ViewModel() {
+    val customDate = MutableLiveData<Date>()
+    val saveOldPictures = MutableLiveData<SavePicturesDate>()
+    val syncIntervalType = MutableLiveData<IntervalType>()
+    val syncFolder = MutableLiveData<Int?>()
 
-    private val syncSettingsViewModel: SyncSettingsViewModel by activityViewModels()
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) = with(binding) {
-        super.onViewCreated(view, savedInstanceState)
-
-        selectTitle.setText(R.string.syncSettingsButtonSaveDate)
-
-        selectRecyclerView.adapter = SelectSaveDateBottomSheetAdapter(syncSettingsViewModel.saveOldPictures.value!!) {
-            syncSettingsViewModel.saveOldPictures.value = it
-            dismiss()
-        }
+    fun init(intervalTypeValue: IntervalType, syncFolderId: Int?) {
+        syncIntervalType.value = intervalTypeValue
+        syncFolder.value = syncFolderId
+        saveOldPictures.value = SavePicturesDate.SINCE_NOW
     }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsViewModel.kt
@@ -27,11 +27,11 @@ class SyncSettingsViewModel : ViewModel() {
     val customDate = MutableLiveData<Date>()
     val saveOldPictures = MutableLiveData<SavePicturesDate>()
     val syncIntervalType = MutableLiveData<IntervalType>()
-    val syncFolder = MutableLiveData<Int?>()
+    val syncFolderId = MutableLiveData<Int?>()
 
     fun init(intervalTypeValue: IntervalType, syncFolderId: Int?) {
+        this.syncFolderId.value = syncFolderId
         syncIntervalType.value = intervalTypeValue
-        syncFolder.value = syncFolderId
         saveOldPictures.value = SavePicturesDate.SINCE_NOW
     }
 }


### PR DESCRIPTION
**Description:**

Sometimes we select a folder, but once validated it still shows us to select a folder.
This can only be reproduced in an account with a single drive and a single user.