### PR TITLE
refactor: Move `goToPlayStore()` from Legacy to new Core

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/UpdateAvailableBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/UpdateAvailableBottomSheetDialog.kt
@@ -21,9 +21,9 @@ import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.activityViewModels
+import com.infomaniak.core.extensions.goToPlayStore
 import com.infomaniak.drive.R
 import com.infomaniak.lib.core.utils.getAppName
-import com.infomaniak.lib.core.utils.goToPlayStore
 import com.infomaniak.lib.stores.StoresSettingsRepository
 import com.infomaniak.lib.stores.StoresViewModel
 


### PR DESCRIPTION
Depends on https://github.com/Infomaniak/android-core/pull/302