### PR TITLE
chore: Improve Gradle plugins version management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
 
-    project.ext.kotlinVersion = '2.0.21'
+    project.ext.kotlinVersion = '2.1.21'
 
     dependencies {
         classpath 'androidx.navigation:navigation-safe-args-gradle-plugin:2.9.0'
@@ -14,9 +14,10 @@ buildscript {
 
 plugins {
     id 'io.sentry.android.gradle' version '3.1.5'
+    alias core.plugins.compose.compiler version "$kotlinVersion" apply false
     id 'org.jetbrains.kotlin.android' version "$kotlinVersion" apply false
     id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlinVersion" apply false
-    id 'com.google.devtools.ksp' version '2.0.21-1.0.28' apply false
+    id 'com.google.devtools.ksp' version '2.1.21-2.0.1' apply false
 }
 
 tasks.register('clean', Delete) { delete rootProject.layout.buildDirectory }


### PR DESCRIPTION
This allows the project to use Kotlin 2.1+.
This commit also upgrades the Sentry Gradle plugin.