### PR TITLE
fix: Drop too old schema 0 DriveInfos instead of crashing

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
@@ -25,24 +25,23 @@ import com.infomaniak.drive.data.models.drive.Drive
 import com.infomaniak.drive.data.models.drive.DriveInfo
 import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.RealmModules
-import io.realm.Realm
-import io.realm.RealmConfiguration
-import io.realm.RealmQuery
-import io.realm.Sort
+import io.realm.*
 import io.realm.kotlin.oneOf
 
 object DriveInfosController {
 
     private const val DB_NAME = "DrivesInfos.realm"
 
-    private val realmConfiguration = RealmConfiguration.Builder()
+    val baseDriveInfosRealmConfigurationBuilder: RealmConfiguration.Builder = RealmConfiguration.Builder()
         .name(DB_NAME)
         .schemaVersion(DriveMigration.DB_VERSION) // Must be bumped when the schema changes
-        .migration(DriveMigration())
         .modules(RealmModules.DriveFilesModule())
+
+    private val realmConfiguration = baseDriveInfosRealmConfigurationBuilder
+        .migration(DriveMigration())
         .build()
 
-    fun getRealmInstance(): Realm = Realm.getInstance(realmConfiguration)
+    fun getRealmInstance(): Realm = HandleSchemaVersionBelowZero.getInstance(realmConfiguration)
 
     private fun ArrayList<Drive>.initDriveForRealm(
         drive: Drive,

--- a/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/DriveInfosController.kt
@@ -25,7 +25,10 @@ import com.infomaniak.drive.data.models.drive.Drive
 import com.infomaniak.drive.data.models.drive.DriveInfo
 import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.RealmModules
-import io.realm.*
+import io.realm.Realm
+import io.realm.RealmConfiguration
+import io.realm.RealmQuery
+import io.realm.Sort
 import io.realm.kotlin.oneOf
 
 object DriveInfosController {
@@ -41,7 +44,7 @@ object DriveInfosController {
         .migration(DriveMigration())
         .build()
 
-    fun getRealmInstance(): Realm = HandleSchemaVersionBelowZero.getInstance(realmConfiguration)
+    fun getRealmInstance(): Realm = HandleSchemaVersionBelowZero.getRealmInstance(realmConfiguration)
 
     private fun ArrayList<Drive>.initDriveForRealm(
         drive: Drive,

--- a/app/src/main/java/com/infomaniak/drive/data/cache/HandleSchemaVersionBelowZero.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/HandleSchemaVersionBelowZero.kt
@@ -27,7 +27,7 @@ object HandleSchemaVersionBelowZero {
         .migration(DetectTooOldSchemaMigration())
         .build()
 
-    private val deleteTooOldSchemaVersionRealmConfiguration = DriveInfosController.baseDriveInfosRealmConfigurationBuilder
+    private val deleteRealmConfiguration = DriveInfosController.baseDriveInfosRealmConfigurationBuilder
         .deleteRealmIfMigrationNeeded()
         .build()
 
@@ -41,7 +41,7 @@ object HandleSchemaVersionBelowZero {
             Realm.getInstance(throwOldSchemaVersionRealmConfiguration)
         }.getOrElse {
             if (it is OldSchemaVersion && it.oldVersion == 0L) {
-                Realm.getInstance(deleteTooOldSchemaVersionRealmConfiguration)
+                Realm.getInstance(deleteRealmConfiguration)
             } else {
                 throw requireNotNull(originalMigrationException) { "This field must have been set when the first runCatching has failed" }
             }

--- a/app/src/main/java/com/infomaniak/drive/data/cache/HandleSchemaVersionBelowZero.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/HandleSchemaVersionBelowZero.kt
@@ -31,7 +31,7 @@ object HandleSchemaVersionBelowZero {
         .deleteRealmIfMigrationNeeded()
         .build()
 
-    fun getInstance(realmConfiguration: RealmConfiguration): Realm {
+    fun getRealmInstance(realmConfiguration: RealmConfiguration): Realm {
         var originalMigrationException: Throwable? = null
 
         return runCatching {

--- a/app/src/main/java/com/infomaniak/drive/data/cache/HandleSchemaVersionBelowZero.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/HandleSchemaVersionBelowZero.kt
@@ -1,0 +1,56 @@
+/*
+ * Infomaniak kDrive - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.drive.data.cache
+
+import io.realm.DynamicRealm
+import io.realm.Realm
+import io.realm.RealmConfiguration
+import io.realm.RealmMigration
+
+object HandleSchemaVersionBelowZero {
+    private val throwOldSchemaVersionRealmConfiguration = DriveInfosController.baseDriveInfosRealmConfigurationBuilder
+        .migration(DetectTooOldSchemaMigration())
+        .build()
+
+    private val deleteTooOldSchemaVersionRealmConfiguration = DriveInfosController.baseDriveInfosRealmConfigurationBuilder
+        .deleteRealmIfMigrationNeeded()
+        .build()
+
+    fun getInstance(realmConfiguration: RealmConfiguration): Realm {
+        var originalMigrationException: Throwable? = null
+
+        return runCatching {
+            Realm.getInstance(realmConfiguration)
+        }.recoverCatching {
+            originalMigrationException = it
+            Realm.getInstance(throwOldSchemaVersionRealmConfiguration)
+        }.getOrElse {
+            if (it is OldSchemaVersion && it.oldVersion == 0L) {
+                Realm.getInstance(deleteTooOldSchemaVersionRealmConfiguration)
+            } else {
+                throw requireNotNull(originalMigrationException) { "This field must have been set when the first runCatching has failed" }
+            }
+        }
+    }
+
+    private class DetectTooOldSchemaMigration : RealmMigration {
+        override fun migrate(realm: DynamicRealm, oldVersion: Long, newVersion: Long) = throw OldSchemaVersion(oldVersion)
+    }
+
+    private class OldSchemaVersion(val oldVersion: Long) : Exception()
+}


### PR DESCRIPTION
DB that have configuration dating back to 4.4.7 or earlier that update to the 5.4.0 or superior keep on crashing when booting because the migration fails because it only supports DB configurations of 4.4.8+

This PR can detect if a migration failed due to the mentioned issue or not and delete the realm altogether as a migration in this only case. The reste of the time, the realm will continue crashing as usual if we ever make other mistakes in futur migrations