### PR TITLE
fix: Be able to import a single file (public share)

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
@@ -289,8 +289,13 @@ class PublicShareListFragment : FileListFragment() {
         if (data == null || destinationDriveId == PUBLIC_SHARE_DEFAULT_ID || destinationFolderId == PUBLIC_SHARE_DEFAULT_ID) {
             showSnackbar(RCore.string.anErrorHasOccurred, anchor = importButton)
         } else {
+            val rootSharedFileId = publicShareViewModel.rootSharedFile.value?.id
             val fileIds = multiSelectManager.selectedItemsIds.toList().ifEmpty {
-                if (folderId == publicShareViewModel.rootSharedFile.value?.id) emptyList() else listOf(folderId)
+                if (folderId == rootSharedFileId || publicShareViewModel.fileId == rootSharedFileId) {
+                    emptyList()
+                } else {
+                    listOf(folderId)
+                }
             }
             closeMultiSelect()
             publicShareViewModel.importFilesToDrive(

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareViewModel.kt
@@ -72,6 +72,9 @@ class PublicShareViewModel(application: Application, val savedStateHandle: Saved
     val driveId: Int
         inline get() = savedStateHandle[PublicShareActivityArgs::driveId.name] ?: ROOT_SHARED_FILE_ID
 
+    val fileId: Int
+        inline get() = savedStateHandle[PublicShareActivityArgs::fileId.name] ?: ROOT_SHARED_FILE_ID
+
     val publicShareUuid: String
         inline get() = savedStateHandle[PublicShareActivityArgs::publicShareUuid.name] ?: ""
 
@@ -83,9 +86,6 @@ class PublicShareViewModel(application: Application, val savedStateHandle: Saved
 
     private val canDownload: Boolean
         inline get() = savedStateHandle[PublicShareActivityArgs::canDownload.name] ?: false
-
-    private val fileId: Int
-        inline get() = savedStateHandle[PublicShareActivityArgs::fileId.name] ?: ROOT_SHARED_FILE_ID
 
     private var getPublicShareFilesJob: Job = Job()
     private var currentCursor: String? = null


### PR DESCRIPTION
If a single file is shared, the folderId remains at 1 (default value) and therefore creates an error. So if the folderId is 1, you need to check the fileId.