### PR TITLE
fix: Update parent folder when refreshActivities is called

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -155,13 +155,12 @@ class MainViewModel(
 
     private fun getContext() = getApplication<MainApplication>()
 
-    fun getFileWithDetailsById(parentId: Int, userDrive: UserDrive? = null, callback: (File?) -> Unit) {
+    suspend fun getFileWithDetailsById(parentId: Int, userDrive: UserDrive? = null): File? {
+        var file: File? = null
         viewModelScope.launch(Dispatchers.IO) {
-            val updatedFileDetails = FileController.getFileDetails(parentId, userDrive ?: UserDrive())
-            withContext(Dispatchers.Main) {
-                callback(updatedFileDetails)
-            }
-        }
+            file = FileController.getFileDetails(parentId, userDrive ?: UserDrive())
+        }.join()
+        return file
     }
 
     fun setCurrentFolder(folder: File?) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -590,8 +590,8 @@ open class FileListFragment : MultiSelectFragment(
         activitiesRefreshTimer.cancel()
         isLoadingActivities = true
         mainViewModel.currentFolder.value?.let { localCurrentFolder ->
-            mainViewModel.getFileWithDetailsById(localCurrentFolder.id, userDrive) { updatedFolder ->
-                updatedFolder?.let { downloadFolderActivities(updatedFolder) }
+            viewLifecycleOwner.lifecycleScope.launch {
+                mainViewModel.getFileWithDetailsById(localCurrentFolder.id, userDrive)?.let { downloadFolderActivities(it) }
                 activitiesRefreshTimer.start()
             }
         } ?: run { activitiesRefreshTimer.start() }


### PR DESCRIPTION
This is to always have an updated parent updatedAt with the right value.