### PR TITLE
fix: Upload with wrong last_modified date

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -427,12 +427,14 @@ class UploadTask(
     }
 
     private fun UploadFile.prepareUploadSession(totalChunks: Int): String? {
+        val currentTimeMillis = System.currentTimeMillis()
+        val lastModifiedAt = if (fileModifiedAt.time > currentTimeMillis) currentTimeMillis else fileModifiedAt.time
         val sessionBody = UploadSession.StartSessionBody(
             conflict = if (replaceOnConflict()) ConflictOption.VERSION else ConflictOption.RENAME,
             createdAt = if (fileCreatedAt == null) null else fileCreatedAt!!.time / 1_000L,
             directoryId = remoteFolder,
             fileName = fileName,
-            lastModifiedAt = fileModifiedAt.time / 1_000L,
+            lastModifiedAt = lastModifiedAt / 1_000L,
             subDirectoryPath = remoteSubFolder ?: "",
             totalChunks = totalChunks,
             totalSize = fileSize,

--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -23,6 +23,7 @@ import android.content.Context
 import android.net.Uri
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.net.toFile
 import androidx.work.Data
 import androidx.work.workDataOf
 import com.google.gson.annotations.SerializedName
@@ -128,7 +129,7 @@ class UploadTask(
                 scope.setExtra("fileModifiedAt", "${uploadFile.fileModifiedAt.time}")
                 scope.setExtra("fileCreatedAt", "${uploadFile.fileCreatedAt?.time}")
             }
-
+            if (uploadFile.isSchemeFile()) Dispatchers.IO { uploadFile.getUriObject().toFile().delete() }
             uploadFile.deleteIfExists(keepFile = uploadFile.isSync())
         } catch (exception: FileNotFoundException) {
             uploadFile.deleteIfExists(keepFile = uploadFile.isSync())

--- a/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
@@ -71,6 +71,8 @@ open class UploadFile(
     @delegate:Ignore
     val okHttpClient: OkHttpClient by lazy { runBlocking { AccountUtils.getHttpClient(userId = userId, timeout = 120) } }
 
+    fun isSchemeFile() = getUriObject().scheme.equals(ContentResolver.SCHEME_FILE)
+
     fun createSubFolder(parent: String, createDatedSubFolders: Boolean) {
         remoteSubFolder = parent + if (createDatedSubFolders) "/${fileModifiedAt.format("yyyy/MM")}" else ""
     }

--- a/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/services/UploadWorker.kt
@@ -268,7 +268,7 @@ class UploadWorker(appContext: Context, params: WorkerParameters) : CoroutineWor
         updateUploadCountNotification()
 
         try {
-            if (uri.scheme.equals(ContentResolver.SCHEME_FILE)) {
+            if (isSchemeFile()) {
                 uploadSchemeFile(uri)
             } else {
                 uploadSchemeContent(uri)

--- a/app/src/main/java/com/infomaniak/drive/utils/SyncUtils.kt
+++ b/app/src/main/java/com/infomaniak/drive/utils/SyncUtils.kt
@@ -64,8 +64,7 @@ object SyncUtils {
         SentryLog.d(TAG, "lastModifiedIndex = $lastModifiedIndex dateModifiedIndex = $dateModifiedIndex")
         var fileModifiedAt = when {
             cursor.isValidDate(lastModifiedIndex) -> {
-                val lastModifiedValue = cursor.getLong(lastModifiedIndex)
-                SentryLog.d(TAG, "lastModifiedIndex is a valid date with $lastModifiedValue")
+                val lastModifiedValue = getLastModifiedOrNow(cursor, lastModifiedIndex)
                 Date(lastModifiedValue)
             }
             cursor.isValidDate(dateModifiedIndex) -> {
@@ -86,6 +85,17 @@ object SyncUtils {
         }
 
         return Pair(fileCreatedAt, fileModifiedAt)
+    }
+
+    private fun getLastModifiedOrNow(cursor: Cursor, lastModifiedIndex: Int): Long {
+        val lastModifiedValue = cursor.getLong(lastModifiedIndex)
+        val currentTimeMillis = System.currentTimeMillis()
+        return if (lastModifiedValue > currentTimeMillis) {
+            SentryLog.w(TAG, "lastModifiedIndex is not a valid date with $lastModifiedValue")
+            currentTimeMillis
+        } else {
+            lastModifiedValue
+        }
     }
 
     private fun Cursor.isValidDate(index: Int) = index != -1 && this.getLong(index) > 0


### PR DESCRIPTION
**Description**
When uploading and the last_modified date is not in milliseconds, we receive a validation failed message from the API.

**Fix**
We protect the last_modified field. If the format causes problems, we use today's date instead.