### PR TITLE
fix: On chromeOS document provider queryChildDocuments now synchronized

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
@@ -87,7 +87,7 @@ class CloudStorageProvider : DocumentsProvider() {
 
     private lateinit var cacheDir: IOFile
     private val cloudScope = CoroutineScope(
-        Dispatchers.IO + CoroutineName("CloudStorage") + Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+        CoroutineName("CloudStorage") + Executors.newSingleThreadExecutor().asCoroutineDispatcher()
     )
 
     /**


### PR DESCRIPTION
 Currently, there is a bug in the Chrome OS file explorer.
When the contentResolver is notified asynchronously, the file explorer does not necessarily refresh the view and does not request the updated file list again.
The file list is therefore only loaded synchronously on Chrome OS.