### PR TITLE
fix: Fix CloudStorageProvider crash for drives with @ in their name

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
@@ -894,10 +894,7 @@ class CloudStorageProvider : DocumentsProvider() {
                 val drivePath = parentDocumentId.substringAfter(SEPARATOR)
                 val driveName = drivePath.substringBeforeLast(DRIVE_SEPARATOR)
                 val driveId = drivePath.substringAfterLast(DRIVE_SEPARATOR).toInt()
-                DriveDocument(
-                    name = driveName,
-                    id = driveId
-                )
+                DriveDocument(name = driveName, id = driveId)
             } else DriveDocument(name = "", id = -1)
         }
 


### PR DESCRIPTION
Couldn't test it because the backend doesn't let me change the drive name for the test account.

@sirambd Could you test it on your side?