### PR TITLE
chore: Add SentryLog when OnlyOffice webview throw console errors 

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/OnlyOfficeActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/OnlyOfficeActivity.kt
@@ -196,11 +196,9 @@ class OnlyOfficeActivity : AppCompatActivity() {
     }
 
     private inner class OnlyOfficeWebChromeClient : WebChromeClient() {
-        override fun onProgressChanged(view: WebView, newProgress: Int) {
-            with(binding) {
-                progressBar.progress = newProgress
-                if (newProgress == 100) progressBar.isGone = true
-            }
+        override fun onProgressChanged(view: WebView, newProgress: Int) = with(binding) {
+            progressBar.progress = newProgress
+            if (newProgress == 100) progressBar.isGone = true
         }
 
         override fun onShowFileChooser(


### PR DESCRIPTION
If the OnlyOffice WebView encounters errors, we are not notified with Sentry.