### PR TITLE
fix(BackgroundSyncBattery): Fix crash when asking for background sync permissions the first time

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
@@ -188,7 +188,7 @@ class SyncSettingsActivity : BaseActivity() {
 
         saveButton.initProgress(this@SyncSettingsActivity)
         saveButton.setOnClickListener {
-            if (drivePermissions.checkSyncPermissions()) saveSettings()
+            if (drivePermissions.checkSyncPermissions(showBatteryDialog = false)) saveSettings()
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
@@ -124,7 +124,7 @@ class SyncSettingsActivity : BaseActivity() {
 
     override fun onResume() {
         super.onResume()
-        saveSettingVisibility(binding.activateSyncSwitch.isChecked)
+        saveSettingVisibility(isVisible = binding.activateSyncSwitch.isChecked, showBatteryDialog = false)
     }
 
     private fun initUserAndDrive() {
@@ -145,10 +145,12 @@ class SyncSettingsActivity : BaseActivity() {
 
         activateSync.setOnClickListener { activateSyncSwitch.isChecked = !activateSyncSwitch.isChecked }
         activateSyncSwitch.setOnCheckedChangeListener { _, isChecked ->
-            saveSettingVisibility(isChecked)
+            saveSettingVisibility(isVisible = isChecked, showBatteryDialog = isChecked)
             if (AccountUtils.isEnableAppSync() == isChecked) editNumber-- else editNumber++
             if (isChecked && !drivePermissions.checkUserChoiceStoragePermission()) {
-                drivePermissions.checkSyncPermissions()
+                // We only request permissions if user haven't chosen the "selected image" permission to avoid spamming him
+                // with this files choosing UI
+                drivePermissions.checkWriteStoragePermission()
             }
             changeSaveButtonStatus()
         }
@@ -327,8 +329,8 @@ class SyncSettingsActivity : BaseActivity() {
         selectDrive.setOnClickListener { SelectDriveDialog().show(supportFragmentManager, "SyncSettingsSelectDriveDialog") }
     }
 
-    private fun saveSettingVisibility(isVisible: Boolean) = with(binding) {
-        val hasPermissions = drivePermissions.checkSyncPermissions(requestPermission = false)
+    private fun saveSettingVisibility(isVisible: Boolean, showBatteryDialog: Boolean) = with(binding) {
+        val hasPermissions = drivePermissions.checkSyncPermissions(requestPermission = false, showBatteryDialog)
         photoAccessDeniedLayout.isVisible = isVisible && !hasPermissions
         photoAccessDeniedTitle.setText(DrivePermissions.permissionNeededDescriptionRes)
         settingsLayout.isVisible = isVisible && hasPermissions

--- a/app/src/main/java/com/infomaniak/drive/utils/DrivePermissions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/DrivePermissions.kt
@@ -85,9 +85,14 @@ class DrivePermissions {
 
     /**
      * Check if the sync has all permissions to work
+     *
+     * @param requestPermission Whether or not the app should just check if it has the permissions,
+     * or requests it if it's not the case
+     * @param showBatteryDialog We want to be able to show the battery dialog even if we don't request the mandatory permissions
+     *
      * @return [Boolean] true if the sync has all permissions or false
      */
-    fun checkSyncPermissions(requestPermission: Boolean = true): Boolean {
+    fun checkSyncPermissions(requestPermission: Boolean = true, showBatteryDialog: Boolean = true): Boolean {
 
         fun displayBatteryDialog() {
             with(backgroundSyncPermissionsBottomSheetDialog) {
@@ -97,7 +102,7 @@ class DrivePermissions {
             }
         }
 
-        if (UiSettings(activity).mustDisplayBatteryDialog || !checkBatteryLifePermission(false)) {
+        if (showBatteryDialog && (UiSettings(activity).mustDisplayBatteryDialog || !checkBatteryLifePermission(false))) {
             displayBatteryDialog()
         }
 

--- a/app/src/main/java/com/infomaniak/drive/utils/SyncUtils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/SyncUtils.kt
@@ -80,7 +80,7 @@ object SyncUtils {
 
     fun FragmentActivity.launchAllUpload(drivePermissions: DrivePermissions) {
         if (AccountUtils.isEnableAppSync() &&
-            drivePermissions.checkSyncPermissions(false) &&
+            drivePermissions.checkSyncPermissions(requestPermission = false) &&
             UploadFile.getAllPendingUploads().isNotEmpty()
         ) {
             syncImmediately()


### PR DESCRIPTION
A double check to the permissions added the dialog two times in a row, thus provocking an IllegalStateException

I didn't way the "long" way of migrating the navigation to BottomSheetFragment to a safeArgs style because of the refactor that would imply. Due to the many different contexts of usage of this code, the refactor would be a bit costly and could easily introduce oversight. 
It's probably the permissions as a whole which could be refactored if we wanted to go this way