### PR TITLE
chore: Bump GeniusScan SDK from 5.6.1 to 5.11.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -192,7 +192,7 @@ dependencies {
     implementation("com.github.realm:realm-android-adapters:v4.0.0")
 
     "standardImplementation"("com.google.firebase:firebase-messaging-ktx:24.1.1")
-    "standardImplementation"("com.geniusscansdk:gssdk:5.6.1")
+    "standardImplementation"("com.geniusscansdk:gssdk:5.11.0")
 
     implementation("com.googlecode.plist:dd-plist:1.28")
 


### PR DESCRIPTION
There was no interesting changes, only bug fixes and internal enhancements, so no changes are needed on our side.

https://geniusscansdk.com/docs/changelog/