### PR TITLE
fix: Don't use `.all { }` if the list is empty, it will always return `true`

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
@@ -40,7 +40,7 @@ object DriveInfosController {
         .modules(RealmModules.DriveFilesModule())
         .build()
 
-    fun getRealmInstance() = Realm.getInstance(realmConfiguration)
+    fun getRealmInstance(): Realm = Realm.getInstance(realmConfiguration)
 
     private fun ArrayList<Drive>.initDriveForRealm(
         drive: Drive,

--- a/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
@@ -128,11 +128,15 @@ class LaunchActivity : AppCompatActivity() {
             AccountUtils.updateCurrentUserAndDrives(this)
         }
 
-        val areAllDrivesInMaintenance = DriveInfosController.getDrives(userId = AccountUtils.currentUserId).all { it.maintenance }
+        val areAllDrivesInMaintenance = DriveInfosController.getDrives(userId = AccountUtils.currentUserId)
+            .takeUnless { it.isEmpty() }
+            ?.all { it.maintenance }
+            ?: false
 
-        return when {
-            areAllDrivesInMaintenance -> MaintenanceActivity::class.java
-            else -> MainActivity::class.java
+        return if (areAllDrivesInMaintenance) {
+            MaintenanceActivity::class.java
+        } else {
+            MainActivity::class.java
         }
     }
 

--- a/fastlane/metadata/android/fr/changelogs/5_03_003_01.txt
+++ b/fastlane/metadata/android/fr/changelogs/5_03_003_01.txt
@@ -1,1 +1,1 @@
-- Correctement déconnecte l'utilisateur si son token expire
+- Déconnecte correctement l'utilisateur si son token expire


### PR DESCRIPTION
Depends on https://github.com/Infomaniak/android-core/pull/278