### PR TITLE
Update translations of the "Common folders" folder's name

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -464,7 +464,7 @@
     <string name="lastEditsTitle">Letzte Änderungen</string>
     <string name="localizedFilenamePrivateSpace">Meine Dateien</string>
     <string name="localizedFilenamePrivateTeamSpace">Mein persönlicher Ordner</string>
-    <string name="localizedFilenameTeamSpace">Akten der Organisation</string>
+    <string name="localizedFilenameTeamSpace">Gemeinsame Ordner</string>
     <string name="locateButton">Finden Sie</string>
     <string name="manageCategoriesCreateTitle">%s erstellen</string>
     <string name="manageCategoriesNoCategory">Keine Kategorie</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -464,7 +464,7 @@
     <string name="lastEditsTitle">Últimas modificaciones</string>
     <string name="localizedFilenamePrivateSpace">Mis archivos</string>
     <string name="localizedFilenamePrivateTeamSpace">Mi carpeta personal</string>
-    <string name="localizedFilenameTeamSpace">Archivos de la organización</string>
+    <string name="localizedFilenameTeamSpace">Carpetas comunes</string>
     <string name="locateButton">Localizar</string>
     <string name="manageCategoriesCreateTitle">Crear %s</string>
     <string name="manageCategoriesNoCategory">Sin categoría</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -464,7 +464,7 @@
     <string name="lastEditsTitle">Dernières modifications</string>
     <string name="localizedFilenamePrivateSpace">Mes fichiers</string>
     <string name="localizedFilenamePrivateTeamSpace">Mon dossier personnel</string>
-    <string name="localizedFilenameTeamSpace">Dossiers de l’organisation</string>
+    <string name="localizedFilenameTeamSpace">Dossiers communs</string>
     <string name="locateButton">Localiser</string>
     <string name="manageCategoriesCreateTitle">Créer %s</string>
     <string name="manageCategoriesNoCategory">Aucune catégorie</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -464,7 +464,7 @@
     <string name="lastEditsTitle">Ultime modifiche</string>
     <string name="localizedFilenamePrivateSpace">I miei file</string>
     <string name="localizedFilenamePrivateTeamSpace">La mia cartella personale</string>
-    <string name="localizedFilenameTeamSpace">File dell’organizzazione</string>
+    <string name="localizedFilenameTeamSpace">Cartelle comuni</string>
     <string name="locateButton">Localizzare</string>
     <string name="manageCategoriesCreateTitle">Crea %s</string>
     <string name="manageCategoriesNoCategory">Nessuna categoria</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -475,7 +475,7 @@
     <string name="lastEditsTitle">Most recent changes</string>
     <string name="localizedFilenamePrivateSpace">My files</string>
     <string name="localizedFilenamePrivateTeamSpace">My personal folder</string>
-    <string name="localizedFilenameTeamSpace">Organisation’s files</string>
+    <string name="localizedFilenameTeamSpace">Common folders</string>
     <string name="locateButton">Locate</string>
     <string name="manageCategoriesCreateTitle">Create %s</string>
     <string name="manageCategoriesNoCategory">No category</string>


### PR DESCRIPTION
The names did not match the web app's names. In order to be coherent we updated the names to be the same as the web app