### PR TITLE
fix: The Mediastore deletion request may generate a NullPointerException if the limit exceeds 10_000 uris.

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
@@ -326,7 +326,7 @@ open class UploadFile(
         }
 
         private fun deleteFromRealm(realm: Realm, uploadFileUri: String) {
-            uploadFileByUriQuery(realm, uploadFileUri.toString()).findFirst()?.let { uploadFileRealm ->
+            uploadFileByUriQuery(realm, uploadFileUri).findFirst()?.let { uploadFileRealm ->
                 // Don't delete definitively if it's a sync
                 if (uploadFileRealm.type == Type.SYNC.name) {
                     uploadFileRealm.deletedAt = Date()

--- a/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
@@ -309,20 +309,34 @@ open class UploadFile(
             getRealmInstance().use {
                 it.executeTransaction { realm ->
                     uploadFiles.forEach { uploadFile ->
-                        uploadFileByUriQuery(realm, uploadFile.uri).findFirst()?.let { uploadFileRealm ->
-                            // Don't delete definitively if it's a sync
-                            if (uploadFileRealm.type == Type.SYNC.name) {
-                                uploadFileRealm.deletedAt = Date()
-                            } else {
-                                // Delete definitively
-                                val uri = uploadFileRealm.getUriObject()
-                                if (uri.scheme.equals(ContentResolver.SCHEME_FILE) && !uploadFile.isSyncOffline()) {
-                                    uri.toFile().apply { if (exists()) delete() }
-                                }
-                                uploadFileRealm.deleteFromRealm()
-                            }
-                        }
+                        deleteFromRealm(realm, uploadFile.uri)
                     }
+                }
+            }
+        }
+
+        fun deleteAllFromUris(uris: List<Uri>) {
+            getRealmInstance().use {
+                it.executeTransaction { mutableRealm ->
+                    uris.forEach { uri ->
+                        deleteFromRealm(mutableRealm, uri.toString())
+                    }
+                }
+            }
+        }
+
+        private fun deleteFromRealm(realm: Realm, uploadFileUri: String) {
+            uploadFileByUriQuery(realm, uploadFileUri.toString()).findFirst()?.let { uploadFileRealm ->
+                // Don't delete definitively if it's a sync
+                if (uploadFileRealm.type == Type.SYNC.name) {
+                    uploadFileRealm.deletedAt = Date()
+                } else {
+                    // Delete definitively
+                    val uri = uploadFileRealm.getUriObject()
+                    if (uri.scheme.equals(ContentResolver.SCHEME_FILE) && !uploadFileRealm.isSyncOffline()) {
+                        uri.toFile().apply { if (exists()) delete() }
+                    }
+                    uploadFileRealm.deleteFromRealm()
                 }
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
@@ -118,8 +118,14 @@ class MainActivity : BaseActivity() {
 
     private lateinit var drivePermissions: DrivePermissions
 
+    private val pendingFilesUrisQueue = ArrayDeque<List<Uri>>()
+
     private val filesDeletionResult = registerForActivityResult(StartIntentSenderForResult()) {
-        it.whenResultIsOk { lifecycleScope.launch(Dispatchers.IO) { UploadFile.deleteAll(uploadedFilesToDelete) } }
+        it.whenResultIsOk {
+            val filesUris = pendingFilesUrisQueue.removeFirstOrNull() ?: return@whenResultIsOk
+            lifecycleScope.launch(Dispatchers.IO) { UploadFile.deleteAllFromUris(filesUris) }
+            if (pendingFilesUrisQueue.isNotEmpty()) launchNextDeleteRequest()
+        }
     }
 
     private val fileObserver: FileObserver by lazy {
@@ -348,6 +354,14 @@ class MainActivity : BaseActivity() {
         handleDeletionOfUploadedPhotos()
     }
 
+    private fun launchNextDeleteRequest() {
+        val filesUris = pendingFilesUrisQueue.firstOrNull() ?: return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val deletionRequest = MediaStore.createDeleteRequest(contentResolver, filesUris)
+            filesDeletionResult.launch(IntentSenderRequest.Builder(deletionRequest.intentSender).build())
+        }
+    }
+
     private fun handleDeletionOfUploadedPhotos() {
 
         fun getFilesUriToDelete(uploadFiles: List<UploadFile>): List<Uri> {
@@ -361,9 +375,9 @@ class MainActivity : BaseActivity() {
 
         fun onConfirmation(filesUploadedRecently: ArrayList<UploadFile>, filesUriToDelete: List<Uri>) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                val filesDeletionRequest = MediaStore.createDeleteRequest(contentResolver, filesUriToDelete)
-                uploadedFilesToDelete = filesUploadedRecently
-                filesDeletionResult.launch(IntentSenderRequest.Builder(filesDeletionRequest.intentSender).build())
+                pendingFilesUrisQueue.clear()
+                pendingFilesUrisQueue.addAll(filesUriToDelete.chunked(MEDIASTORE_DELETE_BATCH_LIMIT))
+                launchNextDeleteRequest()
             } else {
                 mainViewModel.deleteSynchronizedFilesOnDevice(filesUploadedRecently)
             }
@@ -605,5 +619,10 @@ class MainActivity : BaseActivity() {
 
     companion object {
         private const val SYNCED_FILES_DELETION_FILES_AMOUNT = 10
+
+        // Maximum number of elements in the list supported by the mediastore when Uris are to be deleted.
+        // When you exceed this value, the system may not propagate dialog to delete the images,
+        // and when you exceed 10_000 you receive a `NullPointerException`.
+        private const val MEDIASTORE_DELETE_BATCH_LIMIT = 5000
     }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
@@ -401,7 +401,6 @@ class MainActivity : BaseActivity() {
             isDeletion = true,
             onConfirmation = { onConfirmation(filesUploadedRecently, filesUriToDelete) }
         )
-
     }
 
     private fun onDestinationChanged(destination: NavDestination, navigationArgs: Bundle?) {
@@ -627,6 +626,6 @@ class MainActivity : BaseActivity() {
         // Maximum number of elements in the list supported by the mediastore when Uris are to be deleted.
         // When you exceed this value, the system may not propagate dialog to delete the images,
         // and when you exceed 10_000 you receive a `NullPointerException`.
-        private const val MEDIASTORE_DELETE_BATCH_LIMIT = 50
+        private const val MEDIASTORE_DELETE_BATCH_LIMIT = 5_000
     }
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
@@ -114,7 +114,6 @@ class MainActivity : BaseActivity() {
 
     private lateinit var downloadReceiver: DownloadReceiver
 
-    private var uploadedFilesToDelete = arrayListOf<UploadFile>()
     private var hasDisplayedInformationPanel: Boolean = false
 
     private lateinit var drivePermissions: DrivePermissions

--- a/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
@@ -376,9 +376,11 @@ class MainActivity : BaseActivity() {
 
         fun onConfirmation(filesUploadedRecently: ArrayList<UploadFile>, filesUriToDelete: List<Uri>) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                pendingFilesUrisQueue.clear()
-                pendingFilesUrisQueue.addAll(filesUriToDelete.chunked(MEDIASTORE_DELETE_BATCH_LIMIT))
-                launchNextDeleteRequest()
+                lifecycleScope.launch {
+                    pendingFilesUrisQueue.clear()
+                    pendingFilesUrisQueue.addAll(filesUriToDelete.chunked(MEDIASTORE_DELETE_BATCH_LIMIT))
+                    launchNextDeleteRequest()
+                }
             } else {
                 mainViewModel.deleteSynchronizedFilesOnDevice(filesUploadedRecently)
             }

--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -531,7 +531,7 @@ class MainViewModel(
         syncOfflineFilesJob.cancel()
     }
 
-    @Deprecated(message = "Only for API 29 and below, otherwise use MediaStore.createDeleteRequest()")
+    // Only for API 29 and below, otherwise use MediaStore.createDeleteRequest()
     fun deleteSynchronizedFilesOnDevice(filesToDelete: ArrayList<UploadFile>) = viewModelScope.launch(Dispatchers.IO) {
         val fileDeleted = arrayListOf<UploadFile>()
         filesToDelete.forEach { uploadFile ->
@@ -541,10 +541,9 @@ class MainViewModel(
                 query?.use { cursor ->
                     if (cursor.moveToFirst()) {
                         var columnIndex: Int? = null
-                        var pathname: String? = null
                         try {
                             columnIndex = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA)
-                            pathname = cursor.getString(columnIndex)
+                            val pathname = cursor.getString(columnIndex)
                             IOFile(pathname).delete()
                             getContext().contentResolver.delete(uri, null, null)
                         } catch (nullPointerException: NullPointerException) {

--- a/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Utils.kt
@@ -82,7 +82,7 @@ object Utils {
         autoDismiss: Boolean = true,
         isDeletion: Boolean = false,
         onConfirmation: (dialog: Dialog) -> Unit
-    ) {
+    ): AlertDialog {
         val style = if (isDeletion) R.style.DeleteDialogStyle else R.style.DialogStyle
         val dialog = MaterialAlertDialogBuilder(context, style)
             .setTitle(title)
@@ -101,6 +101,7 @@ object Utils {
                 dialog.getButton(AlertDialog.BUTTON_NEGATIVE).isEnabled = false
             }
         }
+        return dialog
     }
 
     fun confirmFileDeletion(


### PR DESCRIPTION
- Make a chunk of 5000 per uris when we exceed, because even before 10_000 it happens that the query does not work.
- Avoid multiple dialogs when requesting media deletion
- Make sure that the request is made only in Start rather than in summary, which didn't make much sense.