### PR TITLE
Removing animateLayoutChanges on the Background sync BottomSheet

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/BackgroundSyncPermissionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/BackgroundSyncPermissionsBottomSheetDialog.kt
@@ -24,6 +24,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.infomaniak.drive.BuildConfig
 import com.infomaniak.drive.data.models.UiSettings
@@ -38,6 +40,8 @@ class BackgroundSyncPermissionsBottomSheetDialog : BottomSheetDialogFragment() {
     private val drivePermissions = DrivePermissions()
     private var hasDoneNecessary = false
     private var hadBatteryLifePermission = false
+
+    private val bottomSheetBehavior by lazy { (dialog as BottomSheetDialog).behavior }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return FragmentBottomSheetBackgroundSyncBinding.inflate(inflater, container, false).also { binding = it }.root
@@ -78,6 +82,8 @@ class BackgroundSyncPermissionsBottomSheetDialog : BottomSheetDialogFragment() {
     private fun onHasBatteryPermission(hasBatteryPermission: Boolean) {
         hadBatteryLifePermission = hasBatteryPermission
         showManufacturerWarning(hasBatteryPermission)
+
+        if (hasBatteryPermission) bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
     }
 
     private fun showManufacturerWarning(hasBatteryPermission: Boolean) {

--- a/app/src/main/res/layout/fragment_bottom_sheet_background_sync.xml
+++ b/app/src/main/res/layout/fragment_bottom_sheet_background_sync.xml
@@ -20,12 +20,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.bottomSheetDialogs.CategoryInfoActionsBottomSheetDialog">
+    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+    tools:context=".ui.bottomSheetDialogs.BackgroundSyncPermissionsBottomSheetDialog">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:animateLayoutChanges="true"
         android:paddingHorizontal="@dimen/marginStandard"
         tools:background="@color/appBar">
 


### PR DESCRIPTION
When we change the visibility of a view inside a BottomSheet with `animateLayoutChanges`, this one goes to the top. A ticket has been opened at Google Issue Tracker for a long time but no fix has been done. So to avoid that, we remove the animation.

Before:

https://github.com/user-attachments/assets/57dc403e-cbae-4331-bb9d-7d143ed6c513

After:

https://github.com/user-attachments/assets/91dca5bf-b973-4fda-9f08-eace29cab4b0