### PR TITLE
feat: Harden app lock

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
@@ -32,7 +32,6 @@ import com.infomaniak.drive.data.api.ApiRepository
 import com.infomaniak.drive.data.api.ErrorCode
 import com.infomaniak.drive.data.cache.DriveInfosController
 import com.infomaniak.drive.data.cache.FileMigration
-import com.infomaniak.drive.data.models.AppSettings
 import com.infomaniak.drive.data.models.ShareLink
 import com.infomaniak.drive.data.services.UploadWorker
 import com.infomaniak.drive.ui.login.LoginActivity
@@ -44,8 +43,6 @@ import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.PublicShareUtils
 import com.infomaniak.drive.utils.Utils
 import com.infomaniak.drive.utils.Utils.ROOT_ID
-import com.infomaniak.lib.applock.LockActivity
-import com.infomaniak.lib.applock.Utils.isKeyguardSecure
 import com.infomaniak.lib.core.api.ApiController
 import com.infomaniak.lib.core.extensions.setDefaultLocaleIfNeeded
 import com.infomaniak.lib.core.models.ApiError
@@ -106,21 +103,13 @@ class LaunchActivity : AppCompatActivity() {
 
         val destinationClass = getDestinationClass()
 
-        if (destinationClass == LockActivity::class.java) {
-            LockActivity.startAppLockActivity(
-                context = this,
-                destinationClass = MainActivity::class.java,
-                destinationClassArgs = mainActivityExtras
-            )
-        } else {
-            Intent(this, destinationClass).apply {
-                when (destinationClass) {
-                    MainActivity::class.java -> mainActivityExtras?.let(::putExtras)
-                    LoginActivity::class.java -> putExtra("isHelpShortcutPressed", isHelpShortcutPressed)
-                    PublicShareActivity::class.java -> publicShareActivityExtras?.let(::putExtras)
-                }
-            }.also(::startActivity)
-        }
+        Intent(this, destinationClass).apply {
+            when (destinationClass) {
+                MainActivity::class.java -> mainActivityExtras?.let(::putExtras)
+                LoginActivity::class.java -> putExtra("isHelpShortcutPressed", isHelpShortcutPressed)
+                PublicShareActivity::class.java -> publicShareActivityExtras?.let(::putExtras)
+            }
+        }.also(::startActivity)
     }
 
     private suspend fun getDestinationClass(): Class<out AppCompatActivity> = withContext(Dispatchers.IO) {
@@ -143,7 +132,6 @@ class LaunchActivity : AppCompatActivity() {
 
         return when {
             areAllDrivesInMaintenance -> MaintenanceActivity::class.java
-            isKeyguardSecure() && AppSettings.appSecurityLock -> LockActivity::class.java
             else -> MainActivity::class.java
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -41,6 +41,7 @@ import com.infomaniak.drive.MatomoDrive.trackUserId
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.cache.DriveInfosController
 import com.infomaniak.drive.data.cache.FileController
+import com.infomaniak.drive.data.models.AppSettings
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.data.models.UiSettings
 import com.infomaniak.drive.data.models.UiSettings.SaveExternalFilesData
@@ -52,11 +53,25 @@ import com.infomaniak.drive.ui.fileList.SelectFolderActivity
 import com.infomaniak.drive.ui.fileList.SelectFolderActivityArgs
 import com.infomaniak.drive.ui.menu.settings.SelectDriveDialog
 import com.infomaniak.drive.ui.menu.settings.SelectDriveViewModel
-import com.infomaniak.drive.utils.*
+import com.infomaniak.drive.utils.AccountUtils
+import com.infomaniak.drive.utils.DrivePermissions
+import com.infomaniak.drive.utils.IOFile
+import com.infomaniak.drive.utils.SyncUtils
 import com.infomaniak.drive.utils.SyncUtils.syncImmediately
 import com.infomaniak.drive.utils.Utils.OTHER_ROOT_ID
-import com.infomaniak.lib.core.utils.*
+import com.infomaniak.drive.utils.isValidUrl
+import com.infomaniak.drive.utils.showOrHideEmptyError
+import com.infomaniak.lib.applock.LockActivity
+import com.infomaniak.lib.core.utils.FORMAT_NEW_FILE
 import com.infomaniak.lib.core.utils.SnackbarUtils.showSnackbar
+import com.infomaniak.lib.core.utils.format
+import com.infomaniak.lib.core.utils.getFileName
+import com.infomaniak.lib.core.utils.hideProgressCatching
+import com.infomaniak.lib.core.utils.initProgress
+import com.infomaniak.lib.core.utils.parcelableArrayListExtra
+import com.infomaniak.lib.core.utils.parcelableExtra
+import com.infomaniak.lib.core.utils.showProgressCatching
+import com.infomaniak.lib.core.utils.whenResultIsOk
 import io.sentry.Sentry
 import io.sentry.SentryLevel
 import kotlinx.coroutines.Dispatchers
@@ -110,6 +125,11 @@ class SaveExternalFilesActivity : BaseActivity() {
         setupSaveButton()
 
         fileNameEdit.selectAllButFileExtension()
+
+        LockActivity.scheduleLockIfNeeded(
+            targetActivity = this@SaveExternalFilesActivity,
+            isAppLockEnabled = { AppSettings.appSecurityLock }
+        )
     }
 
     private fun TextInputEditText.selectAllButFileExtension() {

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/AppSecuritySettingsActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/AppSecuritySettingsActivity.kt
@@ -24,6 +24,7 @@ import androidx.core.view.isVisible
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.AppSettings
 import com.infomaniak.drive.databinding.ViewSwitchSettingsBinding
+import com.infomaniak.lib.applock.LockActivity
 import com.infomaniak.lib.applock.Utils.silentlyReverseSwitch
 
 class AppSecuritySettingsActivity : AppCompatActivity() {
@@ -47,7 +48,10 @@ class AppSecuritySettingsActivity : AppCompatActivity() {
             isChecked = AppSettings.appSecurityLock
             setOnCheckedChangeListener { _, _ ->
                 // Reverse switch (before official parameter changed) by silent click
-                silentlyReverseSwitch(this) { shouldLock -> AppSettings.appSecurityLock = shouldLock }
+                silentlyReverseSwitch(this) { shouldLock ->
+                    AppSettings.appSecurityLock = shouldLock
+                    if (shouldLock) LockActivity.unlock()
+                }
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SettingsFragment.kt
@@ -38,7 +38,7 @@ import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.DrivePermissions
 import com.infomaniak.drive.utils.SyncUtils.launchAllUpload
 import com.infomaniak.drive.utils.SyncUtils.syncImmediately
-import com.infomaniak.lib.applock.Utils.isKeyguardSecure
+import com.infomaniak.lib.applock.LockActivity
 import com.infomaniak.lib.core.utils.openAppNotificationSettings
 import com.infomaniak.lib.core.utils.safeBinding
 import com.infomaniak.lib.core.utils.safeNavigate
@@ -79,7 +79,7 @@ class SettingsFragment : Fragment() {
             requireContext().openAppNotificationSettings()
         }
         appSecurity.apply {
-            if (requireContext().isKeyguardSecure()) {
+            if (LockActivity.hasBiometrics()) {
                 appSecuritySeparator.isVisible = true
                 isVisible = true
                 setOnClickListener {


### PR DESCRIPTION
Enable app lock for the Save to kDrive Activity (SaveExternalFilesActivity).

Also includes changes from the core submodule:
- Use SystemClock.elapsedRealtime() instead of System.currentTimeMillis(), so it's not possible to unlock the app by setting the time in the past.
- Ensure the app starts locked if the system had to kill the process.

Depends on https://github.com/Infomaniak/android-core/pull/249