### PR TITLE
fix: Folder name when save external file and select other drive 

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/MainApplication.kt
+++ b/app/src/main/java/com/infomaniak/drive/MainApplication.kt
@@ -222,10 +222,11 @@ class MainApplication : Application(), ImageLoaderFactory, DefaultLifecycleObser
             AccountUtils.removeUserAndDeleteToken(this@MainApplication, user)
         }
     }
-   private fun configureSentry() {
+
+    private fun configureSentry() {
         this.configureSentry(
             isDebug = BuildConfig.DEBUG,
             isSentryTrackingEnabled = UiSettings(applicationContext).isSentryTrackingEnabled,
         )
-   }
+    }
 }

--- a/app/src/main/java/com/infomaniak/drive/MainApplication.kt
+++ b/app/src/main/java/com/infomaniak/drive/MainApplication.kt
@@ -194,16 +194,10 @@ class MainApplication : Application(), ImageLoaderFactory, DefaultLifecycleObser
     }
 
     override fun newImageLoader(): ImageLoader {
-        val factory = if (SDK_INT >= 28) {
-            ImageDecoderDecoder.Factory()
-        } else {
-            GifDecoder.Factory()
-        }
-
-        return CoilUtils.newImageLoader(applicationContext, tokenInterceptorListener(), customFactories = listOf(factory))
+        return newImageLoader(userId = null)
     }
 
-    fun newImageLoader(userId: Int? = null): ImageLoader {
+    fun newImageLoader(userId: Int?): ImageLoader {
 
         val tokenInterceptorListener = when (userId) {
             null -> tokenInterceptorListener()

--- a/app/src/main/java/com/infomaniak/drive/MainApplication.kt
+++ b/app/src/main/java/com/infomaniak/drive/MainApplication.kt
@@ -42,22 +42,18 @@ import com.infomaniak.drive.GeniusScanUtils.initGeniusScanSdk
 import com.infomaniak.drive.data.api.ErrorCode
 import com.infomaniak.drive.data.api.FileDeserialization
 import com.infomaniak.drive.data.documentprovider.CloudStorageProvider.Companion.initRealm
-import com.infomaniak.drive.data.models.AppSettings
 import com.infomaniak.drive.data.models.File
 import com.infomaniak.drive.data.models.UiSettings
 import com.infomaniak.drive.data.services.DeviceInfoUpdateWorker
 import com.infomaniak.drive.data.services.MqttClientWrapper
 import com.infomaniak.drive.ui.LaunchActivity
 import com.infomaniak.drive.utils.AccountUtils
-import com.infomaniak.drive.utils.AccountUtils.getUserById
-import com.infomaniak.drive.utils.AccountUtils.setUserToken
 import com.infomaniak.drive.utils.MyKSuiteDataUtils
 import com.infomaniak.drive.utils.NotificationUtils.buildGeneralNotification
 import com.infomaniak.drive.utils.NotificationUtils.initNotificationChannel
 import com.infomaniak.drive.utils.NotificationUtils.notifyCompat
 import com.infomaniak.lib.core.InfomaniakCore
 import com.infomaniak.lib.core.api.ApiController
-import com.infomaniak.lib.core.auth.TokenInterceptorListener
 import com.infomaniak.lib.core.models.user.User
 import com.infomaniak.lib.core.networking.AccessTokenUsageInterceptor
 import com.infomaniak.lib.core.networking.HttpClient
@@ -65,12 +61,10 @@ import com.infomaniak.lib.core.networking.HttpClientConfig
 import com.infomaniak.lib.core.utils.CoilUtils
 import com.infomaniak.lib.core.utils.NotificationUtilsCore.Companion.PENDING_INTENT_FLAGS
 import com.infomaniak.lib.core.utils.clearStack
-import com.infomaniak.lib.login.ApiToken
 import com.infomaniak.lib.stores.AppUpdateScheduler
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import splitties.init.injectAsAppCtx
@@ -125,7 +119,8 @@ class MainApplication : Application(), ImageLoaderFactory, DefaultLifecycleObser
 
         AccountUtils.onRefreshTokenError = refreshTokenError
         initNotificationChannel()
-        val tokenInterceptorListener = tokenInterceptorListener()
+        val tokenInterceptorListener =
+            TokenInterceptorListenerProvider.tokenInterceptorListener(refreshTokenError, applicationScope)
         HttpClientConfig.customInterceptors = listOf(
             AccessTokenUsageInterceptor(
                 previousApiCall = uiSettings.accessTokenApiCallRecord,
@@ -200,8 +195,8 @@ class MainApplication : Application(), ImageLoaderFactory, DefaultLifecycleObser
     fun newImageLoader(userId: Int?): ImageLoader {
 
         val tokenInterceptorListener = when (userId) {
-            null -> tokenInterceptorListener()
-            else -> tokenInterceptorListenerByUserId(userId)
+            null -> TokenInterceptorListenerProvider.tokenInterceptorListener(refreshTokenError, applicationScope)
+            else -> TokenInterceptorListenerProvider.tokenInterceptorListenerByUserId(refreshTokenError, userId)
         }
 
         val factory = if (SDK_INT >= 28) {
@@ -227,46 +222,6 @@ class MainApplication : Application(), ImageLoaderFactory, DefaultLifecycleObser
             AccountUtils.removeUserAndDeleteToken(this@MainApplication, user)
         }
     }
-
-    private fun tokenInterceptorListener() = object : TokenInterceptorListener {
-        val userTokenFlow by lazy { AppSettings.currentUserIdFlow.mapToApiToken(applicationScope) }
-
-        override suspend fun onRefreshTokenSuccess(apiToken: ApiToken) {
-            if (AccountUtils.currentUser == null) AccountUtils.requestCurrentUser()
-            AccountUtils.setUserToken(AccountUtils.currentUser!!, apiToken)
-        }
-
-        override suspend fun onRefreshTokenError() {
-            if (AccountUtils.currentUser == null) AccountUtils.requestCurrentUser()
-            refreshTokenError(AccountUtils.currentUser!!)
-        }
-
-        override suspend fun getUserApiToken(): ApiToken? = userTokenFlow.first()
-
-        override fun getCurrentUserId(): Int = AccountUtils.currentUserId
-    }
-
-    private fun tokenInterceptorListenerByUserId(userId: Int) = object : TokenInterceptorListener {
-        val onRefreshTokenError: ((user: User) -> Unit)? = null
-
-        override suspend fun onRefreshTokenSuccess(apiToken: ApiToken) {
-            val user = getUserById(userId)
-            setUserToken(user, apiToken)
-        }
-
-        override suspend fun onRefreshTokenError() {
-            val user = getUserById(userId)
-            user?.let { onRefreshTokenError?.invoke(it) }
-        }
-
-        override suspend fun getUserApiToken(): ApiToken? {
-            val user = getUserById(userId)
-            return user?.apiToken
-        }
-
-        override fun getCurrentUserId() = null
-    }
-
    private fun configureSentry() {
         this.configureSentry(
             isDebug = BuildConfig.DEBUG,

--- a/app/src/main/java/com/infomaniak/drive/TokenInterceptorListenerProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/TokenInterceptorListenerProvider.kt
@@ -1,0 +1,77 @@
+/*
+ * Infomaniak kDrive - Android
+ * Copyright (C) 2025 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.drive
+
+import com.infomaniak.drive.data.models.AppSettings
+import com.infomaniak.drive.utils.AccountUtils
+import com.infomaniak.drive.utils.AccountUtils.getUserById
+import com.infomaniak.drive.utils.AccountUtils.setUserToken
+import com.infomaniak.lib.core.auth.TokenInterceptorListener
+import com.infomaniak.lib.core.models.user.User
+import com.infomaniak.lib.login.ApiToken
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+
+object TokenInterceptorListenerProvider {
+    private suspend fun onRefreshTokenSuccessCommon(apiToken: ApiToken, user: User?) = setUserToken(user!!, apiToken)
+    private suspend fun onRefreshTokenErrorCommon(refreshTokenError: (User) -> Unit, user: User?) = refreshTokenError(user!!)
+
+    fun tokenInterceptorListener(
+        refreshTokenError: (User) -> Unit,
+        globalCoroutineScope: CoroutineScope,
+    ): TokenInterceptorListener = object : TokenInterceptorListener {
+        val userTokenFlow by lazy { AppSettings.currentUserIdFlow.mapToApiToken(globalCoroutineScope) }
+        override suspend fun onRefreshTokenSuccess(apiToken: ApiToken) {
+            if (AccountUtils.currentUser == null) AccountUtils.requestCurrentUser()
+            onRefreshTokenSuccessCommon(apiToken, AccountUtils.currentUser)
+        }
+
+        override suspend fun onRefreshTokenError() {
+            if (AccountUtils.currentUser == null) AccountUtils.requestCurrentUser()
+            onRefreshTokenErrorCommon(refreshTokenError, AccountUtils.currentUser!!)
+        }
+
+        override suspend fun getUserApiToken(): ApiToken? = userTokenFlow.first()
+
+        override fun getCurrentUserId(): Int = AccountUtils.currentUserId
+    }
+
+    fun tokenInterceptorListenerByUserId(
+        refreshTokenError: (User) -> Unit,
+        userId: Int,
+    ): TokenInterceptorListener = object : TokenInterceptorListener {
+        override suspend fun onRefreshTokenSuccess(apiToken: ApiToken) {
+            val user = getUserById(userId)
+            onRefreshTokenSuccessCommon(apiToken, user)
+        }
+
+        override suspend fun onRefreshTokenError() {
+            val user = getUserById(userId)
+            onRefreshTokenErrorCommon(refreshTokenError, user)
+        }
+
+        override suspend fun getUserApiToken(): ApiToken? {
+            val user = getUserById(userId)
+            return user?.apiToken
+        }
+
+        override fun getCurrentUserId(): Int = userId
+    }
+
+
+}

--- a/app/src/main/java/com/infomaniak/drive/TokenInterceptorListenerProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/TokenInterceptorListenerProvider.kt
@@ -28,14 +28,16 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 
 object TokenInterceptorListenerProvider {
-    private suspend fun onRefreshTokenSuccessCommon(apiToken: ApiToken, user: User?) = setUserToken(user!!, apiToken)
-    private suspend fun onRefreshTokenErrorCommon(refreshTokenError: (User) -> Unit, user: User?) = refreshTokenError(user!!)
+
+    private suspend fun onRefreshTokenSuccessCommon(apiToken: ApiToken, user: User?) = setUserToken(user, apiToken)
+    private fun onRefreshTokenErrorCommon(refreshTokenError: (User) -> Unit, user: User?) = refreshTokenError(user!!)
 
     fun tokenInterceptorListener(
         refreshTokenError: (User) -> Unit,
-        globalCoroutineScope: CoroutineScope,
+        coroutineScope: CoroutineScope,
     ): TokenInterceptorListener = object : TokenInterceptorListener {
-        val userTokenFlow by lazy { AppSettings.currentUserIdFlow.mapToApiToken(globalCoroutineScope) }
+        val userTokenFlow by lazy { AppSettings.currentUserIdFlow.mapToApiToken(coroutineScope) }
+
         override suspend fun onRefreshTokenSuccess(apiToken: ApiToken) {
             if (AccountUtils.currentUser == null) AccountUtils.requestCurrentUser()
             onRefreshTokenSuccessCommon(apiToken, AccountUtils.currentUser)
@@ -72,6 +74,4 @@ object TokenInterceptorListenerProvider {
 
         override fun getCurrentUserId(): Int = userId
     }
-
-
 }

--- a/app/src/main/java/com/infomaniak/drive/data/api/ApiRepository.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/ApiRepository.kt
@@ -150,7 +150,7 @@ object ApiRepository : ApiRepositoryCore() {
         file: File,
         cursor: String?,
         forFileList: Boolean,
-        okHttpClient: OkHttpClient = HttpClient.okHttpClientLongTimeout,
+        okHttpClient: OkHttpClient = okHttpClientLongTimeout,
     ): CursorApiResponse<ArrayList<FileActivity>> {
         val url = ApiRoutes.getFileActivities(file, forFileList, loadCursor(cursor))
         return callApiWithCursor(url, GET, okHttpClient = okHttpClient)
@@ -166,7 +166,7 @@ object ApiRepository : ApiRepositoryCore() {
         driveId: Int,
         fileIds: List<Int>,
         fromDate: Long,
-        okHttpClient: OkHttpClient = HttpClient.okHttpClientLongTimeout,
+        okHttpClient: OkHttpClient = okHttpClientLongTimeout,
     ): ApiResponse<ArrayList<FileActivity>> {
         val formattedFileIds = fileIds.joinToString(",") { it.toString() }
         return callApi(ApiRoutes.getFileActivities(driveId, formattedFileIds, fromDate), GET, okHttpClient = okHttpClient)

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -179,18 +179,16 @@ object FileController {
             .toFlow()
     }
 
-    fun getRecentFolders(recentFolderNumber: Int): Flow<List<File>> {
-        return getRealmInstance().use { realm ->
-            realm.where(File::class.java)
-                .equalTo(File::type.name, Type.DIRECTORY.value)
-                .greaterThan(File::id.name, ROOT_ID)
-                .greaterThan(File::parentId.name, ROOT_ID)
-                .sort(File::lastModifiedAt.name, Sort.DESCENDING)
-                .limit(recentFolderNumber.toLong())
-                .sort(File::lastModifiedAt.name, Sort.ASCENDING)
-                .findAllAsync()
-                .toFlow()
-        }
+    fun getRecentFolders(realm: Realm, recentFolderNumber: Int): Flow<List<File>> {
+        return realm.where(File::class.java)
+            .equalTo(File::type.name, Type.DIRECTORY.value)
+            .greaterThan(File::id.name, ROOT_ID)
+            .greaterThan(File::parentId.name, ROOT_ID)
+            .sort(File::lastModifiedAt.name, Sort.DESCENDING)
+            .limit(recentFolderNumber.toLong())
+            .sort(File::lastModifiedAt.name, Sort.ASCENDING)
+            .findAllAsync()
+            .toFlow()
     }
 
     //region isMarkedAsOffline

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FolderFilesProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FolderFilesProvider.kt
@@ -31,6 +31,7 @@ import com.infomaniak.drive.data.services.MqttClientWrapper
 import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.FileId
 import com.infomaniak.drive.utils.Utils.ROOT_ID
+import com.infomaniak.lib.core.networking.HttpClient
 import com.infomaniak.lib.core.utils.SentryLog
 import io.realm.Realm
 import io.realm.RealmQuery
@@ -239,7 +240,7 @@ object FolderFilesProvider {
 
         ensureActive()
 
-        handleRemoteFiles(realm, apiResponse, folderFilesProviderArgs, folderProxy)
+        handleRemoteFiles(realm, apiResponse, folderFilesProviderArgs, folderProxy, okHttpClient)
     }
 
     private fun loadCloudStorageFromRemote(
@@ -278,13 +279,14 @@ object FolderFilesProvider {
         apiResponse: CursorApiResponse<List<File>>,
         folderFilesProviderArgs: FolderFilesProviderArgs,
         folderProxy: File?,
+        okHttpClient: OkHttpClient = HttpClient.okHttpClient,
     ): FolderFilesProviderResult? {
         val userDrive = folderFilesProviderArgs.userDrive
         val apiResponseData = apiResponse.data
         val folderWithChildren = folderFilesProviderArgs.withChildren
 
         val localFolder = folderProxy?.freeze()
-            ?: ApiRepository.getFileDetails(File(id = folderFilesProviderArgs.folderId, driveId = userDrive.driveId)).data
+            ?: ApiRepository.getFileDetails(File(id = folderFilesProviderArgs.folderId, driveId = userDrive.driveId), okHttpClient).data
             ?: return null
 
         return when {

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FolderFilesProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FolderFilesProvider.kt
@@ -19,6 +19,8 @@ package com.infomaniak.drive.data.cache
 
 import androidx.collection.ArrayMap
 import androidx.collection.arrayMapOf
+import com.infomaniak.core.network.networking.HttpClient
+import com.infomaniak.core.sentry.SentryLog
 import com.infomaniak.drive.data.api.ApiRepository
 import com.infomaniak.drive.data.api.CursorApiResponse
 import com.infomaniak.drive.data.cache.FileController.saveRemoteFiles
@@ -31,8 +33,6 @@ import com.infomaniak.drive.data.services.MqttClientWrapper
 import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.FileId
 import com.infomaniak.drive.utils.Utils.ROOT_ID
-import com.infomaniak.lib.core.networking.HttpClient
-import com.infomaniak.lib.core.utils.SentryLog
 import io.realm.Realm
 import io.realm.RealmQuery
 import io.sentry.Sentry
@@ -286,7 +286,10 @@ object FolderFilesProvider {
         val folderWithChildren = folderFilesProviderArgs.withChildren
 
         val localFolder = folderProxy?.freeze()
-            ?: ApiRepository.getFileDetails(File(id = folderFilesProviderArgs.folderId, driveId = userDrive.driveId), okHttpClient).data
+            ?: ApiRepository.getFileDetails(
+                File(id = folderFilesProviderArgs.folderId, driveId = userDrive.driveId),
+                okHttpClient
+            ).data
             ?: return null
 
         return when {

--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -189,7 +189,6 @@ class SaveExternalFilesActivity : BaseActivity() {
         selectDriveViewModel.apply {
             selectedUserId.value = userId
             selectedDrive.value = drive
-            showSharedWithMe = true
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
@@ -76,14 +76,12 @@ open class FileAdapter(
     var isSelectingFolder = false
     var showShareFileButton = true
     var viewHolderType: DisplayType = DisplayType.LIST
-
-    var newImageLoader: ImageLoader? = null
-
     var uploadInProgress = false
     var publicShareCanDownload = true
 
     var isComplete = false
     var isHomeOffline = false
+    var newImageLoader: ImageLoader? = null
 
     private var offlineMode = false
     private var pendingWifiConnection = false
@@ -332,12 +330,12 @@ open class FileAdapter(
                 is CardviewFileListBinding -> (binding as CardviewFileListBinding).itemViewFile.setFileItem(
                     file = file,
                     isGrid = isGrid,
-                    imageLoader = getNewImageLoader(binding.context)
+                    imageLoader = getNewImageLoader(binding.context),
                 )
                 is CardviewFileGridBinding -> (binding as CardviewFileGridBinding).setFileItem(
                     file = file,
                     isGrid = isGrid,
-                    imageLoader = getNewImageLoader(binding.context)
+                    imageLoader = getNewImageLoader(binding.context),
                 )
                 is CardviewFolderGridBinding -> (binding as CardviewFolderGridBinding).setFileItem(file = file, isGrid = isGrid)
             }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
@@ -31,6 +31,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 import coil.ImageLoader
+import coil.imageLoader
 import com.google.android.material.card.MaterialCardView
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.AppSettings
@@ -77,6 +78,7 @@ open class FileAdapter(
     var viewHolderType: DisplayType = DisplayType.LIST
 
     var newImageLoader: ImageLoader? = null
+
     var uploadInProgress = false
     var publicShareCanDownload = true
 
@@ -87,6 +89,8 @@ open class FileAdapter(
     private var pendingWifiConnection = false
     private var showLoading = false
     private var fileAdapterObserver: AdapterDataObserver? = null
+
+    private fun getNewImageLoader(context: Context) = newImageLoader ?: context.imageLoader
 
     private fun createFileAdapterObserver(recyclerView: RecyclerView) = object : AdapterDataObserver() {
 
@@ -325,9 +329,17 @@ open class FileAdapter(
 
         currentBindScope.launch(start = CoroutineStart.UNDISPATCHED) {
             when (binding) {
-                is CardviewFileListBinding -> (binding as CardviewFileListBinding).itemViewFile.setFileItem(file, isGrid, newImageLoader)
-                is CardviewFileGridBinding -> (binding as CardviewFileGridBinding).setFileItem(file, isGrid, newImageLoader)
-                is CardviewFolderGridBinding -> (binding as CardviewFolderGridBinding).setFileItem(file, isGrid)
+                is CardviewFileListBinding -> (binding as CardviewFileListBinding).itemViewFile.setFileItem(
+                    file = file,
+                    isGrid = isGrid,
+                    imageLoader = getNewImageLoader(binding.context)
+                )
+                is CardviewFileGridBinding -> (binding as CardviewFileGridBinding).setFileItem(
+                    file = file,
+                    isGrid = isGrid,
+                    imageLoader = getNewImageLoader(binding.context)
+                )
+                is CardviewFolderGridBinding -> (binding as CardviewFolderGridBinding).setFileItem(file = file, isGrid = isGrid)
             }
         }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
@@ -30,6 +30,7 @@ import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
+import coil.ImageLoader
 import com.google.android.material.card.MaterialCardView
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.AppSettings
@@ -61,7 +62,7 @@ import java.util.UUID
 open class FileAdapter(
     private val multiSelectManager: MultiSelectManager,
     var fileList: OrderedRealmCollection<File> = RealmList(),
-    override val lifecycle: Lifecycle
+    override val lifecycle: Lifecycle,
 ) : RealmRecyclerViewAdapter<File, FileViewHolder>(fileList, true, true), LifecycleOwner {
 
     private var fileAsyncListDiffer: AsyncListDiffer<File>? = null
@@ -75,6 +76,7 @@ open class FileAdapter(
     var showShareFileButton = true
     var viewHolderType: DisplayType = DisplayType.LIST
 
+    var newImageLoader: ImageLoader? = null
     var uploadInProgress = false
     var publicShareCanDownload = true
 
@@ -323,8 +325,8 @@ open class FileAdapter(
 
         currentBindScope.launch(start = CoroutineStart.UNDISPATCHED) {
             when (binding) {
-                is CardviewFileListBinding -> (binding as CardviewFileListBinding).itemViewFile.setFileItem(file, isGrid)
-                is CardviewFileGridBinding -> (binding as CardviewFileGridBinding).setFileItem(file, isGrid)
+                is CardviewFileListBinding -> (binding as CardviewFileListBinding).itemViewFile.setFileItem(file, isGrid, newImageLoader)
+                is CardviewFileGridBinding -> (binding as CardviewFileGridBinding).setFileItem(file, isGrid, newImageLoader)
                 is CardviewFolderGridBinding -> (binding as CardviewFolderGridBinding).setFileItem(file, isGrid)
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -500,22 +500,7 @@ open class FileListFragment : MultiSelectFragment(
                 mainApp.newImageLoader(userDrive?.userId)
             }
 
-            onFileClicked = { file ->
-                if (file.isUsable()) {
-                    when {
-                        file.isFolder() -> openFolder(
-                            FileListNavigationType.Folder(file),
-                            navigationArgs.shouldHideBottomNavigation,
-                            navigationArgs.shouldShowSmallFab,
-                            fileListViewModel,
-                        )
-                        file.isBookmark() -> openBookmark(file)
-                        else -> displayFile(file, mainViewModel, fileAdapter)
-                    }
-                } else {
-                    refreshActivities()
-                }
-            }
+            onFileClicked = getFunctionByFileType()
 
             onMenuClicked = { file ->
                 val fileObject = file.realm?.copyFromRealm(file, 1) ?: file
@@ -551,6 +536,23 @@ open class FileListFragment : MultiSelectFragment(
                 context?.let { fileAdapter.toggleOfflineMode(it, !isInternetAvailable) }
             },
         )
+    }
+
+    private fun getFunctionByFileType(): (File) -> Unit = { file ->
+        if (file.isUsable()) {
+            when {
+                file.isFolder() -> openFolder(
+                    FileListNavigationType.Folder(file),
+                    navigationArgs.shouldHideBottomNavigation,
+                    navigationArgs.shouldShowSmallFab,
+                    fileListViewModel,
+                )
+                file.isBookmark() -> openBookmark(file)
+                else -> displayFile(file, mainViewModel, fileAdapter)
+            }
+        } else {
+            refreshActivities()
+        }
     }
 
     protected open fun homeClassName(): String? = null

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -496,7 +496,9 @@ open class FileListFragment : MultiSelectFragment(
 
             onEmptyList = { checkIfNoFiles() }
 
-            newImageLoader = mainApp.newImageLoader(userDrive?.userId)
+            if (userDrive != null && userDrive?.userId != AccountUtils.currentUserId) {
+                mainApp.newImageLoader(userDrive?.userId)
+            }
 
             onFileClicked = { file ->
                 if (file.isUsable()) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -497,7 +497,7 @@ open class FileListFragment : MultiSelectFragment(
             onEmptyList = { checkIfNoFiles() }
 
             if (userDrive != null && userDrive?.userId != AccountUtils.currentUserId) {
-                mainApp.newImageLoader(userDrive?.userId)
+                newImageLoader = mainApp.newImageLoader(userDrive?.userId)
             }
 
             onFileClicked = getFunctionByFileType()

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -43,6 +43,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.work.WorkInfo
 import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.appbar.MaterialToolbar
+import com.infomaniak.drive.MainApplication
 import com.infomaniak.drive.MatomoDrive.MatomoCategory
 import com.infomaniak.drive.MatomoDrive.MatomoName
 import com.infomaniak.drive.MatomoDrive.trackEvent
@@ -483,15 +484,23 @@ open class FileListFragment : MultiSelectFragment(
             updateMultiSelect = { onUpdateMultiSelect() }
         }
 
+        val mainApp = requireContext().applicationContext as MainApplication
+
         fileAdapter = FileAdapter(
             multiSelectManager = multiSelectManager,
             fileList = FileController.emptyList(mainViewModel.realm),
-            lifecycle = viewLifecycleOwner.lifecycle
+            lifecycle = viewLifecycleOwner.lifecycle,
         ).apply {
             stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
             setHasStableIds(true)
 
             onEmptyList = { checkIfNoFiles() }
+
+            newImageLoader = if (userDrive?.userId != AccountUtils.currentUserId) {
+                mainApp.newImageLoaderWithOtherUserId(userDrive?.userId)
+            } else {
+                mainApp.newImageLoader()
+            }
 
             onFileClicked = { file ->
                 if (file.isUsable()) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -496,11 +496,7 @@ open class FileListFragment : MultiSelectFragment(
 
             onEmptyList = { checkIfNoFiles() }
 
-            newImageLoader = if (userDrive?.userId != AccountUtils.currentUserId) {
-                mainApp.newImageLoaderWithOtherUserId(userDrive?.userId)
-            } else {
-                mainApp.newImageLoader()
-            }
+            newImageLoader = mainApp.newImageLoader(userDrive?.userId)
 
             onFileClicked = { file ->
                 if (file.isUsable()) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
@@ -80,24 +80,25 @@ class FileListViewModel(application: Application) : AndroidViewModel(application
 
     var lastItemCount: FileCount? = null
 
-    private val loadRootFiles = MutableSharedFlow<UserDrive>(replay = 1)
+    private val rootFilesUserDrive = MutableSharedFlow<UserDrive>(replay = 1)
 
     fun sortTypeIsInitialized() = ::sortType.isInitialized
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val rootFiles: LiveData<Map<File.VisibilityType, File>> = loadRootFiles.distinctUntilChanged().flatMapLatest {
-        FileController.getRealmInstance(it).run {
-            realm = this
-            FileController.getFolderFilesFlow(this, Utils.ROOT_ID)
+    val rootFiles: LiveData<Map<File.VisibilityType, File>> =
+        rootFilesUserDrive.distinctUntilChanged().flatMapLatest { userDrive ->
+            FileController.getRealmInstance(userDrive).run {
+                realm = this
+                FileController.getFolderFilesFlow(this, Utils.ROOT_ID)
+            }
         }
-    }
-        .mapLatest { it.associateBy(File::getVisibilityType) }
-        .cancellable()
-        .asLiveData(viewModelScope.coroutineContext)
+            .mapLatest { it.associateBy(File::getVisibilityType) }
+            .cancellable()
+            .asLiveData(viewModelScope.coroutineContext)
 
     fun updateRootFiles(userDrive: UserDrive) {
         viewModelScope.launch {
-            loadRootFiles.emit(userDrive)
+            rootFilesUserDrive.emit(userDrive)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderActivity.kt
@@ -139,7 +139,7 @@ class SelectFolderActivity : BaseActivity() {
         }
     }
 
-    private fun navigateToCurrentFolder(currentUserDrive: UserDrive) {
+    private fun navigateToCurrentFolder(userDrive: UserDrive) {
         // Making sure the current backstack entry is selectRootFolderFragment because it'll generate a
         // crash when "Don't keep activities" is activated
         navController.popBackStack(R.id.selectRootFolderFragment, false)
@@ -149,14 +149,14 @@ class SelectFolderActivity : BaseActivity() {
                 navController.navigate(
                     SelectRootFolderFragmentDirections.selectRootFolderFragmentToSelectFolderFragment(
                         folderId = folderId,
-                        userDrive = currentUserDrive
+                        userDrive = userDrive
                     )
                 )
             } else {
                 navController.navigate(
                     SelectFolderFragmentDirections.fileListFragmentToFileListFragment(
                         folderId = folderId,
-                        userDrive = currentUserDrive
+                        userDrive = userDrive
                     )
                 )
             }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderActivity.kt
@@ -76,7 +76,7 @@ class SelectFolderActivity : BaseActivity() {
 
             navController.setGraph(
                 R.navigation.select_folder_navigation,
-                SelectRootFolderFragmentArgs(driveId = driveId, userDrive = currentUserDrive).toBundle()
+                SelectRootFolderFragmentArgs(userDrive = currentUserDrive).toBundle()
             )
 
             setSaveButton(customArgs)
@@ -132,7 +132,7 @@ class SelectFolderActivity : BaseActivity() {
 
     private fun MutableList<Int>.addNavigationIdsRecursively(folderId: Int, userDrive: UserDrive) {
         FileController.getParentFileProxy(folderId, userDrive, getCustomRealm(userDrive))?.id?.let { parentId ->
-            if (parentId != Utils.ROOT_ID) {
+            if (parentId != ROOT_ID) {
                 add(parentId)
                 addNavigationIdsRecursively(parentId, userDrive)
             }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,7 +47,7 @@ class SelectFolderFragment : FileListFragment() {
     override val noItemsTitle = R.string.noFilesDescription
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?): Unit = with(binding) {
-        userDrive = selectFolderViewModel.userDrive
+        userDrive = navigationArgs.userDrive
         super.onViewCreated(view, savedInstanceState)
 
         folderName = if (folderId == ROOT_ID) selectFolderViewModel.currentDrive?.name ?: "/" else navigationArgs.folderName
@@ -82,7 +82,13 @@ class SelectFolderFragment : FileListFragment() {
             onFileClicked = { file ->
                 if (file.isFolder() && !file.isDisabled()) {
                     fileListViewModel.cancelDownloadFiles()
-                    safeNavigate(SelectFolderFragmentDirections.fileListFragmentToFileListFragment(file.id, file.name))
+                    safeNavigate(
+                        SelectFolderFragmentDirections.fileListFragmentToFileListFragment(
+                            folderId = file.id,
+                            folderName = file.name,
+                            userDrive = userDrive!!
+                        )
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderFragment.kt
@@ -86,7 +86,7 @@ class SelectFolderFragment : FileListFragment() {
                         SelectFolderFragmentDirections.fileListFragmentToFileListFragment(
                             folderId = file.id,
                             folderName = file.name,
-                            userDrive = userDrive!!
+                            userDrive = navigationArgs.userDrive
                         )
                     )
                 }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderFragment.kt
@@ -86,7 +86,7 @@ class SelectFolderFragment : FileListFragment() {
                         SelectFolderFragmentDirections.fileListFragmentToFileListFragment(
                             folderId = file.id,
                             folderName = file.name,
-                            userDrive = navigationArgs.userDrive
+                            userDrive = userDrive ?: navigationArgs.userDrive,
                         )
                     )
                 }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderFragment.kt
@@ -52,9 +52,7 @@ class SelectRootFolderFragment : BaseRootFolderFragment() {
 
     override val fileListViewModel: FileListViewModel by viewModels()
 
-    private val navigationArgs by navArgs<SelectRootFolderFragmentArgs>()
-
-    private val driveId by lazy { navigationArgs.driveId }
+    private val navigationArgs: SelectRootFolderFragmentArgs by navArgs()
 
     override val rootFolderLayout: RootFolderLayoutBinding
         get() = binding.rootFolderLayout
@@ -78,7 +76,7 @@ class SelectRootFolderFragment : BaseRootFolderFragment() {
 
         collapsingToolbarLayout.title = getString(R.string.selectFolderTitle)
 
-        val currentDrive = DriveInfosController.getDrive(driveId = driveId)
+        val currentDrive = DriveInfosController.getDrive(driveId = navigationArgs.userDrive.driveId)
 
         rootFolderTitle.text = currentDrive?.name
 
@@ -146,8 +144,8 @@ class SelectRootFolderFragment : BaseRootFolderFragment() {
             safelyNavigate(
                 SelectRootFolderFragmentDirections.selectRootFolderFragmentToSelectFolderFragment(
                     folderId = file.id,
+                    folderName = file.name,
                     userDrive = navigationArgs.userDrive,
-                    folderName = file.name
                 )
             )
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderFragment.kt
@@ -38,7 +38,6 @@ import com.infomaniak.drive.databinding.RootFolderLayoutBinding
 import com.infomaniak.drive.extensions.enableEdgeToEdge
 import com.infomaniak.drive.ui.BaseRootFolderFragment
 import com.infomaniak.drive.ui.home.RootFilesFragment.FolderToOpen
-import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.TypeFolder
 import com.infomaniak.drive.utils.setFileItem
 import com.infomaniak.lib.core.utils.setMargins
@@ -79,11 +78,7 @@ class SelectRootFolderFragment : BaseRootFolderFragment() {
 
         collapsingToolbarLayout.title = getString(R.string.selectFolderTitle)
 
-        val currentDrive = if (driveId == 0) {
-            AccountUtils.getCurrentDrive(forceRefresh = true)
-        } else {
-            DriveInfosController.getDrive(driveId = driveId)
-        }
+        val currentDrive = DriveInfosController.getDrive(driveId = driveId)
 
         rootFolderTitle.text = currentDrive?.name
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderFragment.kt
@@ -95,6 +95,8 @@ class SelectRootFolderFragment : BaseRootFolderFragment() {
 
         setupRecentFoldersViews()
 
+        selectRootFolderViewModel.loadRootFiles(navigationArgs.userDrive)
+
         (activity as SelectFolderActivity).hideSaveButton()
 
         rootFolderLayout.cardView.setMargins(top = resources.getDimension(R.dimen.marginStandardSmall).toInt())

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.data.models.File
+import com.infomaniak.drive.data.models.UserDrive
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -33,12 +34,18 @@ import kotlinx.coroutines.launch
 class SelectRootFolderViewModel : ViewModel() {
 
     private val loadFiles = MutableSharedFlow<Int>(replay = 1)
+
+    private var userDrive: UserDrive? = null
+    private val realm
+        get() = FileController.getRealmInstance(userDrive)
+
     @OptIn(ExperimentalCoroutinesApi::class)
     val recentFiles: StateFlow<List<File>> = loadFiles.distinctUntilChanged().flatMapLatest { limit ->
-        FileController.getRecentFolders(limit)
+        FileController.getRecentFolders(realm, limit)
     }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
-    fun getRecentFolders(limit: Int) {
+    fun getRecentFolders(userDrive: UserDrive, limit: Int) {
+        this.userDrive = userDrive
         viewModelScope.launch {
             loadFiles.emit(limit)
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderViewModel.kt
@@ -71,7 +71,6 @@ class SelectRootFolderViewModel : ViewModel() {
                     userDrive = userDrive,
                 )
             )
-
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderViewModel.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.launch
 
 class SelectRootFolderViewModel : ViewModel() {
 
-    private val loadFiles = MutableSharedFlow<Int>(replay = 1)
+    private val loadRecentFiles = MutableSharedFlow<Int>(replay = 1)
 
     private var userDrive: UserDrive? = null
     private val realm
@@ -48,14 +48,14 @@ class SelectRootFolderViewModel : ViewModel() {
     private var rootFilesJob: Job = Job()
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val recentFiles: StateFlow<List<File>> = loadFiles.distinctUntilChanged().flatMapLatest { limit ->
+    val recentFiles: StateFlow<List<File>> = loadRecentFiles.distinctUntilChanged().flatMapLatest { limit ->
         FileController.getRecentFolders(realm, limit)
     }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
     fun getRecentFolders(userDrive: UserDrive, limit: Int) {
         this.userDrive = userDrive
         viewModelScope.launch {
-            loadFiles.emit(limit)
+            loadRecentFiles.emit(limit)
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/home/RootFilesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/RootFilesFragment.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavDirections
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.UiSettings
+import com.infomaniak.drive.data.models.UserDrive
 import com.infomaniak.drive.databinding.FragmentRootFilesBinding
 import com.infomaniak.drive.databinding.RootFolderLayoutBinding
 import com.infomaniak.drive.extensions.enableEdgeToEdge
@@ -69,6 +70,8 @@ class RootFilesFragment : BaseRootFolderFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) = with(binding) {
         super.onViewCreated(view, savedInstanceState)
+
+        fileListViewModel.updateRootFiles(UserDrive())
 
         setupDriveToolbar(collapsingToolbarLayout, switchDriveLayout, appBar)
 

--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -145,7 +145,7 @@ fun Context.getAvailableMemory(): ActivityManager.MemoryInfo {
 fun ImageView.loadAny(
     data: Any?,
     @DrawableRes errorRes: Int = R.drawable.fallback_image,
-    imageLoader: ImageLoader? = context.imageLoader
+    imageLoader: ImageLoader = context.imageLoader
 ) {
     imageLoader?.let {
         load(data, it) {

--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -62,6 +62,8 @@ import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import androidx.work.OneTimeWorkRequest
 import androidx.work.OutOfQuotaPolicy
+import coil.ImageLoader
+import coil.imageLoader
 import coil.load
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.CollapsingToolbarLayout
@@ -140,8 +142,18 @@ fun Context.getAvailableMemory(): ActivityManager.MemoryInfo {
     }
 }
 
-fun ImageView.loadAny(data: Any?, @DrawableRes errorRes: Int = R.drawable.fallback_image) {
-    load(data) {
+fun ImageView.loadAny(
+    data: Any?,
+    @DrawableRes errorRes: Int = R.drawable.fallback_image,
+    imageLoader: ImageLoader? = context.imageLoader
+) {
+    imageLoader?.let {
+        load(data, it) {
+            error(errorRes)
+            fallback(errorRes)
+            placeholder(R.drawable.placeholder)
+        }
+    } ?: load(data) {
         error(errorRes)
         fallback(errorRes)
         placeholder(R.drawable.placeholder)

--- a/app/src/main/java/com/infomaniak/drive/utils/FileItemUtils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/FileItemUtils.kt
@@ -29,6 +29,8 @@ import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.viewbinding.ViewBinding
+import coil.ImageLoader
+import coil.imageLoader
 import coil.load
 import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.infomaniak.core.FormatterFileSize.formatShortFileSize
@@ -60,23 +62,25 @@ import kotlinx.coroutines.withContext
 suspend fun ItemFileBinding.setFileItem(
     file: File,
     isGrid: Boolean = false,
+    imageLoader: ImageLoader? = context.imageLoader,
     typeFolder: TypeFolder = TypeFolder.fileList
 ): Nothing {
-    setFileItemWithoutCategories(file = file, typeFolder = typeFolder, isGrid = isGrid)
+    setFileItemWithoutCategories(file = file, typeFolder = typeFolder, isGrid = isGrid, imageLoader)
     categoriesLayout.displayCategoriesForFile(file)
 }
 
 fun ItemFileBinding.setFileItemWithoutCategories(
     file: File,
     typeFolder: TypeFolder = TypeFolder.fileList,
-    isGrid: Boolean = false
+    isGrid: Boolean = false,
+    imageLoader: ImageLoader? = context.imageLoader,
 ) {
     fileName.text = file.getDisplayName(context)
     fileFavorite.isVisible = file.isFavorite
     progressLayout.isGone = true
     displayDate(file)
     displaySize(file)
-    filePreview.displayIcon(file, isGrid, progressLayout)
+    filePreview.displayIcon(file, isGrid, progressLayout, imageLoader = imageLoader)
     iconLayout.setMargins(left = typeFolder.iconHorizontalMargin, right = typeFolder.iconHorizontalMargin)
     displayExternalImport(file, filePreview, fileProgression, fileDate)
 }
@@ -90,11 +94,11 @@ suspend fun CardviewFolderGridBinding.setFileItem(file: File, isGrid: Boolean = 
     categoriesLayout.displayCategoriesForFile(file)
 }
 
-suspend fun CardviewFileGridBinding.setFileItem(file: File, isGrid: Boolean = false): Nothing {
+suspend fun CardviewFileGridBinding.setFileItem(file: File, isGrid: Boolean = false, imageLoader: ImageLoader?): Nothing {
     fileName.text = file.getDisplayName(context)
     fileFavorite.isVisible = file.isFavorite
     progressLayout.isGone = true
-    filePreview.displayIcon(file, isGrid, progressLayout, filePreview2)
+    filePreview.displayIcon(file, isGrid, progressLayout, filePreview2, imageLoader)
     categoriesLayout.displayCategoriesForFile(file)
 }
 
@@ -121,11 +125,12 @@ private fun ImageView.displayIcon(
     isGrid: Boolean,
     progressLayout: ProgressLayoutView,
     filePreview: ImageView? = null,
+    imageLoader: ImageLoader? = context.imageLoader,
 ) {
     scaleType = if (isGrid) ImageView.ScaleType.FIT_CENTER else ImageView.ScaleType.CENTER
     when {
         file.isFolder() -> displayFolderIcon(file)
-        else -> displayFileIcon(file, isGrid, progressLayout, filePreview)
+        else -> displayFileIcon(file, isGrid, progressLayout, filePreview, imageLoader)
     }
 }
 
@@ -139,6 +144,7 @@ private fun ImageView.displayFileIcon(
     isGrid: Boolean,
     progressLayout: ProgressLayoutView,
     filePreview: ImageView? = null,
+    imageLoader: ImageLoader?,
 ) {
     val fileType = file.getFileType()
     val isGraphic = fileType == ExtensionType.IMAGE || fileType == ExtensionType.VIDEO
@@ -146,7 +152,7 @@ private fun ImageView.displayFileIcon(
     when {
         file.hasThumbnail && (isGrid || isGraphic) -> {
             scaleType = ImageView.ScaleType.CENTER_CROP
-            loadAny(ApiRoutes.getThumbnailUrl(file), fileType.icon)
+            loadAny(ApiRoutes.getThumbnailUrl(file), fileType.icon, imageLoader)
         }
         file.isFromUploads && isGraphic -> {
             scaleType = ImageView.ScaleType.CENTER_CROP

--- a/app/src/main/java/com/infomaniak/drive/utils/FileItemUtils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/FileItemUtils.kt
@@ -62,7 +62,7 @@ import kotlinx.coroutines.withContext
 suspend fun ItemFileBinding.setFileItem(
     file: File,
     isGrid: Boolean = false,
-    imageLoader: ImageLoader? = context.imageLoader,
+    imageLoader: ImageLoader = context.imageLoader,
     typeFolder: TypeFolder = TypeFolder.fileList
 ): Nothing {
     setFileItemWithoutCategories(file = file, typeFolder = typeFolder, isGrid = isGrid, imageLoader)
@@ -73,7 +73,7 @@ fun ItemFileBinding.setFileItemWithoutCategories(
     file: File,
     typeFolder: TypeFolder = TypeFolder.fileList,
     isGrid: Boolean = false,
-    imageLoader: ImageLoader? = context.imageLoader,
+    imageLoader: ImageLoader = context.imageLoader,
 ) {
     fileName.text = file.getDisplayName(context)
     fileFavorite.isVisible = file.isFavorite
@@ -94,7 +94,7 @@ suspend fun CardviewFolderGridBinding.setFileItem(file: File, isGrid: Boolean = 
     categoriesLayout.displayCategoriesForFile(file)
 }
 
-suspend fun CardviewFileGridBinding.setFileItem(file: File, isGrid: Boolean = false, imageLoader: ImageLoader?): Nothing {
+suspend fun CardviewFileGridBinding.setFileItem(file: File, isGrid: Boolean = false, imageLoader: ImageLoader): Nothing {
     fileName.text = file.getDisplayName(context)
     fileFavorite.isVisible = file.isFavorite
     progressLayout.isGone = true
@@ -125,7 +125,7 @@ private fun ImageView.displayIcon(
     isGrid: Boolean,
     progressLayout: ProgressLayoutView,
     filePreview: ImageView? = null,
-    imageLoader: ImageLoader? = context.imageLoader,
+    imageLoader: ImageLoader = context.imageLoader,
 ) {
     scaleType = if (isGrid) ImageView.ScaleType.FIT_CENTER else ImageView.ScaleType.CENTER
     when {
@@ -144,7 +144,7 @@ private fun ImageView.displayFileIcon(
     isGrid: Boolean,
     progressLayout: ProgressLayoutView,
     filePreview: ImageView? = null,
-    imageLoader: ImageLoader?,
+    imageLoader: ImageLoader,
 ) {
     val fileType = file.getFileType()
     val isGraphic = fileType == ExtensionType.IMAGE || fileType == ExtensionType.VIDEO

--- a/app/src/main/res/layout/activity_select_folder.xml
+++ b/app/src/main/res/layout/activity_select_folder.xml
@@ -31,8 +31,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:navGraph="@navigation/select_folder_navigation" />
+        app:layout_constraintTop_toTopOf="parent"/>
 
     <View
         android:layout_width="match_parent"

--- a/app/src/main/res/navigation/select_folder_navigation.xml
+++ b/app/src/main/res/navigation/select_folder_navigation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak kDrive - Android
-  ~ Copyright (C) 2022-2024 Infomaniak Network SA
+  ~ Copyright (C) 2022-2025 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -42,6 +42,14 @@
         <action
             android:id="@+id/actionSelectRootFolderFragmentToFavoritesFragment"
             app:destination="@id/favoritesFragment" />
+        <argument
+            android:name="driveId"
+            android:defaultValue="0"
+            app:argType="integer" />
+
+        <argument
+            android:name="userDrive"
+            app:argType="com.infomaniak.drive.data.models.UserDrive" />
     </fragment>
 
     <fragment
@@ -117,6 +125,11 @@
             android:name="folderName"
             android:defaultValue="/"
             app:argType="string" />
+
+        <argument
+            android:name="userDrive"
+            app:argType="com.infomaniak.drive.data.models.UserDrive" />
+
         <action
             android:id="@+id/fileListFragmentToFileListFragment"
             app:destination="@id/selectFolderFragment"

--- a/app/src/main/res/navigation/select_folder_navigation.xml
+++ b/app/src/main/res/navigation/select_folder_navigation.xml
@@ -43,11 +43,6 @@
             android:id="@+id/actionSelectRootFolderFragmentToFavoritesFragment"
             app:destination="@id/favoritesFragment" />
         <argument
-            android:name="driveId"
-            android:defaultValue="0"
-            app:argType="integer" />
-
-        <argument
             android:name="userDrive"
             app:argType="com.infomaniak.drive.data.models.UserDrive" />
     </fragment>


### PR DESCRIPTION
The first issue was that the filename displayed in the `collapseTitle` was incorrect when navigating on a drive different from the current one.

The second issue was related to the mismanagement of the `driveId` in the **RootSelectFolderFragment**. It was possible to select another drive, but that selection was never actually taken into account, since everything was created based on the `currentUserDrive`.

In addition, when you share a folder with an account, the drive for the shared folder was in the drive choice list when you saved external. So we hide it and can access the shared folder using `share with me`.

Finally, when trying to access a drive that wasn't loaded in realm, nothing was displayed, so we've added `loadRootFiles` and corrected the tokens so as not to get error 401, when trying to access a file from an account that isn't the current account.