### PR TITLE
refactor: Simplify update upload file

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
@@ -105,13 +105,9 @@ open class UploadFile(
     fun uploadConflictOption() = if (replaceOnConflict()) ConflictOption.VERSION else ConflictOption.RENAME
 
     fun resetUploadToken() {
-        getRealmInstance().use { realm ->
-            uploadFileByUriQuery(realm, uri).findFirst()?.apply {
-                realm.executeTransaction {
-                    uploadToken = null
-                    uploadHost = null
-                }
-            }
+        updateDbInstance {
+            it.uploadToken = null
+            it.uploadHost = null
         }
     }
 
@@ -127,24 +123,19 @@ open class UploadFile(
     }
 
     fun updateFileSize(newFileSize: Long) {
-        getRealmInstance().use { realm ->
-            uploadFileByUriQuery(realm, uri).findFirst()?.let { uploadFile ->
-                realm.executeTransaction { uploadFile.fileSize = newFileSize }
-            }
+        update {
+            it.fileSize = newFileSize
         }
-        fileSize = newFileSize
     }
 
     fun updateUploadToken(newUploadToken: String, uploadHost: String) {
-        getRealmInstance().use { realm ->
-            uploadFileByUriQuery(realm, uri).findFirst()?.let { uploadFile ->
-                realm.executeTransaction {
-                    uploadFile.uploadToken = newUploadToken
-                    uploadFile.uploadHost = uploadHost
-                }
-            }
+        updateDbInstance {
+            it.uploadToken = newUploadToken
+            it.uploadHost = uploadHost
         }
-        uploadToken = newUploadToken
+        updateCurrentInstance {
+            it.uploadToken = newUploadToken
+        }
     }
 
     fun deleteIfExists(keepFile: Boolean = false, customRealm: Realm? = null) {

--- a/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
@@ -167,9 +167,9 @@ open class UploadFile(
 
     private fun updateDbInstance(transactionBlock: (UploadFile) -> Unit) {
         getRealmInstance().use { realm ->
-            uploadFileByUriQuery(realm, uri).findFirst()?.apply {
-                realm.executeTransaction { transactionBlock(this) }
-            }
+            uploadFileByUriQuery(realm, uri)
+                .findFirst()
+                ?.let { uploadFile -> realm.executeTransaction { transactionBlock(uploadFile) } }
         }
     }
 

--- a/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
@@ -169,6 +169,23 @@ open class UploadFile(
         }
     }
 
+    private fun update(transaction: (UploadFile) -> Unit) {
+        updateDbInstance(transaction)
+        updateCurrentInstance(transaction)
+    }
+
+    private fun updateDbInstance(transactionBlock: (UploadFile) -> Unit) {
+        getRealmInstance().use { realm ->
+            uploadFileByUriQuery(realm, uri).findFirst()?.apply {
+                realm.executeTransaction { transactionBlock(this) }
+            }
+        }
+    }
+
+    private fun updateCurrentInstance(transactionBlock: (UploadFile) -> Unit) {
+        transactionBlock(this)
+    }
+
     enum class Type {
         SYNC, UPLOAD, SHARED_FILE, SYNC_OFFLINE, CLOUD_STORAGE
     }


### PR DESCRIPTION
Merge all the logic of updating in a single method which use two sub methods (update DB and update current instance). For the moment to be full compliant with existing code, I use sometimes the sub method instead of the global one. I think we can call the global one everywhere, but I need a second sight on it.

Part of feature on updating upload error management