### PR TITLE
feat: Can select folder in shared with me

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/MainApplication.kt
+++ b/app/src/main/java/com/infomaniak/drive/MainApplication.kt
@@ -46,6 +46,8 @@ import com.infomaniak.drive.data.services.DeviceInfoUpdateWorker
 import com.infomaniak.drive.data.services.MqttClientWrapper
 import com.infomaniak.drive.ui.LaunchActivity
 import com.infomaniak.drive.utils.AccountUtils
+import com.infomaniak.drive.utils.AccountUtils.getUserById
+import com.infomaniak.drive.utils.AccountUtils.setUserToken
 import com.infomaniak.drive.utils.MyKSuiteDataUtils
 import com.infomaniak.drive.utils.NotificationUtils.buildGeneralNotification
 import com.infomaniak.drive.utils.NotificationUtils.initNotificationChannel
@@ -189,6 +191,37 @@ class MainApplication : Application(), ImageLoaderFactory, DefaultLifecycleObser
         }
 
         return CoilUtils.newImageLoader(applicationContext, tokenInterceptorListener(), customFactories = listOf(factory))
+    }
+
+    fun newImageLoaderWithOtherUserId(userId: Int?): ImageLoader {
+        var onRefreshTokenError: ((user: User) -> Unit)? = null
+
+        val tokenInterceptorListener = object : TokenInterceptorListener {
+            override suspend fun onRefreshTokenSuccess(apiToken: ApiToken) {
+                val user = userId?.let { getUserById(userId) } ?: run { AccountUtils.currentUser }
+                setUserToken(user, apiToken)
+            }
+
+            override suspend fun onRefreshTokenError() {
+                val user = userId?.let { getUserById(userId) } ?: run { AccountUtils.currentUser }
+                user?.let { onRefreshTokenError?.invoke(it) }
+            }
+
+            override suspend fun getUserApiToken(): ApiToken? {
+                val user = userId?.let { getUserById(userId) } ?: run { AccountUtils.currentUser }
+                return user?.apiToken
+            }
+
+            override fun getCurrentUserId() = null
+        }
+
+        val factory = if (SDK_INT >= 28) {
+            ImageDecoderDecoder.Factory()
+        } else {
+            GifDecoder.Factory()
+        }
+
+        return CoilUtils.newImageLoader(applicationContext, tokenInterceptorListener, customFactories = listOf(factory))
     }
 
     private val refreshTokenError: (User) -> Unit = { user ->

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -177,18 +177,16 @@ object FileController {
             .toFlow()
     }
 
-    fun getRecentFolders(recentFolderNumber: Int): Flow<List<File>> {
-        return getRealmInstance().use { realm ->
-            realm.where(File::class.java)
-                .equalTo(File::type.name, Type.DIRECTORY.value)
-                .greaterThan(File::id.name, ROOT_ID)
-                .greaterThan(File::parentId.name, ROOT_ID)
-                .sort(File::lastModifiedAt.name, Sort.DESCENDING)
-                .limit(recentFolderNumber.toLong())
-                .sort(File::lastModifiedAt.name, Sort.ASCENDING)
-                .findAllAsync()
-                .toFlow()
-        }
+    fun getRecentFolders(realm: Realm, recentFolderNumber: Int): Flow<List<File>> {
+        return realm.where(File::class.java)
+            .equalTo(File::type.name, Type.DIRECTORY.value)
+            .greaterThan(File::id.name, ROOT_ID)
+            .greaterThan(File::parentId.name, ROOT_ID)
+            .sort(File::lastModifiedAt.name, Sort.DESCENDING)
+            .limit(recentFolderNumber.toLong())
+            .sort(File::lastModifiedAt.name, Sort.ASCENDING)
+            .findAllAsync()
+            .toFlow()
     }
 
     //region isMarkedAsOffline

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -79,6 +79,15 @@ object FileController {
         return realm.where(File::class.java).equalTo(File::id.name, fileId).findFirst()
     }
 
+    fun getSharedDriveIdById(userId: Int, fileId: Int): File? {
+        val sharedDrive = UserDrive(userId = userId, sharedWithMe = true)
+        getRealmInstance(sharedDrive).use { realm ->
+            return realm.where(File::class.java).equalTo(File::id.name, fileId).findFirst()?.let {
+                realm.copyFromRealm(it, 1)
+            }
+        }
+    }
+
     // https://github.com/realm/realm-java/issues/1862
     fun emptyList(realm: Realm): RealmResults<File> = realm.where(File::class.java).alwaysFalse().findAll()
 

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FolderFilesProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FolderFilesProvider.kt
@@ -31,6 +31,7 @@ import com.infomaniak.drive.data.services.MqttClientWrapper
 import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.FileId
 import com.infomaniak.drive.utils.Utils.ROOT_ID
+import com.infomaniak.lib.core.networking.HttpClient
 import com.infomaniak.lib.core.utils.SentryLog
 import io.realm.Realm
 import io.realm.RealmQuery
@@ -239,7 +240,7 @@ object FolderFilesProvider {
 
         ensureActive()
 
-        handleRemoteFiles(realm, apiResponse, folderFilesProviderArgs, folderProxy)
+        handleRemoteFiles(realm, apiResponse, folderFilesProviderArgs, folderProxy, okHttpClient)
     }
 
     private fun loadCloudStorageFromRemote(
@@ -278,13 +279,14 @@ object FolderFilesProvider {
         apiResponse: CursorApiResponse<List<File>>,
         folderFilesProviderArgs: FolderFilesProviderArgs,
         folderProxy: File?,
+        okHttpClient: OkHttpClient = HttpClient.okHttpClient,
     ): FolderFilesProviderResult? {
         val userDrive = folderFilesProviderArgs.userDrive
         val apiResponseData = apiResponse.data
         val folderWithChildren = folderFilesProviderArgs.withChildren
 
         val localFolder = folderProxy?.freeze()
-            ?: ApiRepository.getFileDetails(File(id = folderFilesProviderArgs.folderId, driveId = userDrive.driveId)).data
+            ?: ApiRepository.getFileDetails(File(id = folderFilesProviderArgs.folderId, driveId = userDrive.driveId), okHttpClient).data
             ?: return null
 
         return when {

--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -20,6 +20,7 @@ package com.infomaniak.drive.ui
 import android.app.Application
 import android.content.Context
 import android.provider.MediaStore
+import android.util.Log
 import androidx.collection.MutableIntList
 import androidx.collection.mutableIntListOf
 import androidx.fragment.app.FragmentActivity
@@ -290,7 +291,12 @@ class MainViewModel(
         }
     }
 
-    fun moveFile(file: File, newParent: File, onSuccess: ((fileId: Int) -> Unit)? = null) = liveData(Dispatchers.IO) {
+    fun moveFile(
+        file: File,
+        newParent: File,
+        isSharedWithMe: Boolean = false,
+        onSuccess: ((fileId: Int) -> Unit)? = null
+    ) = liveData(Dispatchers.IO) {
         val apiResponse = ApiRepository.moveFile(file, newParent)
         if (apiResponse.isSuccess()) {
             FileController.getRealmInstance().use { realm ->
@@ -306,7 +312,18 @@ class MainViewModel(
                     runCatching { localFolder.children.remove(file) }
                 }
 
-                FileController.addChild(newParent.id, file.apply { parentId = newParent.id }, realm)
+                if (isSharedWithMe) {
+                    // If the selected folder is a shared folder, it is removed from the user's realm table (userId_driveId)
+                    // and added to the share realm (userId_share)
+                    FileController.removeFile(fileId = file.id, customRealm = realm)
+                    FileController.getRealmInstance(UserDrive(sharedWithMe = true)).use {realm ->
+                        FileController.updateFile(newParent.id, realm) { localFolder ->
+                            runCatching { localFolder.children.add(file) }
+                        }
+                    }
+                } else {
+                    FileController.addChild(newParent.id, file.apply { parentId = newParent.id }, realm)
+                }
             }
 
             onSuccess?.invoke(file.id)

--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -250,6 +250,7 @@ class SaveExternalFilesActivity : BaseActivity() {
                     putExtras(
                         SelectFolderActivityArgs(
                             userId = selectDriveViewModel.selectedUserId.value!!,
+                            fromSaveExternal = true,
                             driveId = selectDriveViewModel.selectedDrive.value?.id!!,
                         ).toBundle()
                     )

--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -101,6 +101,8 @@ class SaveExternalFilesActivity : BaseActivity() {
     private var currentUri: Uri? = null
     private var isMultiple = false
 
+    private var driveIdSharedWithMe: Int? = null
+
     private val selectFolderResultLauncher = registerForActivityResult(StartActivityForResult()) {
         it.whenResultIsOk { data ->
             data?.extras?.let { bundle ->
@@ -263,9 +265,7 @@ class SaveExternalFilesActivity : BaseActivity() {
     private fun fetchFolder() = with(selectDriveViewModel) {
         saveExternalFilesViewModel.folderId.observe(this@SaveExternalFilesActivity) { folderId ->
 
-            val folder = if (selectedUserId.value == null || selectedDrive.value?.id == null
-                || folderId == null
-            ) {
+            val folder = if (selectedUserId.value == null || selectedDrive.value?.id == null || folderId == null) {
                 null
             } else {
                 val userDrive = UserDrive(
@@ -273,7 +273,16 @@ class SaveExternalFilesActivity : BaseActivity() {
                     driveId = selectedDrive.value!!.id,
                     sharedWithMe = selectedDrive.value!!.sharedWithMe,
                 )
-                FileController.getFileById(folderId, userDrive)
+                driveIdSharedWithMe = FileController.getSharedDriveIdById(userDrive.userId, folderId)?.driveId
+
+                FileController.getFileById(folderId, userDrive) ?: FileController.getFileById(
+                    fileId = folderId,
+                    userDrive = UserDrive(
+                        userId = selectedUserId.value!!,
+                        driveId = driveIdSharedWithMe!!,
+                        sharedWithMe = true,
+                    )
+                )
             }
 
             folder?.let {
@@ -291,7 +300,11 @@ class SaveExternalFilesActivity : BaseActivity() {
             setOnClickListener {
                 if (navigationArgs.isPublicShare) {
                     Intent().apply {
-                        putExtra(DESTINATION_DRIVE_ID_KEY, selectDriveViewModel.selectedDrive.value?.id)
+                        if (driveIdSharedWithMe != null) {
+                            putExtra(DESTINATION_DRIVE_ID_KEY, driveIdSharedWithMe)
+                        } else {
+                            putExtra(DESTINATION_DRIVE_ID_KEY, selectDriveViewModel.selectedDrive.value?.id)
+                        }
                         putExtra(DESTINATION_FOLDER_ID_KEY, saveExternalFilesViewModel.folderId.value)
                         setResult(RESULT_OK, this)
                     }
@@ -302,13 +315,13 @@ class SaveExternalFilesActivity : BaseActivity() {
                 showProgressCatching()
                 if (drivePermissions.checkSyncPermissions()) {
                     val userId = selectedUserId.value!!
-                    val driveId = selectedDrive.value?.id!!
+                    val driveId = selectedDrive.value!!.id
                     val folderId = saveExternalFilesViewModel.folderId.value!!
 
                     if (canSaveFilesPref()) uiSettings.setSaveExternalFilesPref(userId, driveId, folderId)
 
                     lifecycleScope.launch(Dispatchers.IO) {
-                        if (storeFiles(userId, driveId, folderId)) {
+                        if (storeFiles(userId, driveIdSharedWithMe ?: driveId, folderId)) {
                             syncImmediately()
                             finish()
                         } else {

--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -189,7 +189,6 @@ class SaveExternalFilesActivity : BaseActivity() {
         selectDriveViewModel.apply {
             selectedUserId.value = userId
             selectedDrive.value = drive
-            showSharedWithMe = true
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
@@ -361,8 +361,8 @@ class FileInfoActionsBottomSheetDialog : BottomSheetDialogFragment(), FileInfoAc
         }
     }
 
-    override fun onMoveFile(destinationFolder: File) {
-        mainViewModel.moveFile(currentFile, destinationFolder)
+    override fun onMoveFile(destinationFolder: File, isSharedWithMe: Boolean) {
+        mainViewModel.moveFile(currentFile, destinationFolder, isSharedWithMe)
             .observe(viewLifecycleOwner) { fileRequest ->
                 if (fileRequest.isSuccess) {
                     mainViewModel.refreshActivities.value = true

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FavoritesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FavoritesFragment.kt
@@ -20,12 +20,16 @@ package com.infomaniak.drive.ui.fileList
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isGone
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.data.models.BulkOperationType
 import com.infomaniak.drive.data.models.File
+import com.infomaniak.drive.data.models.Rights
+import com.infomaniak.drive.ui.fileList.SelectFolderActivity.SelectFolderViewModel
 import com.infomaniak.drive.ui.fileList.multiSelect.FavoritesMultiSelectActionsBottomSheetDialog
 import com.infomaniak.drive.ui.fileList.multiSelect.MultiSelectActionsBottomSheetDialog
 import com.infomaniak.drive.utils.Utils
@@ -41,6 +45,8 @@ class FavoritesFragment : FileListFragment() {
     override val noItemsRootIcon = R.drawable.ic_star_filled
     override val noItemsRootTitle = R.string.favoritesNoFile
 
+    private val selectFolderViewModel: SelectFolderViewModel by activityViewModels()
+
     override fun initSwipeRefreshLayout(): SwipeRefreshLayout = binding.swipeRefreshLayout
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -49,6 +55,17 @@ class FavoritesFragment : FileListFragment() {
         setToolbarTitle(R.string.favoritesTitle)
         setupAdapter()
         setupMultiSelectLayout()
+        if (requireActivity() is SelectFolderActivity) {
+            lifecycleScope.launchWhenResumed {
+                with(requireActivity() as SelectFolderActivity) {
+                    showSaveButton()
+                    val currentFolderRights = FileController.getFileById(folderId, userDrive)?.rights ?: Rights()
+                    val enable = folderId != selectFolderViewModel.disableSelectedFolderId
+                            && (currentFolderRights.canMoveInto || currentFolderRights.canCreateFile)
+                    enableSaveButton(enable)
+                }
+            }
+        }
     }
 
     private fun initParams() {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileAdapter.kt
@@ -30,6 +30,7 @@ import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
+import coil.ImageLoader
 import com.google.android.material.card.MaterialCardView
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.AppSettings
@@ -61,7 +62,7 @@ import java.util.UUID
 open class FileAdapter(
     private val multiSelectManager: MultiSelectManager,
     var fileList: OrderedRealmCollection<File> = RealmList(),
-    override val lifecycle: Lifecycle
+    override val lifecycle: Lifecycle,
 ) : RealmRecyclerViewAdapter<File, FileViewHolder>(fileList, true, true), LifecycleOwner {
 
     private var fileAsyncListDiffer: AsyncListDiffer<File>? = null
@@ -75,6 +76,7 @@ open class FileAdapter(
     var showShareFileButton = true
     var viewHolderType: DisplayType = DisplayType.LIST
 
+    var newImageLoader: ImageLoader? = null
     var uploadInProgress = false
     var publicShareCanDownload = true
 
@@ -323,8 +325,8 @@ open class FileAdapter(
 
         currentBindScope.launch(start = CoroutineStart.UNDISPATCHED) {
             when (binding) {
-                is CardviewFileListBinding -> (binding as CardviewFileListBinding).itemViewFile.setFileItem(file, isGrid)
-                is CardviewFileGridBinding -> (binding as CardviewFileGridBinding).setFileItem(file, isGrid)
+                is CardviewFileListBinding -> (binding as CardviewFileListBinding).itemViewFile.setFileItem(file, isGrid, newImageLoader)
+                is CardviewFileGridBinding -> (binding as CardviewFileGridBinding).setFileItem(file, isGrid, newImageLoader)
                 is CardviewFolderGridBinding -> (binding as CardviewFolderGridBinding).setFileItem(file, isGrid)
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -43,6 +43,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.work.WorkInfo
 import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.appbar.MaterialToolbar
+import com.infomaniak.drive.MainApplication
 import com.infomaniak.drive.MatomoDrive.MatomoCategory
 import com.infomaniak.drive.MatomoDrive.MatomoName
 import com.infomaniak.drive.MatomoDrive.trackEvent
@@ -484,15 +485,23 @@ open class FileListFragment : MultiSelectFragment(
             updateMultiSelect = { onUpdateMultiSelect() }
         }
 
+        val mainApp = requireContext().applicationContext as MainApplication
+
         fileAdapter = FileAdapter(
             multiSelectManager = multiSelectManager,
             fileList = FileController.emptyList(mainViewModel.realm),
-            lifecycle = viewLifecycleOwner.lifecycle
+            lifecycle = viewLifecycleOwner.lifecycle,
         ).apply {
             stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
             setHasStableIds(true)
 
             onEmptyList = { checkIfNoFiles() }
+
+            newImageLoader = if (userDrive?.userId != AccountUtils.currentUserId) {
+                mainApp.newImageLoaderWithOtherUserId(userDrive?.userId)
+            } else {
+                mainApp.newImageLoader()
+            }
 
             onFileClicked = { file ->
                 if (file.isUsable()) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -497,11 +497,7 @@ open class FileListFragment : MultiSelectFragment(
 
             onEmptyList = { checkIfNoFiles() }
 
-            newImageLoader = if (userDrive?.userId != AccountUtils.currentUserId) {
-                mainApp.newImageLoaderWithOtherUserId(userDrive?.userId)
-            } else {
-                mainApp.newImageLoader()
-            }
+            newImageLoader = mainApp.newImageLoader(userDrive?.userId)
 
             onFileClicked = { file ->
                 if (file.isUsable()) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,12 +42,16 @@ import com.infomaniak.drive.utils.FileId
 import com.infomaniak.drive.utils.Position
 import com.infomaniak.drive.utils.Utils
 import com.infomaniak.lib.core.utils.SingleLiveEvent
+import io.realm.Realm
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.cancellable
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -58,8 +62,7 @@ import kotlinx.coroutines.sync.withLock
 class FileListViewModel(application: Application) : AndroidViewModel(application) {
 
     private inline val context get() = getApplication<MainApplication>().applicationContext
-
-    private val realm = FileController.getRealmInstance()
+    private var realm: Realm? = null
 
     private var getFilesJob: Job = Job()
     private var getFolderActivitiesJob: Job = Job()
@@ -75,13 +78,26 @@ class FileListViewModel(application: Application) : AndroidViewModel(application
 
     var lastItemCount: FileCount? = null
 
+    private val loadRootFiles = MutableSharedFlow<UserDrive>(replay = 1)
+
     fun sortTypeIsInitialized() = ::sortType.isInitialized
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val rootFiles = FileController.getFolderFilesFlow(realm, Utils.ROOT_ID)
+    val rootFiles: LiveData<Map<File.VisibilityType, File>> = loadRootFiles.distinctUntilChanged().flatMapLatest {
+        FileController.getRealmInstance(it).run {
+            realm = this
+            FileController.getFolderFilesFlow(this, Utils.ROOT_ID)
+        }
+    }
         .mapLatest { it.associateBy(File::getVisibilityType) }
         .cancellable()
         .asLiveData(viewModelScope.coroutineContext)
+
+    fun updateRootFiles(userDrive: UserDrive) {
+        viewModelScope.launch {
+            loadRootFiles.emit(userDrive)
+        }
+    }
 
     fun getFiles(
         folderId: Int,
@@ -310,7 +326,7 @@ class FileListViewModel(application: Application) : AndroidViewModel(application
 
     override fun onCleared() {
         super.onCleared()
-        runCatching { realm.close() }
+        runCatching { realm?.close() }
         cancelDownloadFiles()
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderActivity.kt
@@ -102,7 +102,7 @@ class SelectFolderActivity : BaseActivity() {
 
     private fun setSaveButton(customArgs: Bundle?) = with(binding) {
         saveButton.setOnClickListener {
-            val currentFragment = navHostFragment.childFragmentManager.fragments.first() as SelectFolderFragment
+            val currentFragment = navHostFragment.childFragmentManager.fragments.first() as FileListFragment
             Intent().apply {
                 putExtras(
                     SelectFolderActivityArgs(

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderActivity.kt
@@ -57,6 +57,7 @@ class SelectFolderActivity : BaseActivity() {
 
         val userId = navigationArgs.userId
         val driveId = navigationArgs.driveId
+        val fromSaveExternal = navigationArgs.fromSaveExternal
         val customArgs = navigationArgs.customArgs
         val currentFolderId = navigationArgs.folderId.getIntOrNull()
         val disabledFolderId = navigationArgs.disabledFolderId.getIntOrNull()
@@ -76,7 +77,11 @@ class SelectFolderActivity : BaseActivity() {
 
             navController.setGraph(
                 R.navigation.select_folder_navigation,
-                SelectRootFolderFragmentArgs(driveId = driveId, userDrive = currentUserDrive).toBundle()
+                SelectRootFolderFragmentArgs(
+                    driveId = driveId,
+                    fromSaveExternal = fromSaveExternal,
+                    userDrive = currentUserDrive
+                ).toBundle()
             )
 
             setSaveButton(customArgs)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderActivity.kt
@@ -34,6 +34,7 @@ import com.infomaniak.drive.databinding.ActivitySelectFolderBinding
 import com.infomaniak.drive.extensions.onApplyWindowInsetsListener
 import com.infomaniak.drive.ui.BaseActivity
 import com.infomaniak.drive.ui.MainViewModel
+import com.infomaniak.drive.ui.menu.SharedWithMeFragment
 import com.infomaniak.drive.utils.Utils
 import com.infomaniak.drive.utils.Utils.ROOT_ID
 import com.infomaniak.lib.core.utils.setMargins
@@ -113,7 +114,8 @@ class SelectFolderActivity : BaseActivity() {
                     SelectFolderActivityArgs(
                         folderId = currentFragment.folderId,
                         folderName = currentFragment.folderName,
-                        customArgs = customArgs
+                        customArgs = customArgs,
+                        isSharedWithMe = navHostFragment.childFragmentManager.fragments.first() is SharedWithMeFragment
                     ).toBundle()
                 )
                 setResult(RESULT_OK, this)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2025 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,7 +47,7 @@ class SelectFolderFragment : FileListFragment() {
     override val noItemsTitle = R.string.noFilesDescription
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?): Unit = with(binding) {
-        userDrive = selectFolderViewModel.userDrive
+        userDrive = navigationArgs.userDrive
         super.onViewCreated(view, savedInstanceState)
 
         folderName = if (folderId == ROOT_ID) selectFolderViewModel.currentDrive?.name ?: "/" else navigationArgs.folderName
@@ -82,7 +82,13 @@ class SelectFolderFragment : FileListFragment() {
             onFileClicked = { file ->
                 if (file.isFolder() && !file.isDisabled()) {
                     fileListViewModel.cancelDownloadFiles()
-                    safeNavigate(SelectFolderFragmentDirections.fileListFragmentToFileListFragment(file.id, file.name))
+                    safeNavigate(
+                        SelectFolderFragmentDirections.fileListFragmentToFileListFragment(
+                            folderId = file.id,
+                            folderName = file.name,
+                            userDrive = userDrive!!
+                        )
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderFragment.kt
@@ -95,6 +95,8 @@ class SelectRootFolderFragment : BaseRootFolderFragment() {
 
         setupRecentFoldersViews()
 
+        selectRootFolderViewModel.loadRootFiles(navigationArgs.userDrive)
+
         (activity as SelectFolderActivity).hideSaveButton()
 
         rootFolderLayout.cardView.setMargins(top = resources.getDimension(R.dimen.marginStandardSmall).toInt())

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderFragment.kt
@@ -104,7 +104,9 @@ class SelectRootFolderFragment : BaseRootFolderFragment() {
         setupItems(
             folderLayout = binding.rootFolderLayout,
             favoritesNav = SelectRootFolderFragmentDirections.actionSelectRootFolderFragmentToFavoritesFragment(),
-            sharedWithMeNav = SelectRootFolderFragmentDirections.actionSelectRootFolderFragmentToSharedWithMeFragment(),
+            sharedWithMeNav = SelectRootFolderFragmentDirections.actionSelectRootFolderFragmentToSharedWithMeFragment(
+                fromSaveExternal = navigationArgs.fromSaveExternal
+            ),
             mySharesNav = SelectRootFolderFragmentDirections.actionSelectRootFolderFragmentToMySharesFragment()
         )
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.infomaniak.drive.data.cache.FileController
 import com.infomaniak.drive.data.models.File
+import com.infomaniak.drive.data.models.UserDrive
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -33,12 +34,18 @@ import kotlinx.coroutines.launch
 class SelectRootFolderViewModel : ViewModel() {
 
     private val loadFiles = MutableSharedFlow<Int>(replay = 1)
+
+    private var userDrive: UserDrive? = null
+    private val realm
+        get() = FileController.getRealmInstance(userDrive)
+
     @OptIn(ExperimentalCoroutinesApi::class)
     val recentFiles: StateFlow<List<File>> = loadFiles.distinctUntilChanged().flatMapLatest { limit ->
-        FileController.getRecentFolders(limit)
+        FileController.getRecentFolders(realm, limit)
     }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
-    fun getRecentFolders(limit: Int) {
+    fun getRecentFolders(userDrive: UserDrive, limit: Int) {
+        this.userDrive = userDrive
         viewModelScope.launch {
             loadFiles.emit(limit)
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectRootFolderViewModel.kt
@@ -71,7 +71,6 @@ class SelectRootFolderViewModel : ViewModel() {
                     userDrive = userDrive,
                 )
             )
-
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewPDFActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewPDFActivity.kt
@@ -165,7 +165,7 @@ class PreviewPDFActivity : AppCompatActivity(), OnItemClickListener {
     override fun onDeleteFile(onApiResponse: () -> Unit) = Unit
     override fun onDuplicateFile(destinationFolder: File) = Unit
     override fun onLeaveShare(onApiResponse: () -> Unit) = Unit
-    override fun onMoveFile(destinationFolder: File) = Unit
+    override fun onMoveFile(destinationFolder: File, isSharedWithMe: Boolean) = Unit
     override fun onRenameFile(newName: String, onApiResponse: () -> Unit) = Unit
     override fun removeOfflineFile(offlineLocalPath: IOFile, cacheFile: IOFile) = Unit
 }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
@@ -309,7 +309,7 @@ class PreviewSliderFragment : BasePreviewSliderFragment(), FileInfoActionsView.O
         }
     }
 
-    override fun onMoveFile(destinationFolder: File) {
+    override fun onMoveFile(destinationFolder: File, isSharedWithMe: Boolean) {
         mainViewModel.moveFile(currentFile, destinationFolder)
             .observe(viewLifecycleOwner) { fileRequest ->
                 if (fileRequest.isSuccess) {

--- a/app/src/main/java/com/infomaniak/drive/ui/home/RootFilesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/RootFilesFragment.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavDirections
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.models.UiSettings
+import com.infomaniak.drive.data.models.UserDrive
 import com.infomaniak.drive.databinding.FragmentRootFilesBinding
 import com.infomaniak.drive.databinding.RootFolderLayoutBinding
 import com.infomaniak.drive.extensions.enableEdgeToEdge
@@ -69,6 +70,8 @@ class RootFilesFragment : BaseRootFolderFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) = with(binding) {
         super.onViewCreated(view, savedInstanceState)
+
+        fileListViewModel.updateRootFiles(UserDrive())
 
         setupDriveToolbar(collapsingToolbarLayout, switchDriveLayout, appBar)
 

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/MySharesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/MySharesFragment.kt
@@ -19,11 +19,15 @@ package com.infomaniak.drive.ui.menu
 
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.cache.FileController
+import com.infomaniak.drive.data.models.Rights
 import com.infomaniak.drive.ui.fileList.SelectFolderActivity
+import com.infomaniak.drive.ui.fileList.SelectFolderActivity.SelectFolderViewModel
 import com.infomaniak.drive.ui.fileList.multiSelect.MultiSelectActionsBottomSheetDialog
 import com.infomaniak.drive.ui.fileList.multiSelect.MySharesMultiSelectActionsBottomSheetDialog
 import com.infomaniak.drive.utils.Utils
@@ -40,6 +44,8 @@ class MySharesFragment : FileSubTypeListFragment() {
     override val noItemsRootIcon = R.drawable.ic_share
     override val noItemsRootTitle = R.string.mySharesNoFile
 
+    private val selectFolderViewModel: SelectFolderViewModel by activityViewModels()
+
     override fun initSwipeRefreshLayout(): SwipeRefreshLayout = binding.swipeRefreshLayout
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -47,6 +53,17 @@ class MySharesFragment : FileSubTypeListFragment() {
         super.onViewCreated(view, savedInstanceState)
         setToolbarTitle(R.string.mySharesTitle)
         setupAdapter()
+        if (requireActivity() is SelectFolderActivity) {
+            lifecycleScope.launchWhenResumed {
+                with(requireActivity() as SelectFolderActivity) {
+                    showSaveButton()
+                    val currentFolderRights = FileController.getFileById(folderId, userDrive)?.rights ?: Rights()
+                    val enable = folderId != selectFolderViewModel.disableSelectedFolderId
+                            && (currentFolderRights.canMoveInto || currentFolderRights.canCreateFile)
+                    enableSaveButton(enable)
+                }
+            }
+        }
     }
 
     private fun initParams() {

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/SharedWithMeFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/SharedWithMeFragment.kt
@@ -83,9 +83,12 @@ class SharedWithMeFragment : FileSubTypeListFragment() {
                 with(requireActivity() as SelectFolderActivity) {
                     showSaveButton()
                     val currentFolderRights = FileController.getFileById(folderId, userDrive)?.rights ?: Rights()
-                    val withinSameDrive = userDrive?.driveId == AccountUtils.currentDriveId
+                    val fromSaveExternal = if (navigationArgs.fromSaveExternal) true else {
+                        userDrive?.driveId == AccountUtils.currentDriveId
+                    }
                     val enable = folderId != selectFolderViewModel.disableSelectedFolderId
-                            && (currentFolderRights.canMoveInto || currentFolderRights.canCreateFile) && withinSameDrive
+                            && (currentFolderRights.canMoveInto || currentFolderRights.canCreateFile)
+                            && fromSaveExternal
                     enableSaveButton(enable)
                 }
             }
@@ -136,6 +139,7 @@ class SharedWithMeFragment : FileSubTypeListFragment() {
                 folderId = id,
                 folderName = name,
                 driveId = driveId,
+                fromSaveExternal = navigationArgs.fromSaveExternal
             )
         )
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/SharedWithMeFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/SharedWithMeFragment.kt
@@ -83,8 +83,9 @@ class SharedWithMeFragment : FileSubTypeListFragment() {
                 with(requireActivity() as SelectFolderActivity) {
                     showSaveButton()
                     val currentFolderRights = FileController.getFileById(folderId, userDrive)?.rights ?: Rights()
+                    val withinSameDrive = userDrive?.driveId == AccountUtils.currentDriveId
                     val enable = folderId != selectFolderViewModel.disableSelectedFolderId
-                            && (currentFolderRights.canMoveInto || currentFolderRights.canCreateFile)
+                            && (currentFolderRights.canMoveInto || currentFolderRights.canCreateFile) && withinSameDrive
                     enableSaveButton(enable)
                 }
             }

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/OnPublicShareItemClickListener.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/OnPublicShareItemClickListener.kt
@@ -136,7 +136,7 @@ interface OnPublicShareItemClickListener : FileInfoActionsView.OnItemClickListen
     override fun onDeleteFile(onApiResponse: () -> Unit) = Unit
     override fun onLeaveShare(onApiResponse: () -> Unit) = Unit
     override fun onDuplicateFile(destinationFolder: File) = Unit
-    override fun onMoveFile(destinationFolder: File) = Unit
+    override fun onMoveFile(destinationFolder: File, isSharedWithMe: Boolean) = Unit
     override fun onRenameFile(newName: String, onApiResponse: () -> Unit) = Unit
     override fun removeOfflineFile(offlineLocalPath: IOFile, cacheFile: IOFile) = Unit
 }

--- a/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/Extensions.kt
@@ -62,6 +62,8 @@ import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import androidx.work.OneTimeWorkRequest
 import androidx.work.OutOfQuotaPolicy
+import coil.ImageLoader
+import coil.imageLoader
 import coil.load
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.CollapsingToolbarLayout
@@ -139,8 +141,18 @@ fun Context.getAvailableMemory(): ActivityManager.MemoryInfo {
     }
 }
 
-fun ImageView.loadAny(data: Any?, @DrawableRes errorRes: Int = R.drawable.fallback_image) {
-    load(data) {
+fun ImageView.loadAny(
+    data: Any?,
+    @DrawableRes errorRes: Int = R.drawable.fallback_image,
+    imageLoader: ImageLoader? = context.imageLoader
+) {
+    imageLoader?.let {
+        load(data, it) {
+            error(errorRes)
+            fallback(errorRes)
+            placeholder(R.drawable.placeholder)
+        }
+    } ?: load(data) {
         error(errorRes)
         fallback(errorRes)
         placeholder(R.drawable.placeholder)

--- a/app/src/main/java/com/infomaniak/drive/utils/FileItemUtils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/FileItemUtils.kt
@@ -29,6 +29,8 @@ import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.viewbinding.ViewBinding
+import coil.ImageLoader
+import coil.imageLoader
 import coil.load
 import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.infomaniak.core.FormatterFileSize.formatShortFileSize
@@ -60,23 +62,25 @@ import kotlinx.coroutines.withContext
 suspend fun ItemFileBinding.setFileItem(
     file: File,
     isGrid: Boolean = false,
+    imageLoader: ImageLoader? = context.imageLoader,
     typeFolder: TypeFolder = TypeFolder.fileList
 ): Nothing {
-    setFileItemWithoutCategories(file = file, typeFolder = typeFolder, isGrid = isGrid)
+    setFileItemWithoutCategories(file = file, typeFolder = typeFolder, isGrid = isGrid, imageLoader)
     categoriesLayout.displayCategoriesForFile(file)
 }
 
 fun ItemFileBinding.setFileItemWithoutCategories(
     file: File,
     typeFolder: TypeFolder = TypeFolder.fileList,
-    isGrid: Boolean = false
+    isGrid: Boolean = false,
+    imageLoader: ImageLoader? = context.imageLoader,
 ) {
     fileName.text = file.getDisplayName(context)
     fileFavorite.isVisible = file.isFavorite
     progressLayout.isGone = true
     displayDate(file)
     displaySize(file)
-    filePreview.displayIcon(file, isGrid, progressLayout)
+    filePreview.displayIcon(file, isGrid, progressLayout, imageLoader = imageLoader)
     iconLayout.setMargins(left = typeFolder.iconHorizontalMargin, right = typeFolder.iconHorizontalMargin)
     displayExternalImport(file, filePreview, fileProgression, fileDate)
 }
@@ -90,11 +94,11 @@ suspend fun CardviewFolderGridBinding.setFileItem(file: File, isGrid: Boolean = 
     categoriesLayout.displayCategoriesForFile(file)
 }
 
-suspend fun CardviewFileGridBinding.setFileItem(file: File, isGrid: Boolean = false): Nothing {
+suspend fun CardviewFileGridBinding.setFileItem(file: File, isGrid: Boolean = false, imageLoader: ImageLoader?): Nothing {
     fileName.text = file.getDisplayName(context)
     fileFavorite.isVisible = file.isFavorite
     progressLayout.isGone = true
-    filePreview.displayIcon(file, isGrid, progressLayout, filePreview2)
+    filePreview.displayIcon(file, isGrid, progressLayout, filePreview2, imageLoader)
     categoriesLayout.displayCategoriesForFile(file)
 }
 
@@ -121,11 +125,12 @@ private fun ImageView.displayIcon(
     isGrid: Boolean,
     progressLayout: ProgressLayoutView,
     filePreview: ImageView? = null,
+    imageLoader: ImageLoader? = context.imageLoader,
 ) {
     scaleType = if (isGrid) ImageView.ScaleType.FIT_CENTER else ImageView.ScaleType.CENTER
     when {
         file.isFolder() -> displayFolderIcon(file)
-        else -> displayFileIcon(file, isGrid, progressLayout, filePreview)
+        else -> displayFileIcon(file, isGrid, progressLayout, filePreview, imageLoader)
     }
 }
 
@@ -139,6 +144,7 @@ private fun ImageView.displayFileIcon(
     isGrid: Boolean,
     progressLayout: ProgressLayoutView,
     filePreview: ImageView? = null,
+    imageLoader: ImageLoader?,
 ) {
     val fileType = file.getFileType()
     val isGraphic = fileType == ExtensionType.IMAGE || fileType == ExtensionType.VIDEO
@@ -146,7 +152,7 @@ private fun ImageView.displayFileIcon(
     when {
         file.hasThumbnail && (isGrid || isGraphic) -> {
             scaleType = ImageView.ScaleType.CENTER_CROP
-            loadAny(ApiRoutes.getThumbnailUrl(file), fileType.icon)
+            loadAny(ApiRoutes.getThumbnailUrl(file), fileType.icon, imageLoader)
         }
         file.isFromUploads && isGraphic -> {
             scaleType = ImageView.ScaleType.CENTER_CROP

--- a/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
+++ b/app/src/main/java/com/infomaniak/drive/views/FileInfoActionsView.kt
@@ -540,7 +540,7 @@ class FileInfoActionsView @JvmOverloads constructor(
         fun onDeleteFile(onApiResponse: () -> Unit)
         fun onLeaveShare(onApiResponse: () -> Unit)
         fun onDuplicateFile(destinationFolder: File)
-        fun onMoveFile(destinationFolder: File)
+        fun onMoveFile(destinationFolder: File, isSharedWithMe: Boolean = false)
         fun onRenameFile(newName: String, onApiResponse: () -> Unit)
         fun removeOfflineFile(offlineLocalPath: IOFile, cacheFile: IOFile)
 
@@ -561,7 +561,7 @@ class FileInfoActionsView @JvmOverloads constructor(
                     val file = File(id = folderId, name = folderName, driveId = AccountUtils.currentDriveId)
                     when (customArgs?.getString(SINGLE_OPERATION_CUSTOM_TAG)) {
                         SingleOperation.COPY.name -> onDuplicateFile(file)
-                        SingleOperation.MOVE.name -> onMoveFile(file)
+                        SingleOperation.MOVE.name -> onMoveFile(file, isSharedWithMe)
                         else -> Unit
                     }
                 }

--- a/app/src/main/res/layout/activity_select_folder.xml
+++ b/app/src/main/res/layout/activity_select_folder.xml
@@ -31,8 +31,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:navGraph="@navigation/select_folder_navigation" />
+        app:layout_constraintTop_toTopOf="parent"/>
 
     <View
         android:layout_width="match_parent"

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -382,6 +382,11 @@
             android:defaultValue="-1"
             app:argType="integer" />
         <argument
+            android:name="fromSaveExternal"
+            android:defaultValue="false"
+            app:argType="boolean" />
+
+        <argument
             android:name="customArgs"
             android:defaultValue="@null"
             app:argType="android.os.Bundle"
@@ -817,6 +822,10 @@
             android:name="driveId"
             android:defaultValue="0"
             app:argType="integer" />
+        <argument
+            android:name="fromSaveExternal"
+            android:defaultValue="false"
+            app:argType="boolean" />
         <action
             android:id="@+id/action_sharedWithMeFragment_to_sortFilesBottomSheetDialog"
             app:destination="@id/sortFilesBottomSheetDialog" />

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -385,7 +385,10 @@
             android:name="fromSaveExternal"
             android:defaultValue="false"
             app:argType="boolean" />
-
+        <argument
+            android:name="isSharedWithMe"
+            android:defaultValue="false"
+            app:argType="boolean" />
         <argument
             android:name="customArgs"
             android:defaultValue="@null"

--- a/app/src/main/res/navigation/select_folder_navigation.xml
+++ b/app/src/main/res/navigation/select_folder_navigation.xml
@@ -46,7 +46,10 @@
             android:name="driveId"
             android:defaultValue="0"
             app:argType="integer" />
-
+        <argument
+            android:name="fromSaveExternal"
+            android:defaultValue="false"
+            app:argType="boolean" />
         <argument
             android:name="userDrive"
             app:argType="com.infomaniak.drive.data.models.UserDrive" />
@@ -87,6 +90,10 @@
             android:name="driveId"
             android:defaultValue="0"
             app:argType="integer" />
+        <argument
+            android:name="fromSaveExternal"
+            android:defaultValue="false"
+            app:argType="boolean" />
         <action
             android:id="@+id/action_sharedWithMeFragment_to_sortFilesBottomSheetDialog"
             app:destination="@id/sortFilesBottomSheetDialog" />

--- a/app/src/main/res/navigation/select_folder_navigation.xml
+++ b/app/src/main/res/navigation/select_folder_navigation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   ~ Infomaniak kDrive - Android
-  ~ Copyright (C) 2022-2024 Infomaniak Network SA
+  ~ Copyright (C) 2022-2025 Infomaniak Network SA
   ~
   ~ This program is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
@@ -42,6 +42,14 @@
         <action
             android:id="@+id/actionSelectRootFolderFragmentToFavoritesFragment"
             app:destination="@id/favoritesFragment" />
+        <argument
+            android:name="driveId"
+            android:defaultValue="0"
+            app:argType="integer" />
+
+        <argument
+            android:name="userDrive"
+            app:argType="com.infomaniak.drive.data.models.UserDrive" />
     </fragment>
 
     <fragment
@@ -117,6 +125,11 @@
             android:name="folderName"
             android:defaultValue="/"
             app:argType="string" />
+
+        <argument
+            android:name="userDrive"
+            app:argType="com.infomaniak.drive.data.models.UserDrive" />
+
         <action
             android:id="@+id/fileListFragmentToFileListFragment"
             app:destination="@id/selectFolderFragment"


### PR DESCRIPTION
When you perform a `move`, you can select a folder located in `Share With Me, i.e., a shared folder, only if the current **driveId** is the same as the **driveId** of the selected folder.

To import an external file, you can choose to import any shared file (without checking the **driveId**).
