### PR TITLE
fix: Fix crash caused by TypeToken of ApiResponse with generic type on upload error

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -26,7 +26,6 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.work.Data
 import androidx.work.workDataOf
 import com.google.gson.annotations.SerializedName
-import com.google.gson.reflect.TypeToken
 import com.infomaniak.core.io.skipExactly
 import com.infomaniak.core.ktor.toOutgoingContent
 import com.infomaniak.core.rateLimit
@@ -464,8 +463,7 @@ class UploadTask(
                     uploadFile.resetUploadTokenAndCancelSession()
                     throw UploadErrorException()
                 } else {
-                    val responseType = object : TypeToken<ApiResponse<T>>() {}.type
-                    val responseJson = gson.toJson(this, responseType)
+                    val responseJson = gson.toJson(this)
                     throw Exception("$responseJson translateError: ${context.getString(translateError())}")
                 }
             }


### PR DESCRIPTION
Inside of manageUploadErrors() we always created a crash because we tried to write using a TypeToken<ApiResponse<T>> but TypeToken will always crash when given a non generic typing that depends on a generic typing somewhere after the first nesting