### PR TITLE
refactor(PublicShare): Use multitask for public share

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/LaunchActivity.kt
@@ -115,7 +115,10 @@ class LaunchActivity : AppCompatActivity() {
             when (destinationClass) {
                 MainActivity::class.java -> mainActivityExtras?.let(::putExtras)
                 LoginActivity::class.java -> putExtra("isHelpShortcutPressed", isHelpShortcutPressed)
-                PublicShareActivity::class.java -> publicShareActivityExtras?.let(::putExtras)
+                PublicShareActivity::class.java -> {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_MULTIPLE_TASK
+                    publicShareActivityExtras?.let(::putExtras)
+                }
             }
         }.also(::startActivity)
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareActivity.kt
@@ -19,6 +19,7 @@ package com.infomaniak.drive.ui.publicShare
 
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
+import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isGone
@@ -53,6 +54,7 @@ class PublicShareActivity : AppCompatActivity() {
             view.setMargins(left = margin + insets.left, right = margin + insets.right, bottom = margin + insets.bottom)
         }
         if (SDK_INT >= 29) window.isNavigationBarContrastEnforced = false
+        onBackPressedDispatcher.addCallback { finishAndRemoveTask() }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/publicShare/PublicShareListFragment.kt
@@ -194,7 +194,7 @@ class PublicShareListFragment : FileListFragment() {
     private fun onBackPressed() {
         publicShareViewModel.cancelDownload()
         if (folderId == publicShareViewModel.rootSharedFile.value?.id || folderId == ROOT_SHARED_FILE_ID) {
-            requireActivity().finish()
+            requireActivity().finishAndRemoveTask()
         } else {
             findNavController().popBackStack()
         }


### PR DESCRIPTION
Stop opening public Shares on the "main" task. 
Each public share will now have its own task, so user can return to them "later" and manage it independently from the main app