### PR TITLE
feat: Manage my ksuite quotas locally

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/FileDetailsInfoFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/FileDetailsInfoFragment.kt
@@ -299,7 +299,7 @@ class FileDetailsInfoFragment : FileDetailsSubFragment() {
             if (apiResponse.isSuccess()) {
                 binding.shareLinkContainer.update(apiResponse.data)
             } else {
-                showSnackbar(R.string.errorShareLink)
+                showSnackbar(apiResponse.translateError())
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareDetailsFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareDetailsFragment.kt
@@ -266,7 +266,7 @@ class FileShareDetailsFragment : Fragment() {
             if (apiResponse.isSuccess()) {
                 binding.shareLinkContainer.update(apiResponse.data)
             } else {
-                showSnackbar(R.string.errorShareLink)
+                showSnackbar(apiResponse.translateError())
             }
         }
     }


### PR DESCRIPTION
Increment and decrement locally the quota for Dropbox or FileShare to be a bit more up to date without having to call the api more

The sonar duplication issue is inherited from the old code, and will be adressed in the next PR