### PR TITLE
Revert "Fix double SplashScreen"

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
@@ -38,7 +38,6 @@ import com.infomaniak.drive.utils.Utils
 import com.infomaniak.drive.utils.Utils.ROOT_ID
 import com.infomaniak.lib.applock.LockActivity
 import com.infomaniak.lib.applock.Utils.isKeyguardSecure
-import com.infomaniak.lib.core.extensions.keepSplashscreenVisibleWhileLoading
 import com.infomaniak.lib.core.extensions.setDefaultLocaleIfNeeded
 import com.infomaniak.lib.stores.StoreUtils.checkUpdateIsRequired
 import io.sentry.Breadcrumb
@@ -58,8 +57,6 @@ class LaunchActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        keepSplashscreenVisibleWhileLoading()
 
         setDefaultLocaleIfNeeded()
 


### PR DESCRIPTION
This was removing the SplashScreen when opening deeplinks, making it seems like a lag if the connection is bad.