### PR TITLE
chore(Sentry): Remove Sentry when my kSuite data fields are null before Production

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/utils/MyKSuiteDataUtils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/MyKSuiteDataUtils.kt
@@ -42,9 +42,7 @@ object MyKSuiteDataUtils : MyKSuiteDataManager() {
         } else {
             @OptIn(ExperimentalSerializationApi::class)
             apiResponse.error?.exception?.let {
-                if (it is MissingFieldException || it.message?.contains("Unexpected JSON token") == true) {
-                    SentryLog.e(TAG, "Error decoding the api result MyKSuiteObject", it)
-                }
+                if (it is MissingFieldException) SentryLog.e(TAG, "Error decoding the api result MyKSuiteObject", it)
             }
         }
 


### PR DESCRIPTION
It can happens 0.003% of the time, so we just ignore it