### PR TITLE
fix: Close WebView to notify OnlyOffice and release document lock

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/OnlyOfficeActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/OnlyOfficeActivity.kt
@@ -116,6 +116,8 @@ class OnlyOfficeActivity : AppCompatActivity() {
     }
 
     private fun destroyWebView(): Unit = with(binding.webView) {
+        // Close the webview properly so that OnlyOffice is notified that the document has been closed and releases its lock.
+        // We also ensure release without its plant on certain devices.
         stopLoading()
         (parent as? ViewGroup)?.removeView(this)
         webChromeClient = null


### PR DESCRIPTION
In order to support files in `.txt` format, we must notify OnlyOffice that the **WebView** is closed, thus ensuring that no problems arise with devices and also reducing memory consumption, as resources are freed immediately after exiting the **WebView**.