### PR TITLE
chore: Remove useless spaces at the end of strings and correctly order words in template string

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -617,7 +617,7 @@
     <string name="shareLinkPrivateRightTitle">Privat</string>
     <string name="shareLinkPublicRightDescription">Alle med linket kan %1$s denne %3$s%2$s%4$s.</string>
     <string name="shareLinkPublicRightDescriptionDate">indtil %s</string>
-    <string name="shareLinkPublicRightDescriptionPassword">adgangskodebeskyttet</string>
+    <string name="shareLinkPublicRightDescriptionPassword">adgangskodebeskyttet\u0020</string>
     <string name="shareLinkPublicRightDocumentDescriptionShort">Alle med linket kan få adgang til dokumentet.</string>
     <string name="shareLinkPublicRightFileDescriptionShort">Alle med linket kan få adgang til filen.</string>
     <string name="shareLinkPublicRightFolderDescriptionShort">Alle med linket kan få adgang til mappen.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -537,7 +537,7 @@
     <string name="notEnoughStorageDescription1">kDrive-tallennustilasi on lähes täynnä. Päivitä pakettisi ja avaa uusia ominaisuuksia.</string>
     <string name="notEnoughStorageDescription2">kDrive-tallennustilasi on lähes täynnä. Ota yhteyttä ylläpitäjääsi, jotta hän voi päivittää pakettisi.</string>
     <string name="notEnoughStorageUsed">käytetty</string>
-    <string name="notSupportedExtensionDescription">Haluatko luoda kopion tiedostostasi yhteensopivalla laajennuksella verkkomuokkausta varten? Alkuperäinen %s-tiedosto säilyy muuttumattomana.\u0020</string>
+    <string name="notSupportedExtensionDescription">Haluatko luoda kopion tiedostostasi yhteensopivalla laajennuksella verkkomuokkausta varten? Alkuperäinen %s-tiedosto säilyy muuttumattomana.</string>
     <string name="notSupportedExtensionTitle">Laajennusta %s ei tueta verkkomuokkauksessa</string>
     <string name="notificationCommentChannelName">Kommentit</string>
     <string name="notificationGeneralChannelName">Yleiset ilmoitukset</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -537,7 +537,7 @@
     <string name="notEnoughStorageDescription1">L’espace de stockage de votre kDrive est presque plein. Faites évoluer votre offre et débloquez de nouvelles fonctionnalités.</string>
     <string name="notEnoughStorageDescription2">L’espace de stockage de votre kDrive est presque plein. Contactez votre administrateur pour qu’il puisse faire évoluer votre offre.</string>
     <string name="notEnoughStorageUsed">utilisés</string>
-    <string name="notSupportedExtensionDescription">Souhaitez-vous créer une copie de votre fichier avec une extension compatible pour l’éditer en ligne ? Le fichier original %s restera inchangé.\u0020</string>
+    <string name="notSupportedExtensionDescription">Souhaitez-vous créer une copie de votre fichier avec une extension compatible pour l’éditer en ligne ? Le fichier original %s restera inchangé.</string>
     <string name="notSupportedExtensionTitle">L’extension %s n’est pas supportée pour l’édition en ligne</string>
     <string name="notificationCommentChannelName">Commentaires</string>
     <string name="notificationGeneralChannelName">Notifications générales</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -617,7 +617,7 @@
     <string name="shareLinkPrivateRightTitle">Privat</string>
     <string name="shareLinkPublicRightDescription">Alle som har linken kan %1$s denne %2$s%3$s%4$s.</string>
     <string name="shareLinkPublicRightDescriptionDate">\u0020frem til %s</string>
-    <string name="shareLinkPublicRightDescriptionPassword">%s beskyttet av et passord</string>
+    <string name="shareLinkPublicRightDescriptionPassword">\u0020beskyttet av et passord</string>
     <string name="shareLinkPublicRightDocumentDescriptionShort">Alle som har linken kan få tilgang til dokumentet.</string>
     <string name="shareLinkPublicRightFileDescriptionShort">Alle som har linken kan få tilgang til filen.</string>
     <string name="shareLinkPublicRightFolderDescriptionShort">Alle som har linken kan få tilgang til mappen.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -615,9 +615,9 @@
     <string name="shareLinkPasswordRightDescription">Iedereen die de link heeft moet een wachtwoord invoeren om de %s te benaderen.</string>
     <string name="shareLinkPasswordRightTitle">Met wachtwoord</string>
     <string name="shareLinkPrivateRightTitle">Privé</string>
-    <string name="shareLinkPublicRightDescription">Iedereen met de link kan dit %3$s %1$s%2$s%4$s.</string>
+    <string name="shareLinkPublicRightDescription">Iedereen met de link kan dit %3$s%2$s %1$s%4$s.</string>
     <string name="shareLinkPublicRightDescriptionDate">\u0020tot %s</string>
-    <string name="shareLinkPublicRightDescriptionPassword">wachtwoordbeveiligd\u0020</string>
+    <string name="shareLinkPublicRightDescriptionPassword">wachtwoordbeveiligde\u0020</string>
     <string name="shareLinkPublicRightDocumentDescriptionShort">Iedereen met de link kan het document benaderen.</string>
     <string name="shareLinkPublicRightFileDescriptionShort">Iedereen met de link kan het bestand benaderen.</string>
     <string name="shareLinkPublicRightFolderDescriptionShort">Iedereen met de link kan de map benaderen.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -675,7 +675,7 @@
     <string name="shareLinkPrivateRightTitle">Prywatny</string>
     <string name="shareLinkPublicRightDescription">Każdy, kto ma link, może %1$s ten %3$s%2$s%4$s.</string>
     <string name="shareLinkPublicRightDescriptionDate">\u0020do %s</string>
-    <string name="shareLinkPublicRightDescriptionPassword">\u0020chroniony hasłem</string>
+    <string name="shareLinkPublicRightDescriptionPassword">chroniony hasłem\u0020</string>
     <string name="shareLinkPublicRightDocumentDescriptionShort">Każdy, kto ma link, może uzyskać dostęp do dokumentu.</string>
     <string name="shareLinkPublicRightFileDescriptionShort">Każdy, kto ma link, może uzyskać dostęp do pliku.</string>
     <string name="shareLinkPublicRightFolderDescriptionShort">Każdy, kto ma link, może uzyskać dostęp do folderu.</string>


### PR DESCRIPTION
The shareLinkPublicRightDescription argument ordering was wrong in nl.

Also some of the arguments that go in that string were wrong in some languages because they sometimes need a leading or trailing space based on their respective template string `shareLinkPublicRightDescription`