### PR TITLE
Display the Sync import canceling button at the view creation

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/UploadInProgressFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/UploadInProgressFragment.kt
@@ -79,7 +79,10 @@ class UploadInProgressFragment : FileListFragment() {
         if (isPendingFolders()) {
             fileAdapter.onFileClicked = { navigateToUploadView(it.id, it.name) }
         } else {
-            binding.toolbar.setNavigationOnClickListener { popBackStack() }
+            binding.toolbar.apply {
+                setNavigationOnClickListener { popBackStack() }
+                menu.findItem(R.id.closeItem).isVisible = true
+            }
             requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) { popBackStack() }
         }
 
@@ -290,7 +293,6 @@ class UploadInProgressFragment : FileListFragment() {
                     noFilesLayout.toggleVisibility(uploadFolders.isEmpty())
                     showLoadingTimer.cancel()
                     swipeRefreshLayout.isRefreshing = false
-                    toolbar.menu.findItem(R.id.closeItem).isVisible = true
                 }
             }
         }


### PR DESCRIPTION
The user doesn't need to wait til all the files are processed before canceling the whole import