### PR TITLE
chore: Clean useless matrix in android ci github workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,10 +11,6 @@ jobs:
   instrumentation-tests:
     if: github.event.pull_request.draft == false
     runs-on: [ self-hosted, Android ]
-    strategy:
-      matrix:
-        api-level: [ 34 ]
-        target: [ google_apis ]
 
     env:
       ENV_PATH: "app/src/androidTest/java/com/infomaniak/drive/utils/Env.kt"
@@ -56,18 +52,3 @@ jobs:
 
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest --stacktrace
-
-      # - name: Run instrumentation tests
-      #   uses: ReactiveCircus/android-emulator-runner@v2.30.1
-      #   with:
-      #     api-level: ${{ matrix.api-level }}
-      #     target: ${{ matrix.target }}
-      #     profile: pixel_7
-      #     arch: arm64-v8a
-      #     disk-size: 6G
-      #     avd-name: kdrive-test
-      #     force-avd-creation: false
-      #     disable-animations: true
-      #     emulator-options: -no-snapshot-save -noaudio -no-boot-anim -camera-back none -skin 540x1110
-      #     # emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 540x1110
-      #     script: ./gradlew uninstallAll app:connectedStandardDebugAndroidTest --stacktrace


### PR DESCRIPTION
Also remove the commented out code which was the only reason to use this matrix