### PR TITLE
feat: Fine grained permission requests

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
@@ -116,7 +116,7 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
                 checkRemainingUploadsAndUserCancellation()?.let { return@runUploadCatching it }
 
                 // Start uploads
-                result = startSyncFiles()
+                result = uploadPendingFiles()
 
                 // Check if re-sync is needed
                 appSyncSettings?.let {
@@ -176,7 +176,7 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
         return null
     }
 
-    private suspend fun startSyncFiles(): Result = withContext(Dispatchers.IO) {
+    private suspend fun uploadPendingFiles(): Result = withContext(Dispatchers.IO) {
         var uploadFiles: List<UploadFile>
 
         getRealmInstance().use { realm ->
@@ -188,11 +188,11 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
             checkUploadCountReliability(realm)
         }
 
-        SentryLog.d(TAG, "startSyncFiles> upload for ${uploadFiles.count()}")
+        SentryLog.d(TAG, "uploadPendingFiles> upload for ${uploadFiles.count()}")
 
-        for ((index, uploadFile) in uploadFiles.withIndex()) {
+        for ((index, fileToUpload) in uploadFiles.withIndex()) {
             val isLastFile = index == uploadFiles.lastIndex
-            startUpload(uploadFile, isLastFile)
+            uploadFile(fileToUpload, isLastFile)
 
             pendingCount--
 
@@ -200,12 +200,12 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
             if (isLastFile && failedNamesMap.count() == UploadFile.getAllPendingUploadsCount()) break
             // If there is a new file during the sync and it has priority (ex: Manual uploads),
             // then we start again in order to process the priority files first.
-            if (uploadFile.isSync() && UploadFile.getAllPendingPriorityFilesCount() > 0) return@withContext startSyncFiles()
+            if (fileToUpload.isSync() && UploadFile.getAllPendingPriorityFilesCount() > 0) return@withContext uploadPendingFiles()
         }
 
         uploadedCount = successCount
 
-        SentryLog.d(TAG, "startSyncFiles: finish with $uploadedCount uploaded")
+        SentryLog.d(TAG, "uploadPendingFiles: finish with $uploadedCount uploaded")
 
         currentUploadFile?.showUploadedFilesNotification(
             context = applicationContext,
@@ -217,17 +217,17 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
         if (uploadedCount > 0) Result.success() else Result.failure()
     }
 
-    private suspend fun startUpload(uploadFile: UploadFile, isLastFile: Boolean) {
-        SentryLog.d(TAG, "startSyncFiles> size: ${uploadFile.fileSize}")
+    private suspend fun uploadFile(uploadFile: UploadFile, isLastFile: Boolean) {
+        SentryLog.d(TAG, "uploadFile> size: ${uploadFile.fileSize}")
 
-        val fileUploadedWithSuccess = uploadFile.initUpload(isLastFile)
+        val fileUploadedWithSuccess = uploadFile.upload(isLastFile)
         if (fileUploadedWithSuccess) {
-            SentryLog.i(TAG, "startSyncFiles: file uploaded with success")
+            SentryLog.i(TAG, "uploadFile: file uploaded with success")
             successNames.add(uploadFile.fileName)
             if (failedNamesMap[uploadFile.uri] != null) failedNamesMap.remove(uploadFile.uri)
             successCount++
         } else {
-            SentryLog.i(TAG, "startSyncFiles: file upload failed")
+            SentryLog.i(TAG, "uploadFile: file upload failed")
             if (failedNamesMap[uploadFile.uri] == null) {
                 failedNamesMap[uploadFile.uri] = uploadFile.fileName
                 failedCount++
@@ -249,18 +249,18 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
         }
     }
 
-    private suspend fun UploadFile.initUpload(isLastFile: Boolean) = withContext(Dispatchers.IO) {
+    private suspend fun UploadFile.upload(isLastFile: Boolean) = withContext(Dispatchers.IO) {
         val uri = getUriObject()
 
-        currentUploadFile = this@initUpload
+        currentUploadFile = this@upload
         applicationContext.cancelNotification(NotificationUtils.CURRENT_UPLOAD_ID)
         updateUploadCountNotification()
 
         try {
             if (uri.scheme.equals(ContentResolver.SCHEME_FILE)) {
-                initUploadSchemeFile(uri)
+                uploadSchemeFile(uri)
             } else {
-                initUploadSchemeContent(uri)
+                uploadSchemeContent(uri)
             }
         } catch (exception: CancellationException) {
             throw exception
@@ -274,17 +274,17 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
             if (isLastFile) throw exception
             false
         } catch (exception: Exception) {
-            SentryLog.w(TAG, "initUpload: failed", exception)
+            SentryLog.w(TAG, "upload: failed", exception)
             handleException(exception)
             false
         }
     }
 
-    private suspend fun UploadFile.initUploadSchemeFile(uri: Uri): Boolean {
+    private suspend fun UploadFile.uploadSchemeFile(uri: Uri): Boolean {
         SentryLog.d(TAG, "initUploadSchemeFile: start")
         val cacheFile = uri.toFile().apply {
             if (!exists()) {
-                SentryLog.i(TAG, "initUploadSchemeFile: file doesn't exist")
+                SentryLog.i(TAG, "uploadSchemeFile: file doesn't exist")
                 deleteIfExists()
                 return false
             }
@@ -295,19 +295,19 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
         }
     }
 
-    private suspend fun UploadFile.initUploadSchemeContent(uri: Uri): Boolean {
-        SentryLog.d(TAG, "initUploadSchemeContent: start")
+    private suspend fun UploadFile.uploadSchemeContent(uri: Uri): Boolean {
+        SentryLog.d(TAG, "uploadSchemeContent: start")
         return contentResolver.query(uri, null, null, null, null)?.use { cursor ->
             val columns = cursor.columnNames.joinToString { it }
 
             if (cursor.moveToFirst()) {
                 if (!columns.contains(OpenableColumns.SIZE)) {
-                    SentryLog.e(TAG, "initUploadSchemeContent: size column doesn't exist ($columns)")
+                    SentryLog.e(TAG, "uploadSchemeContent: size column doesn't exist ($columns)")
                 }
                 startUploadFile(uri.getFileSize(cursor))
             } else {
                 val sentryMessage = "$fileName moveToFirst failed - count(${cursor.count}), columns($columns)"
-                SentryLog.w(TAG, "initUploadSchemeContent: $sentryMessage")
+                SentryLog.w(TAG, "uploadSchemeContent: $sentryMessage")
                 deleteIfExists(keepFile = isSync())
                 false
             }

--- a/app/src/main/java/com/infomaniak/drive/ui/BasePreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/BasePreviewSliderFragment.kt
@@ -80,7 +80,7 @@ abstract class BasePreviewSliderFragment : Fragment(), FileInfoActionsView.OnIte
 
     // This is not protected, otherwise it won't build because PublicSharePreviewSliderFragment needs it public for the interface
     // it implements
-    val drivePermissions: DrivePermissions = DrivePermissions()
+    val downloadPermissions: DrivePermissions = DrivePermissions(type = DrivePermissions.Type.DownloadingWithDownloadManager)
     open val selectFolderResultLauncher = registerForActivityResult(StartActivityForResult()) {}
 
     val previewPDFHandler by lazy {
@@ -100,7 +100,7 @@ abstract class BasePreviewSliderFragment : Fragment(), FileInfoActionsView.OnIte
 
         setBackActionHandlers()
 
-        drivePermissions.registerPermissions(this@BasePreviewSliderFragment) { authorized ->
+        downloadPermissions.registerPermissions(this@BasePreviewSliderFragment) { authorized ->
             if (authorized) downloadFileClicked()
         }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainActivity.kt
@@ -132,7 +132,7 @@ class MainActivity : BaseActivity() {
 
     private var hasDisplayedInformationPanel: Boolean = false
 
-    private lateinit var drivePermissions: DrivePermissions
+    private lateinit var syncPermissions: DrivePermissions
 
     private var deleteLocalMediaRequestDialog: Dialog? = null
     private val pendingFilesUrisQueue = ArrayDeque<List<Uri>>()
@@ -331,7 +331,7 @@ class MainActivity : BaseActivity() {
     }
 
     private fun setupDrivePermissions() {
-        drivePermissions = DrivePermissions().apply {
+        syncPermissions = DrivePermissions(DrivePermissions.Type.ReadingMediaForSync).apply {
             registerPermissions(this@MainActivity)
         }
     }
@@ -401,7 +401,7 @@ class MainActivity : BaseActivity() {
     override fun onResume() {
         super.onResume()
 
-        launchAllUpload(drivePermissions)
+        launchAllUpload(syncPermissions)
 
         mainViewModel.checkBulkDownloadStatus()
 

--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -97,7 +97,7 @@ class SaveExternalFilesActivity : BaseActivity() {
 
     private val uiSettings by lazy { UiSettings(context = this) }
 
-    private lateinit var drivePermissions: DrivePermissions
+    private lateinit var backgroundUploadPermissions: DrivePermissions
     private var currentUri: Uri? = null
     private var isMultiple = false
 
@@ -164,12 +164,12 @@ class SaveExternalFilesActivity : BaseActivity() {
     }
 
     private fun setupDrivePermissions() {
-        drivePermissions = DrivePermissions().apply {
+        backgroundUploadPermissions = DrivePermissions(DrivePermissions.Type.UploadInTheBackground).apply {
             registerPermissions(
                 activity = this@SaveExternalFilesActivity,
                 onPermissionResult = { authorized -> if (authorized) getFiles() },
             )
-            checkSyncPermissions()
+            hasNeededPermissions(requestIfNotGranted = true)
         }
     }
 
@@ -300,7 +300,7 @@ class SaveExternalFilesActivity : BaseActivity() {
                 }
 
                 showProgressCatching()
-                if (drivePermissions.checkSyncPermissions()) {
+                if (backgroundUploadPermissions.hasNeededPermissions(requestIfNotGranted = true)) {
                     val userId = selectedUserId.value!!
                     val driveId = selectedDrive.value?.id!!
                     val folderId = saveExternalFilesViewModel.folderId.value!!
@@ -325,7 +325,7 @@ class SaveExternalFilesActivity : BaseActivity() {
 
     override fun onResume() {
         super.onResume()
-        if (drivePermissions.checkWriteStoragePermission(false)) getFiles()
+        getFiles()
     }
 
     private fun getFiles() {

--- a/app/src/main/java/com/infomaniak/drive/ui/addFiles/UploadFilesHelper.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/addFiles/UploadFilesHelper.kt
@@ -45,7 +45,7 @@ class UploadFilesHelper private constructor(
     ) : this(context = activity, navController, onOpeningPicker = onOpeningPicker) {
         filePicker = FilePicker(activity).apply { initCallback(::onSelectFilesResult) }
 
-        uploadFilesPermissions = DrivePermissions().apply {
+        uploadFilesPermissions = DrivePermissions(DrivePermissions.Type.UploadInTheBackground).apply {
             registerPermissions(activity) { authorized -> if (authorized) uploadFiles() }
         }
     }
@@ -56,7 +56,7 @@ class UploadFilesHelper private constructor(
 
     fun uploadFiles() {
         ShortcutManagerCompat.reportShortcutUsed(context, Shortcuts.UPLOAD.name)
-        if (uploadFilesPermissions.checkSyncPermissions()) {
+        if (uploadFilesPermissions.hasNeededPermissions(requestIfNotGranted = true)) {
             onOpeningPicker?.invoke()
             filePicker.open()
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
@@ -74,7 +74,7 @@ class FileInfoActionsBottomSheetDialog : BottomSheetDialogFragment(), FileInfoAc
 
     private var binding: FragmentBottomSheetFileInfoActionsBinding by safeBinding()
 
-    private lateinit var drivePermissions: DrivePermissions
+    private lateinit var downloadPermissions: DrivePermissions
     private val mainViewModel: MainViewModel by activityViewModels()
     private val shareLinkViewModel: ShareLinkViewModel by viewModels()
     private val navigationArgs: FileInfoActionsBottomSheetDialogArgs by navArgs()
@@ -99,7 +99,7 @@ class FileInfoActionsBottomSheetDialog : BottomSheetDialogFragment(), FileInfoAc
             return
         }
 
-        drivePermissions = DrivePermissions().apply {
+        downloadPermissions = DrivePermissions(DrivePermissions.Type.DownloadingWithDownloadManager).apply {
             registerPermissions(this@FileInfoActionsBottomSheetDialog) { authorized -> if (authorized) downloadFileClicked() }
         }
 
@@ -225,7 +225,7 @@ class FileInfoActionsBottomSheetDialog : BottomSheetDialogFragment(), FileInfoAc
 
     override fun downloadFileClicked() {
         super.downloadFileClicked()
-        currentContext.downloadFile(drivePermissions, currentFile) { findNavController().popBackStack() }
+        currentContext.downloadFile(downloadPermissions, currentFile) { findNavController().popBackStack() }
     }
 
     override fun manageCategoriesClicked(fileId: Int) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/UploadInProgressFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/UploadInProgressFragment.kt
@@ -37,7 +37,6 @@ import com.infomaniak.drive.data.services.UploadWorker.Companion.trackUploadWork
 import com.infomaniak.drive.data.services.UploadWorker.Companion.trackUploadWorkerSucceeded
 import com.infomaniak.drive.ui.MainActivity
 import com.infomaniak.drive.utils.AccountUtils
-import com.infomaniak.drive.utils.DrivePermissions
 import com.infomaniak.drive.utils.SyncUtils.syncImmediately
 import com.infomaniak.drive.utils.Utils
 import com.infomaniak.drive.utils.navigateToUploadView
@@ -50,7 +49,6 @@ import kotlinx.coroutines.launch
 
 class UploadInProgressFragment : FileListFragment() {
 
-    private val drivePermissions: DrivePermissions by lazy { DrivePermissions() }
     private val uploadInProgressViewModel: UploadInProgressViewModel by viewModels()
 
     override var enabledMultiSelectMode: Boolean = false
@@ -68,9 +66,6 @@ class UploadInProgressFragment : FileListFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         downloadFiles = DownloadFiles()
-        drivePermissions.registerPermissions(this) { authorized ->
-            if (!authorized) findNavController().popBackStack()
-        }
 
         super.onViewCreated(view, savedInstanceState)
 
@@ -252,7 +247,6 @@ class UploadInProgressFragment : FileListFragment() {
 
     private inner class DownloadFiles : (Boolean, Boolean) -> Unit {
         override fun invoke(ignoreCache: Boolean, isNewSort: Boolean) {
-            if (!drivePermissions.checkWriteStoragePermission()) return
             if (ignoreCache) fileAdapter.setFiles(listOf())
 
             showLoadingTimer.start()

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/MultiSelectActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/multiSelect/MultiSelectActionsBottomSheetDialog.kt
@@ -152,14 +152,14 @@ abstract class MultiSelectActionsBottomSheetDialog(private val matomoCategory: M
     }
 
     protected open fun configureDownload() {
-        val drivePermissions = DrivePermissions().apply {
+        val downloadPermissions = DrivePermissions(DrivePermissions.Type.DownloadingWithDownloadManager).apply {
             registerPermissions(this@MultiSelectActionsBottomSheetDialog) { authorized ->
                 if (authorized) download()
             }
         }
 
         binding.downloadFile.apply {
-            setOnClickListener { if (drivePermissions.checkWriteStoragePermission()) download() }
+            setOnClickListener { if (downloadPermissions.hasNeededPermissions(requestIfNotGranted = true)) download() }
             isVisible = navigationArgs.fileIds.isNotEmpty() || navigationArgs.isAllSelected
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
@@ -218,7 +218,7 @@ class PreviewSliderFragment : BasePreviewSliderFragment(), FileInfoActionsView.O
 
     override fun downloadFileClicked() {
         super<BasePreviewSliderFragment>.downloadFileClicked()
-        currentContext.downloadFile(drivePermissions, currentFile) { toggleBottomSheet(shouldShow = true) }
+        currentContext.downloadFile(downloadPermissions, currentFile) { toggleBottomSheet(shouldShow = true) }
     }
 
     override fun onLeaveShare(onApiResponse: () -> Unit) {

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SelectMediaFoldersDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SelectMediaFoldersDialog.kt
@@ -71,10 +71,10 @@ class SelectMediaFoldersDialog : FullScreenBottomSheetDialog(), NoItemsLayoutVie
             mediaFolderList.addItemDecoration(DividerItemDecorator(it))
         }
 
-        val drivePermissions = DrivePermissions().apply {
+        val syncPermissions = DrivePermissions(DrivePermissions.Type.ReadingMediaForSync).apply {
             registerPermissions(this@SelectMediaFoldersDialog) { authorized -> if (authorized) loadFolders() else dismiss() }
         }
-        if (drivePermissions.checkWriteStoragePermission()) loadFolders()
+        if (syncPermissions.hasNeededPermissions(requestIfNotGranted = true)) loadFolders()
     }
 
     private fun loadFolders() = with(binding) {

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SettingsFragment.kt
@@ -79,7 +79,7 @@ class SettingsFragment : Fragment() {
 
         toolbar.setNavigationOnClickListener { findNavController().popBackStack() }
 
-        val drivePermissions = DrivePermissions().apply {
+        val syncPermissions = DrivePermissions(DrivePermissions.Type.ReadingMediaForSync).apply {
             registerPermissions(this@SettingsFragment) { authorized -> if (authorized) requireActivity().syncImmediately() }
         }
 
@@ -87,7 +87,7 @@ class SettingsFragment : Fragment() {
         onlyWifiSync.setOnCheckedChangeListener { _, isChecked ->
             trackSettingsEvent(MatomoName.OnlyWifiTransfer, isChecked)
             AppSettings.onlyWifiSync = isChecked
-            requireActivity().launchAllUpload(drivePermissions)
+            requireActivity().launchAllUpload(syncPermissions)
         }
 
         setupMyKSuiteLayout()

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/OnPublicShareItemClickListener.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/OnPublicShareItemClickListener.kt
@@ -46,7 +46,7 @@ import kotlinx.coroutines.launch
 
 interface OnPublicShareItemClickListener : FileInfoActionsView.OnItemClickListener {
 
-    val drivePermissions: DrivePermissions
+    val downloadPermissions: DrivePermissions
     val publicShareViewModel: PublicShareViewModel
     val previewPDFHandler: PreviewPDFHandler?
 
@@ -76,7 +76,7 @@ interface OnPublicShareItemClickListener : FileInfoActionsView.OnItemClickListen
 
     override fun downloadFileClicked() {
         trackPublicShareActionEvent(MatomoName.Download)
-        currentFile?.let { currentContext.downloadFile(drivePermissions, it, ::onDownloadSuccess) }
+        currentFile?.let { currentContext.downloadFile(downloadPermissions, it, ::onDownloadSuccess) }
     }
 
     override fun printClicked() {

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareFileActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareFileActionsBottomSheetDialog.kt
@@ -45,7 +45,7 @@ class PublicShareFileActionsBottomSheetDialog : BottomSheetDialogFragment(), OnP
     override val previewPDFHandler = null
 
     private val mainButton by lazy { (requireActivity() as PublicShareActivity).getMainButton() }
-    override val drivePermissions = DrivePermissions()
+    override val downloadPermissions = DrivePermissions(DrivePermissions.Type.DownloadingWithDownloadManager)
 
     override fun initCurrentFile() {
         currentFile = publicShareViewModel.fileClicked ?: throw Exception("No current file found")
@@ -69,7 +69,7 @@ class PublicShareFileActionsBottomSheetDialog : BottomSheetDialogFragment(), OnP
 
         initBottomSheet()
 
-        drivePermissions.registerPermissions(this@PublicShareFileActionsBottomSheetDialog) { authorized ->
+        downloadPermissions.registerPermissions(this@PublicShareFileActionsBottomSheetDialog) { authorized ->
             if (authorized) downloadFileClicked()
         }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
@@ -70,7 +70,7 @@ class PublicShareListFragment : FileListFragment() {
     override var enabledMultiSelectMode: Boolean = true
     override var hideBackButtonWhenRoot: Boolean = false
 
-    private val drivePermissions = DrivePermissions()
+    private val downloadPermissions = DrivePermissions(type = DrivePermissions.Type.DownloadingWithDownloadManager)
     private inline val importButton get() = (requireActivity() as PublicShareActivity).getMainButton()
     private val selectDriveAndFolderResultLauncher = registerForActivityResult(StartActivityForResult()) {
         it.whenResultIsOk(::onDriveAndFolderSelected)
@@ -91,7 +91,7 @@ class PublicShareListFragment : FileListFragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        drivePermissions.registerPermissions(this@PublicShareListFragment) { authorized -> if (authorized) downloadAllFiles() }
+        downloadPermissions.registerPermissions(this@PublicShareListFragment) { authorized -> if (authorized) downloadAllFiles() }
 
         return super.onCreateView(inflater, container, savedInstanceState)
     }
@@ -279,7 +279,7 @@ class PublicShareListFragment : FileListFragment() {
     private fun downloadAllFiles() {
         // RootSharedFile can either be a folder or a single file
         trackPublicShareActionEvent(MatomoName.DownloadAllFiles)
-        publicShareViewModel.rootSharedFile.value?.let { file -> requireContext().downloadFile(drivePermissions, file) }
+        publicShareViewModel.rootSharedFile.value?.let { file -> requireContext().downloadFile(downloadPermissions, file) }
     }
 
     private fun onDriveAndFolderSelected(data: Intent?) {

--- a/app/src/main/java/com/infomaniak/drive/utils/DrivePermissions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/DrivePermissions.kt
@@ -19,52 +19,58 @@ package com.infomaniak.drive.utils
 
 import android.Manifest.permission.ACCESS_MEDIA_LOCATION
 import android.Manifest.permission.POST_NOTIFICATIONS
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.Manifest.permission.READ_MEDIA_IMAGES
 import android.Manifest.permission.READ_MEDIA_VIDEO
 import android.Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
-import android.annotation.SuppressLint
 import android.app.Activity
-import android.app.Activity.RESULT_OK
-import android.content.ActivityNotFoundException
-import android.content.Context
 import android.content.DialogInterface
-import android.content.Intent
-import android.net.Uri
 import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.CUR_DEVELOPMENT
-import android.os.PowerManager
-import android.provider.Settings
 import androidx.activity.result.ActivityResultLauncher
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.RequestMultiplePermissions
 import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.infomaniak.drive.BuildConfig
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.UiSettings
 import com.infomaniak.drive.ui.bottomSheetDialogs.BackgroundSyncPermissionsBottomSheetDialog
+import com.infomaniak.drive.utils.DrivePermissions.Type.*
 import com.infomaniak.lib.core.utils.hasPermissions
 import com.infomaniak.lib.core.utils.requestPermissionsIsPossible
 import com.infomaniak.lib.core.utils.startAppSettingsConfig
-import io.sentry.Sentry
-import io.sentry.SentryLevel
+import splitties.init.appCtx
+import splitties.systemservices.powerManager
 
-class DrivePermissions {
+class DrivePermissions(private val type: Type) {
 
-    private lateinit var batteryPermissionResultLauncher: ActivityResultLauncher<Intent>
+    enum class Type {
+        DownloadingWithDownloadManager,
+        ReadingMediaForSync,
+        UploadInTheBackground,
+    }
+
     private lateinit var registerForActivityResult: ActivityResultLauncher<Array<String>>
     private lateinit var activity: FragmentActivity
+
+
+    private val requiredPermissions = permissionsFor(type, includeOptionals = false).toTypedArray()
+    private val permissionsToAsk = permissionsFor(type, includeOptionals = true).toTypedArray()
+
+    private val requiredPermissionsAlreadyGranted: Boolean = appCtx.hasPermissions(requiredPermissions)
 
     private val backgroundSyncPermissionsBottomSheetDialog by lazy { BackgroundSyncPermissionsBottomSheetDialog() }
 
     fun registerPermissions(activity: FragmentActivity, onPermissionResult: ((authorized: Boolean) -> Unit)? = null) {
         this.activity = activity
         registerForActivityResult = activity.registerForActivityResult(RequestMultiplePermissions()) { authorizedPermissions ->
-            val authorized = authorizedPermissions.values.all { it }
-            onPermissionResult?.invoke(authorized)
-            activity.resultPermissions(authorized, permissions)
+            if (requiredPermissionsAlreadyGranted.not()) {
+                val authorized = authorizedPermissions.filterKeys { it in requiredPermissions }.values.all { it }
+                onPermissionResult?.invoke(authorized)
+                activity.resultPermissions(authorized, requiredPermissions)
+            }
         }
     }
 
@@ -72,98 +78,37 @@ class DrivePermissions {
         activity = fragment.requireActivity()
         registerForActivityResult =
             fragment.registerForActivityResult(RequestMultiplePermissions()) { authorizedPermissions ->
-                val authorized = authorizedPermissions.values.all { it }
-                onPermissionResult?.invoke(authorized)
-                activity.resultPermissions(authorized, permissions)
+                if (requiredPermissionsAlreadyGranted.not()) {
+                    val authorized = authorizedPermissions.filterKeys { it in requiredPermissions }.values.all { it }
+                    onPermissionResult?.invoke(authorized)
+                    activity.resultPermissions(authorized, requiredPermissions)
+                }
             }
     }
 
-    fun registerBatteryPermission(fragment: Fragment, onPermissionResult: ((authorized: Boolean) -> Unit)) {
-        activity = fragment.requireActivity()
-        batteryPermissionResultLauncher = fragment.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
-            val hasPermission = it.resultCode == RESULT_OK || checkBatteryLifePermission(false)
-            onPermissionResult(hasPermission)
+    fun hasNeededPermissions(requestIfNotGranted: Boolean = false, canShowBatteryDialog: Boolean = true): Boolean {
+        if (canShowBatteryDialog) when (type) {
+            DownloadingWithDownloadManager -> Unit
+            ReadingMediaForSync, UploadInTheBackground -> tryShowBatteryDialogIfNeeded()
+        }
+        return when {
+            activity.hasPermissions(permissionsToAsk) -> true
+            else -> {
+                if (requestIfNotGranted) {
+                    // All permissions (optionals included) are NOT granted (so we are requesting them)…
+                    registerForActivityResult.launch(permissionsToAsk)
+                }
+                activity.hasPermissions(requiredPermissions) // …but the needed ones might be granted.
+            }
         }
     }
 
-    /**
-     * Check if the sync has all permissions to work
-     *
-     * @param requestPermission Whether or not the app should just check if it has the permissions,
-     * or requests it if it's not the case
-     * @param showBatteryDialog We want to be able to show the battery dialog even if we don't request the mandatory permissions
-     *
-     * @return [Boolean] true if the sync has all permissions or false
-     */
-    fun checkSyncPermissions(requestPermission: Boolean = true, showBatteryDialog: Boolean = true): Boolean {
-
-        fun displayBatteryDialog() {
+    private fun tryShowBatteryDialogIfNeeded() {
+        val mustDisplayIt = UiSettings(activity).mustDisplayBatteryDialog
+        if (mustDisplayIt || powerManager.isIgnoringBatteryOptimizations(BuildConfig.APPLICATION_ID).not()) {
             with(backgroundSyncPermissionsBottomSheetDialog) {
                 if (dialog?.isShowing != true && !isResumed) {
                     show(this@DrivePermissions.activity.supportFragmentManager, "syncPermissionsDialog")
-                }
-            }
-        }
-
-        if (showBatteryDialog && (UiSettings(activity).mustDisplayBatteryDialog || !checkBatteryLifePermission(false))) {
-            displayBatteryDialog()
-        }
-
-        return checkWriteStoragePermission(requestPermission)
-    }
-
-    fun checkUserChoiceStoragePermission(): Boolean {
-        return if (SDK_INT >= 34) {
-            activity.hasPermissions(arrayOf(READ_MEDIA_VISUAL_USER_SELECTED))
-        } else {
-            false
-        }
-    }
-
-    /**
-     * Checks if the user has already confirmed write permission
-     */
-    @SuppressLint("NewApi")
-    fun checkWriteStoragePermission(requestPermission: Boolean = true): Boolean {
-        return when {
-            activity.hasPermissions(permissions) -> true
-            else -> {
-                if (requestPermission) registerForActivityResult.launch(permissions)
-                false
-            }
-        }
-    }
-
-    /**
-     * Checks if the user has already confirmed battery optimization's disabling permission
-     */
-    fun checkBatteryLifePermission(requestPermission: Boolean): Boolean {
-        return with(activity) {
-            val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager?
-            when {
-                powerManager?.isIgnoringBatteryOptimizations(packageName) != false -> true
-                else -> {
-                    if (requestPermission) requestBatteryOptimizationPermission()
-                    false
-                }
-            }
-        }
-    }
-
-    @SuppressLint("BatteryLife")
-    private fun Context.requestBatteryOptimizationPermission() {
-        try {
-            Intent(
-                Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
-                Uri.parse("package:$packageName")
-            ).apply { batteryPermissionResultLauncher.launch(this) }
-        } catch (activityNotFoundException: ActivityNotFoundException) {
-            try {
-                batteryPermissionResultLauncher.launch(Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS))
-            } catch (exception: Exception) {
-                Sentry.withScope { scope ->
-                    scope.level = SentryLevel.WARNING
-                    Sentry.captureException(exception)
                 }
             }
         }
@@ -177,20 +122,25 @@ class DrivePermissions {
             else -> R.string.allPermissionNeeded
         }
 
-        val permissions = buildSet {
-            if (SDK_INT < 33) {
-                // Even if the docs says that it's unless after api 30, it is in fact needed for the related READ_EXTERNAL_STORAGE
-                // permission, which is use up to 32
-                add(WRITE_EXTERNAL_STORAGE)
+        fun permissionsFor(type: Type, includeOptionals: Boolean = false): List<String> = buildList {
+            // Note that order is important, because it'll be the ask order.
+            when (type) {
+                DownloadingWithDownloadManager -> if (SDK_INT < 29) add(WRITE_EXTERNAL_STORAGE)
+                ReadingMediaForSync -> {
+                    // See https://developer.android.com/training/data-storage/shared/media
+                    if (SDK_INT >= 34) add(READ_MEDIA_VISUAL_USER_SELECTED)
+                    if (SDK_INT >= 33) {
+                        add(READ_MEDIA_IMAGES)
+                        add(READ_MEDIA_VIDEO)
+                    } else {
+                        add(READ_EXTERNAL_STORAGE)
+                    }
+                    if (SDK_INT >= 29) add(ACCESS_MEDIA_LOCATION)
+                    if (SDK_INT >= 33 && includeOptionals) add(POST_NOTIFICATIONS)
+                }
+                UploadInTheBackground -> if (SDK_INT >= 33 && includeOptionals) add(POST_NOTIFICATIONS)
             }
-            if (SDK_INT in 29..<CUR_DEVELOPMENT) add(ACCESS_MEDIA_LOCATION)
-            if (SDK_INT in 33..<CUR_DEVELOPMENT) {
-                add(POST_NOTIFICATIONS)
-                add(READ_MEDIA_IMAGES)
-                add(READ_MEDIA_VIDEO)
-            }
-            if (SDK_INT in 34..<CUR_DEVELOPMENT) add(READ_MEDIA_VISUAL_USER_SELECTED)
-        }.toTypedArray()
+        }
 
         fun Activity.resultPermissions(authorized: Boolean, permissions: Array<String>) {
             if (!authorized && !requestPermissionsIsPossible(permissions)) {

--- a/app/src/main/java/com/infomaniak/drive/utils/SyncUtils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/SyncUtils.kt
@@ -79,9 +79,9 @@ object SyncUtils {
 
     private fun Long?.isValidDate() = this != null && this > 0
 
-    fun FragmentActivity.launchAllUpload(drivePermissions: DrivePermissions) {
+    fun FragmentActivity.launchAllUpload(syncPermissions: DrivePermissions) {
         if (AccountUtils.isEnableAppSync() &&
-            drivePermissions.checkSyncPermissions(requestPermission = false) &&
+            syncPermissions.hasNeededPermissions() &&
             UploadFile.getAllPendingUploads().isNotEmpty()
         ) {
             syncImmediately()

--- a/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
+++ b/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
@@ -650,8 +650,8 @@ class FileInfoActionsView @JvmOverloads constructor(
         }
 
         companion object {
-            fun Context.downloadFile(drivePermissions: DrivePermissions, file: File, onSuccess: (() -> Unit)? = null) {
-                if (drivePermissions.checkWriteStoragePermission()) {
+            fun Context.downloadFile(downloadPermissions: DrivePermissions, file: File, onSuccess: (() -> Unit)? = null) {
+                if (downloadPermissions.hasNeededPermissions(requestIfNotGranted = true)) {
                     val fileName = if (file.isFolder()) "${file.name}.zip" else file.name
                     val userBearerToken = AccountUtils.currentUser?.apiToken?.accessToken
                     DownloadManagerUtils.scheduleDownload(


### PR DESCRIPTION
Instead of requesting almost all permissions, we now use a fine-grained approach, and consider optional permissions.

For example, the POST_NOTIFICATIONS permissions will be asked when relevant, but will no longer block the app from doing its job if not granted.