### PR TITLE
fix: Check if the api resume chunk size is correct before resuming the upload

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/api/FileChunkSizeManager.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/FileChunkSizeManager.kt
@@ -39,7 +39,10 @@ class FileChunkSizeManager(
      * @throws AllowedFileSizeExceededException If the file is large enough to chunk with the current config.
      */
     fun computeChunkConfig(fileSize: Long, defaultFileChunkSize: Long? = null): ChunkConfig {
-        val fileChunkSize = defaultFileChunkSize ?: computeChunkSize(fileSize)
+        val fileChunkSize = when {
+            defaultFileChunkSize != null && defaultFileChunkSize >= chunkMinSize -> defaultFileChunkSize
+            else -> computeChunkSize(fileSize)
+        }
         val totalChunks = computeFileChunks(fileSize, fileChunkSize)
 
         require(totalChunks <= maxChunkCount)

--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -195,7 +195,7 @@ class UploadTask(
     }
 
     private fun getChunkConfig(validChunks: ValidChunks?): FileChunkSizeManager.ChunkConfig {
-        val validChuckSize = validChunks?.validChuckSize
+        val validChuckSize = validChunks?.validChunkSize
         return try {
             fileChunkSizeManager.computeChunkConfig(
                 fileSize = uploadFile.fileSize,
@@ -348,7 +348,7 @@ class UploadTask(
     }
 
     private fun ValidChunks.needToResetUpload(chunkSize: Long): Boolean {
-        return if (expectedSize != uploadFile.fileSize || validChuckSize != chunkSize.toInt()) {
+        return if (expectedSize != uploadFile.fileSize || validChunkSize != chunkSize.toInt()) {
             uploadFile.resetUploadTokenAndCancelSession()
             true
         } else {

--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -195,12 +195,12 @@ class UploadTask(
     }
 
     private fun getChunkConfig(validChunks: ValidChunks?): FileChunkSizeManager.ChunkConfig {
+        val validChuckSize = validChunks?.validChuckSize
         return try {
             fileChunkSizeManager.computeChunkConfig(
                 fileSize = uploadFile.fileSize,
-                defaultFileChunkSize = validChunks?.validChuckSize?.toLong(),
+                defaultFileChunkSize = validChuckSize?.toLong(),
             ).also {
-                val validChuckSize = validChunks?.validChuckSize
                 if (validChuckSize != null && validChuckSize != it.fileChunkSize.toInt()) {
                     SentryLog.e(TAG, "Expected api size different") { scope ->
                         scope.setExtra("expected api chunk size", validChuckSize.toString())

--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -19,12 +19,10 @@
 
 package com.infomaniak.drive.data.api
 
-import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.core.net.toFile
 import androidx.work.Data
 import androidx.work.workDataOf
 import com.google.gson.annotations.SerializedName
@@ -149,12 +147,13 @@ class UploadTask(
     }
 
     private suspend fun launchTask() = coroutineScope {
-        val uploadedChunks = uploadFile.getValidChunks()
+        var uploadedChunks = uploadFile.getValidChunks()
         val chunkConfig = getChunkConfig(uploadedChunks)
         val totalChunks = chunkConfig.totalChunks
         val isNewUploadSession = uploadedChunks?.needToResetUpload(chunkConfig.fileChunkSize) ?: true
 
         val uploadHost = if (isNewUploadSession) {
+            uploadedChunks = null
             uploadFile.prepareUploadSession(totalChunks)
         } else {
             uploadFile.uploadHost

--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -149,9 +149,9 @@ class UploadTask(
     }
 
     private suspend fun launchTask() = coroutineScope {
-        val chunkConfig = getChunkConfig()
-        val totalChunks = chunkConfig.totalChunks
         val uploadedChunks = uploadFile.getValidChunks()
+        val chunkConfig = getChunkConfig(uploadedChunks)
+        val totalChunks = chunkConfig.totalChunks
         val isNewUploadSession = uploadedChunks?.needToResetUpload(chunkConfig.fileChunkSize) ?: true
 
         val uploadHost = if (isNewUploadSession) {
@@ -195,11 +195,11 @@ class UploadTask(
         if (isActive) onFinish(uploadFile.getUriObject())
     }
 
-    private fun getChunkConfig(): FileChunkSizeManager.ChunkConfig {
+    private fun getChunkConfig(validChunks: ValidChunks?): FileChunkSizeManager.ChunkConfig {
         return try {
             fileChunkSizeManager.computeChunkConfig(
                 fileSize = uploadFile.fileSize,
-                defaultFileChunkSize = uploadFile.getValidChunks()?.validChuckSize?.toLong(),
+                defaultFileChunkSize = validChunks?.validChuckSize?.toLong(),
             )
         } catch (exception: IllegalArgumentException) {
             uploadFile.resetUploadTokenAndCancelSession()

--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -200,7 +200,15 @@ class UploadTask(
             fileChunkSizeManager.computeChunkConfig(
                 fileSize = uploadFile.fileSize,
                 defaultFileChunkSize = validChunks?.validChuckSize?.toLong(),
-            )
+            ).also {
+                val validChuckSize = validChunks?.validChuckSize
+                if (validChuckSize != null && validChuckSize != it.fileChunkSize.toInt()) {
+                    SentryLog.e(TAG, "Expected api size different") { scope ->
+                        scope.setExtra("expected api chunk size", validChuckSize.toString())
+                        scope.setExtra("calculated chunk size", it.fileChunkSize.toString())
+                    }
+                }
+            }
         } catch (exception: IllegalArgumentException) {
             uploadFile.resetUploadTokenAndCancelSession()
             fileChunkSizeManager.computeChunkConfig(fileSize = uploadFile.fileSize)

--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -195,15 +195,15 @@ class UploadTask(
     }
 
     private fun getChunkConfig(validChunks: ValidChunks?): FileChunkSizeManager.ChunkConfig {
-        val validChuckSize = validChunks?.validChunkSize
+        val validChunkSize = validChunks?.validChunkSize
         return try {
             fileChunkSizeManager.computeChunkConfig(
                 fileSize = uploadFile.fileSize,
-                defaultFileChunkSize = validChuckSize?.toLong(),
+                defaultFileChunkSize = validChunkSize?.toLong(),
             ).also {
-                if (validChuckSize != null && validChuckSize != it.fileChunkSize.toInt()) {
+                if (validChunkSize != null && validChunkSize != it.fileChunkSize.toInt()) {
                     SentryLog.e(TAG, "Expected api size different") { scope ->
-                        scope.setExtra("expected api chunk size", validChuckSize.toString())
+                        scope.setExtra("expected api chunk size", validChunkSize.toString())
                         scope.setExtra("calculated chunk size", it.fileChunkSize.toString())
                         scope.setExtra("expected api chunks count", validChunks.expectedChunksCount.toString())
                         scope.setExtra("calculated chunks count", it.totalChunks.toString())

--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -205,6 +205,8 @@ class UploadTask(
                     SentryLog.e(TAG, "Expected api size different") { scope ->
                         scope.setExtra("expected api chunk size", validChuckSize.toString())
                         scope.setExtra("calculated chunk size", it.fileChunkSize.toString())
+                        scope.setExtra("expected api chunks count", validChunks.expectedChunksCount.toString())
+                        scope.setExtra("calculated chunks count", it.totalChunks.toString())
                     }
                 }
             }

--- a/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
@@ -91,7 +91,10 @@ open class UploadFile(
     fun resetUploadToken() {
         getRealmInstance().use { realm ->
             uploadFileByUriQuery(realm, uri).findFirst()?.apply {
-                realm.executeTransaction { uploadToken = null }
+                realm.executeTransaction {
+                    uploadToken = null
+                    uploadHost = null
+                }
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/data/models/upload/ValidChunks.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/upload/ValidChunks.kt
@@ -34,5 +34,5 @@ data class ValidChunks(
 ) {
     inline val validChunksIds get() = chunks.map { it.number }
 
-    inline val validChuckSize get() = chunks.firstOrNull()?.size ?: 0
+    inline val validChunkSize get() = chunks.firstOrNull()?.size ?: 0
 }


### PR DESCRIPTION
Check the api expected chunk size and add more sentry log when an unexpected error has been occurred