### PR TITLE
feat: Add error in uploadfile

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -261,6 +261,7 @@ dependencies {
     androidTestRuntimeOnly(libs.android.test.runner)
 
     implementation(core.coil.gif)
+    implementation(kotlin("reflect"))
 
     // Compose
     implementation(libs.androidx.ui.android)

--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -225,6 +225,7 @@ class UploadTask(
                 okHttpClient = uploadFile.okHttpClient
             )
             if (!closedSessionResponse.isSuccess()) closedSessionResponse.manageUploadErrors()
+            else uploadFile.updateUploadErrorKey(null)
         }
     }
 
@@ -412,6 +413,8 @@ class UploadTask(
                 ApiResponse<Any>(error = ApiError(description = bodyResponse))
             }
             apiResponse.manageUploadErrors()
+        } else {
+            uploadFile.updateUploadErrorKey(null)
         }
     }
 
@@ -475,14 +478,15 @@ class UploadTask(
         return ApiRepository.startUploadSession(driveId, sessionBody, okHttpClient).also {
             if (it.isSuccess()) it.data?.run {
                 uploadFile.updateUploadToken(token, uploadHost)
+                uploadFile.updateUploadErrorKey(null)
             } else {
-                uploadFile.updateUploadErrorKey(it.error?.code)
                 it.manageUploadErrors()
             }
         }.data?.uploadHost
     }
 
     private fun <T> ApiResponse<T>.manageUploadErrors() {
+        uploadFile.updateUploadErrorKey(error?.code)
         if (error?.exception is ApiControllerNetworkException) throw NetworkException()
         when (error?.code) {
             "file_already_exists_error" -> Unit

--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -476,6 +476,7 @@ class UploadTask(
             if (it.isSuccess()) it.data?.run {
                 uploadFile.updateUploadToken(token, uploadHost)
             } else {
+                uploadFile.updateUploadErrorKey(it.error?.code)
                 it.manageUploadErrors()
             }
         }.data?.uploadHost

--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -42,6 +42,7 @@ import com.infomaniak.drive.data.api.ApiRepository.uploadEmptyFile
 import com.infomaniak.drive.data.api.ApiRoutes.uploadChunkUrl
 import com.infomaniak.drive.data.models.UploadFile
 import com.infomaniak.drive.data.models.drive.Drive.MaintenanceReason
+import com.infomaniak.drive.data.models.up.DriveError
 import com.infomaniak.drive.data.models.upload.UploadSession
 import com.infomaniak.drive.data.models.upload.ValidChunks
 import com.infomaniak.drive.data.services.UploadWorker
@@ -486,8 +487,11 @@ class UploadTask(
     }
 
     private fun <T> ApiResponse<T>.manageUploadErrors() {
+        if (error?.exception is ApiControllerNetworkException) {
+            uploadFile.updateUploadErrorKey(DriveError.Network.NetworkError.key)
+            throw NetworkException()
+        }
         uploadFile.updateUploadErrorKey(error?.code)
-        if (error?.exception is ApiControllerNetworkException) throw NetworkException()
         when (error?.code) {
             "file_already_exists_error" -> Unit
             "lock_error" -> throw LockErrorException()

--- a/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/api/UploadTask.kt
@@ -473,8 +473,8 @@ class UploadTask(
         )
 
         return ApiRepository.startUploadSession(driveId, sessionBody, okHttpClient).also {
-            if (it.isSuccess()) it.data?.token?.let { uploadToken ->
-                uploadFile.updateUploadToken(uploadToken, it.data!!.uploadHost)
+            if (it.isSuccess()) it.data?.run {
+                uploadFile.updateUploadToken(token, uploadHost)
             } else {
                 it.manageUploadErrors()
             }

--- a/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
@@ -32,6 +32,7 @@ import com.infomaniak.drive.data.api.ApiRepository
 import com.infomaniak.drive.data.api.UploadTask
 import com.infomaniak.drive.data.api.UploadTask.Companion.ConflictOption
 import com.infomaniak.drive.data.cache.DriveInfosController
+import com.infomaniak.drive.data.models.up.DriveError
 import com.infomaniak.drive.data.sync.UploadMigration
 import com.infomaniak.drive.utils.AccountUtils
 import com.infomaniak.drive.utils.IOFile
@@ -59,6 +60,7 @@ open class UploadFile(
     @PrimaryKey var uri: String = "",
     var deletedAt: Date? = null,
     var driveId: Int = -1,
+    private var _driveErrorKey: String? = null,
     var fileCreatedAt: Date? = null,
     var fileModifiedAt: Date = Date(),
     var fileName: String = "",
@@ -136,6 +138,10 @@ open class UploadFile(
         updateCurrentInstance {
             it.uploadToken = newUploadToken
         }
+    }
+
+    fun updateUploadErrorKey(driveErrorKey: String?) {
+        update { it._driveErrorKey = driveErrorKey }
     }
 
     fun deleteIfExists(keepFile: Boolean = false, customRealm: Realm? = null) {

--- a/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/UploadFile.kt
@@ -74,6 +74,9 @@ open class UploadFile(
     var userId: Int = -1,
 ) : RealmObject() {
 
+    val error: DriveError?
+        get() = DriveError.find(_driveErrorKey)
+
     @delegate:Ignore
     val okHttpClient: OkHttpClient by lazy { runBlocking { AccountUtils.getHttpClient(userId = userId, timeout = 120) } }
 

--- a/app/src/main/java/com/infomaniak/drive/data/models/up/DriveError.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/up/DriveError.kt
@@ -118,16 +118,16 @@ sealed interface DriveError {
 
 
     companion object {
-        fun find(key: String?): DriveError? = key?.let { allValues.find { it.key == key } }
+        fun find(key: String?): DriveError? = key?.let { allValues[key] }
 
-        private val allValues: List<DriveError> by lazy { buildAllValuesList() }
+        private val allValues: Map<String, DriveError> by lazy { buildAllValuesList() }
 
-        private fun buildAllValuesList(): List<DriveError> {
+        private fun buildAllValuesList(): Map<String, DriveError> {
             return Local::class.values() + Network::class.values() + ServerError::class.values() + ServerPlurals::class.values()
         }
 
-        private inline fun <reified T : DriveError> KClass<T>.values(): List<DriveError> =
-            sealedSubclasses.map { it.objectInstance as DriveError }
+        private inline fun <reified T : DriveError> KClass<T>.values(): Map<String, DriveError> =
+            sealedSubclasses.map { it.objectInstance as DriveError }.associateBy { it.key }
 
     }
 }

--- a/app/src/main/java/com/infomaniak/drive/data/models/up/DriveError.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/up/DriveError.kt
@@ -28,7 +28,7 @@ import kotlin.reflect.KClass
 sealed interface DriveError {
     val key: String
 
-    interface Plurals {
+    fun interface Plurals {
         fun message(quantity: Int): String
     }
 

--- a/app/src/main/java/com/infomaniak/drive/data/models/up/DriveError.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/up/DriveError.kt
@@ -1,0 +1,133 @@
+/*
+ * Infomaniak kDrive - Android
+ * Copyright (C) 2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.infomaniak.drive.data.models.up
+
+import androidx.annotation.PluralsRes
+import androidx.annotation.StringRes
+import com.infomaniak.drive.R
+import com.infomaniak.drive.data.models.up.DriveError.Server.ServerError
+import com.infomaniak.drive.data.models.up.DriveError.Server.ServerPlurals
+import splitties.init.appCtx
+import kotlin.reflect.KClass
+
+sealed interface DriveError {
+    val key: String
+
+    interface Plurals {
+        fun message(quantity: Int): String
+    }
+
+    interface Message {
+        val message: String
+    }
+
+    sealed class Local(
+        override val key: String,
+        @field:StringRes private val id: Int = R.string.errorGeneric
+    ) : DriveError, Message {
+        override val message: String
+            get() = appCtx.getString(id)
+
+        object CachingFailed : Local(key = "cachingFailed", id = R.string.errorCache)
+        object DownloadFailed : Local(key = "downloadFailed", id = R.string.errorDownload)
+        object ErrorDeviceStorage : Local(key = "errorDeviceStorage", id = R.string.errorDeviceStorage)
+        object FileNotFound : Local(key = "fileNotFound")
+        object LocalError : Local(key = "localError")
+        object MoveLocalError : Local(key = "moveLocalError", id = R.string.errorMove)
+        object PhotoAssetNoLongerExists : Local(key = "photoAssetNoLongerExists")
+        object PhotoLibraryWriteAccessDenied : Local(key = "writeAccessDenied", id = R.string.errorPhotoLibraryAccessLimited)
+        object SearchCancelled : Local(key = "searchCancelled")
+        object TaskCancelled : Local(key = "taskCancelled")
+        object TaskExpirationCancelled : Local(key = "taskExpirationCancelled")
+        object TaskRescheduled : Local(key = "taskRescheduled")
+        object UnknownError : Local(key = "unknownError")
+        object UnknownToken : Local(key = "unknownToken")
+        object UploadOverDataRestricted : Local(key = "uploadOverDataRestricted", id = R.string.uploadOverDataRestrictedError)
+    }
+
+    sealed interface Network : DriveError, Message {
+        override val key: String
+            get() = "networkError"
+        override val message: String
+            get() = appCtx.getString(R.string.errorNetwork)
+
+        object NetworkError : Network
+    }
+
+    sealed interface Server : DriveError {
+        sealed class ServerPlurals(
+            override val key: String,
+            @field:PluralsRes private val id: Int
+        ) : Server, Plurals {
+            override fun message(quantity: Int): String = appCtx.resources.getQuantityString(id, quantity, quantity)
+        }
+
+        sealed class ServerError(
+            override val key: String,
+            @field:StringRes private val id: Int = R.string.errorGeneric
+        ) : Server, Message {
+            override val message: String
+                get() = appCtx.getString(id)
+        }
+
+        object CategoryAlreadyExists : ServerError(key = "category_already_exist_error", id = R.string.errorCategoryAlreadyExists)
+        object Conflict : ServerError(key = "conflict_error", id = R.string.errorConflict)
+        object DestinationAlreadyExists : ServerError(key = "destination_already_exists", id = R.string.errorFileAlreadyExists)
+        object DownloadPermission : ServerError(key = "you_must_add_at_least_one_file", id = R.string.errorDownloadPermission)
+        object DriveMaintenance : ServerError(key = "drive_is_in_maintenance_error", id = R.string.driveMaintenanceDescription)
+        object FileAlreadyExistsError : ServerError(key = "file_already_exists_error", id = R.string.errorFileAlreadyExists)
+        object Forbidden : ServerError(key = "forbidden_error", id = R.string.accessDeniedTitle)
+        object InvalidCursorError : ServerError(key = "invalid_cursor_error")
+        object InvalidUploadTokenError : ServerError(key = "invalid_upload_token_error")
+        object LimitExceededError : ServerError(key = "limit_exceeded_error", id = R.string.errorLimitExceeded)
+        object LockError : ServerError(key = "lock_error", id = R.string.errorFileLocked)
+        object NoDrive : ServerError(key = "no_drive")
+        object NotAuthorized : ServerError(key = "not_authorized")
+        object ObjectNotFound : ServerError(key = "object_not_found", id = R.string.uploadFolderNotFoundError)
+        object ProductBlocked : ServerPlurals(key = "product_blocked", id = R.plurals.driveBlockedDescription)
+        object ProductMaintenance : ServerError(key = "product_maintenance", id = R.string.driveMaintenanceDescription)
+        object QuotaExceededError : ServerError(key = "quota_exceeded_error", id = R.string.notEnoughStorageDescription1)
+        object RefreshToken : ServerError(key = "refreshToken")
+        object Generic : ServerError(key = "serverError")
+        object ShareLinkAlreadyExists : ServerError(key = "file_share_link_already_exists", id = R.string.errorShareLink)
+        object StillUploadingError : ServerError(key = "still_uploading_error", id = R.string.errorStillUploading)
+        object UploadDestinationNotFoundError : ServerError(key = "upload_destination_not_found_error")
+        object UploadDestinationNotWritableError : ServerError(key = "upload_destination_not_writable_error")
+        object UploadError : ServerError(key = "upload_error")
+        object UploadFailedError : ServerError(key = "upload_failed_error")
+        object UploadNotTerminated : ServerError(key = "upload_not_terminated")
+        object UploadNotTerminatedError : ServerError(key = "upload_not_terminated_error")
+        object UploadTokenCanceled : ServerError(key = "upload_token_canceled")
+        object UploadTokenIsNotValid : ServerError(key = "upload_token_is_not_valid")
+    }
+
+
+    companion object {
+        fun find(key: String?): DriveError? = key?.let { allValues.find { it.key == key } }
+
+        private val allValues: List<DriveError> by lazy { buildAllValuesList() }
+
+        private fun buildAllValuesList(): List<DriveError> {
+            return Local::class.values() + Network::class.values() + ServerError::class.values() + ServerPlurals::class.values()
+        }
+
+        private inline fun <reified T : DriveError> KClass<T>.values(): List<DriveError> =
+            sealedSubclasses.map { it.objectInstance as DriveError }
+
+    }
+}

--- a/app/src/main/java/com/infomaniak/drive/data/sync/UploadMigration.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/sync/UploadMigration.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -116,9 +116,13 @@ class UploadMigration : RealmMigration {
                 ?.addField("onlyWifiSyncMedia", Boolean::class.java, FieldAttribute.REQUIRED)
         }
 
+        if (oldVersion < 9L) {//stop use of oldVersionTemp as it is useless
+            schema.get(UploadFile::class.java.simpleName)
+                ?.addField("_driveErrorKey", String::class.java)
+        }
     }
 
     companion object {
-        const val DB_VERSION = 8L // Must be bumped when the schema changes
+        const val DB_VERSION = 9L // Must be bumped when the schema changes
     }
 }

--- a/app/src/main/java/com/infomaniak/drive/data/sync/UploadMigration.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/sync/UploadMigration.kt
@@ -116,7 +116,7 @@ class UploadMigration : RealmMigration {
                 ?.addField("onlyWifiSyncMedia", Boolean::class.java, FieldAttribute.REQUIRED)
         }
 
-        if (oldVersion < 9L) {//stop use of oldVersionTemp as it is useless
+        if (oldVersion < 9L) { //stop use of oldVersionTemp as it is useless
             schema.get(UploadFile::class.java.simpleName)
                 ?.addField("_driveErrorKey", String::class.java)
         }

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -269,6 +269,7 @@
     <string name="errorFileAlreadyExists">Filen eller mappen findes allerede</string>
     <string name="errorFileLocked">Filen er i øjeblikket åben af en anden bruger og kan ikke ændres</string>
     <string name="errorFilesLimitExceeded">Grænsen for filer i mappen nået</string>
+    <string name="errorGeneric">Der er opstået en fejl</string>
     <string name="errorGetBookmarkURL">Ikke-gendannelseslink</string>
     <string name="errorLeaveShare">Fejl ved afslutning af deling</string>
     <string name="errorLimitExceeded">Grænsen nået</string>
@@ -277,6 +278,7 @@
     <string name="errorMove">Flytningsfejl</string>
     <string name="errorNetwork">Netværksfejl</string>
     <string name="errorNetworkDescription">Resultaterne kan være ufuldstændige</string>
+    <string name="errorPhotoLibraryAccessLimited">kDrive har ikke adgang til dit fotobibliotek</string>
     <string name="errorPreviewDeleted">Denne fil er blevet slettet permanent</string>
     <string name="errorPreviewTrash">Forhåndsvisning af en fil i papirkurven er ikke mulig</string>
     <string name="errorQuotaExceeded">Ikke nok plads på din kDrive</string>
@@ -760,6 +762,7 @@
     <string name="uploadNetworkErrorTitle">Upload suspenderet</string>
     <string name="uploadNetworkErrorWifiRequired">Venter på WiFi-netværk</string>
     <string name="uploadOutOfMemoryError">Utilstrækkelig tilgængelig RAM-hukommelse</string>
+    <string name="uploadOverDataRestrictedError">Venter på Wi-Fi</string>
     <string name="uploadPausedDescription">Nogle uploads er stadig i gang i kDrive. Åbn appen og hold enheden tilsluttet for at fremskynde upload.</string>
     <string name="uploadPausedTitle">Upload suspenderet</string>
     <string name="uploadPermissionError">Yderligere tilladelser anmodet</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -269,6 +269,7 @@
     <string name="errorFileAlreadyExists">Datei oder Ordner existiert bereits</string>
     <string name="errorFileLocked">Diese Datei ist bereits von einem Benutzer geöffnet und kann nicht verändert werden</string>
     <string name="errorFilesLimitExceeded">Limit der Dateien im Ordner erreicht</string>
+    <string name="errorGeneric">Ein Fehler ist aufgetreten</string>
     <string name="errorGetBookmarkURL">Link nicht wiederherstellbar</string>
     <string name="errorLeaveShare">Fehler beim Abbrechen der Freigabe</string>
     <string name="errorLimitExceeded">Limit erreicht</string>
@@ -277,6 +278,7 @@
     <string name="errorMove">Fehler beim Verschieben</string>
     <string name="errorNetwork">Verbindungsproblem</string>
     <string name="errorNetworkDescription">Die Ergebnisse können unvollständig sein</string>
+    <string name="errorPhotoLibraryAccessLimited">kDrive hat keinen Zugriff auf Ihre Fotobibliothek</string>
     <string name="errorPreviewDeleted">Diese Datei wurde endgültig gelöscht</string>
     <string name="errorPreviewTrash">Die Vorschau auf eine Datei im Papierkorb ist nicht verfügbar</string>
     <string name="errorQuotaExceeded">Unzureichender Platz auf Ihrem kDrive</string>
@@ -760,6 +762,7 @@
     <string name="uploadNetworkErrorTitle">Import ausgesetzt</string>
     <string name="uploadNetworkErrorWifiRequired">Warten auf WLAN</string>
     <string name="uploadOutOfMemoryError">Unzureichend verfügbarer RAM</string>
+    <string name="uploadOverDataRestrictedError">Warten auf Wi-Fi</string>
     <string name="uploadPausedDescription">Einige Uploads sind in kDrive noch im Gange. Öffnen Sie die App und lassen Sie das Gerät verbunden, um den Upload zu beschleunigen.</string>
     <string name="uploadPausedTitle">Pause importieren</string>
     <string name="uploadPermissionError">Zusätzlich beantragte Genehmigungen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -269,6 +269,7 @@
     <string name="errorFileAlreadyExists">Το αρχείο ή ο φάκελος υπάρχει ήδη</string>
     <string name="errorFileLocked">Αυτό το αρχείο είναι αυτή τη στιγμή ανοιχτό από άλλον χρήστη και δεν μπορεί να τροποποιηθεί</string>
     <string name="errorFilesLimitExceeded">Έχει επιτευχθεί το όριο αρχείων στον φάκελο</string>
+    <string name="errorGeneric">Παρουσιάστηκε σφάλμα</string>
     <string name="errorGetBookmarkURL">Σύνδεσμος μη ανακτήσιμος</string>
     <string name="errorLeaveShare">Σφάλμα κατά τη διακοπή της κοινής χρήσης</string>
     <string name="errorLimitExceeded">Υπέρβαση ορίου</string>
@@ -277,6 +278,7 @@
     <string name="errorMove">Σφάλμα μετακίνησης</string>
     <string name="errorNetwork">Σφάλμα δικτύου</string>
     <string name="errorNetworkDescription">Τα αποτελέσματα ενδέχεται να είναι ελλιπή</string>
+    <string name="errorPhotoLibraryAccessLimited">Το kDrive δεν έχει πρόσβαση στη βιβλιοθήκη φωτογραφιών σας</string>
     <string name="errorPreviewDeleted">Αυτό το αρχείο διαγράφηκε οριστικά</string>
     <string name="errorPreviewTrash">Η προεπισκόπηση αρχείου στον κάδο δεν είναι δυνατή</string>
     <string name="errorQuotaExceeded">Δεν υπάρχει αρκετός χώρος στο kDrive σας</string>
@@ -760,6 +762,7 @@
     <string name="uploadNetworkErrorTitle">Η μεταφόρτωση ανεστάλη</string>
     <string name="uploadNetworkErrorWifiRequired">Αναμονή για δίκτυο Wi-Fi</string>
     <string name="uploadOutOfMemoryError">Ανεπαρκής διαθέσιμη μνήμη RAM</string>
+    <string name="uploadOverDataRestrictedError">Αναμονή για Wi-Fi</string>
     <string name="uploadPausedDescription">Κάποιες μεταφορτώσεις εξακολουθούν να βρίσκονται σε εξέλιξη στο kDrive. Ανοίξτε την εφαρμογή και κρατήστε τη συσκευή συνδεδεμένη για να επιταχύνετε τη μεταφόρτωση.</string>
     <string name="uploadPausedTitle">Η μεταφόρτωση ανεστάλη</string>
     <string name="uploadPermissionError">Ζητούνται πρόσθετες άδειες</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -269,6 +269,7 @@
     <string name="errorFileAlreadyExists">Archivo o carpeta ya existente</string>
     <string name="errorFileLocked">El archivo está actualmente abierto por un usuario y no puede ser modificado</string>
     <string name="errorFilesLimitExceeded">Límite de archivos alcanzado en la carpeta</string>
+    <string name="errorGeneric">Se ha producido un error</string>
     <string name="errorGetBookmarkURL">Enlace no recuperable</string>
     <string name="errorLeaveShare">Error al salir del uso compartido</string>
     <string name="errorLimitExceeded">Límite alcanzado</string>
@@ -277,6 +278,7 @@
     <string name="errorMove">Error al moverlo</string>
     <string name="errorNetwork">Problema de conexión</string>
     <string name="errorNetworkDescription">Los resultados pueden ser incompletos</string>
+    <string name="errorPhotoLibraryAccessLimited">kDrive no tiene acceso a tu biblioteca de fotos</string>
     <string name="errorPreviewDeleted">Se ha eliminado definitivamente este archivo</string>
     <string name="errorPreviewTrash">La vista previa de un archivo en la papelera no está disponible</string>
     <string name="errorQuotaExceeded">Espacio insuficiente en tu kDrive</string>
@@ -760,6 +762,7 @@
     <string name="uploadNetworkErrorTitle">Importación suspendida</string>
     <string name="uploadNetworkErrorWifiRequired">A la espera de red WiFi</string>
     <string name="uploadOutOfMemoryError">Insuficiente memoria RAM disponible</string>
+    <string name="uploadOverDataRestrictedError">A la espera de Wi-Fi</string>
     <string name="uploadPausedDescription">Algunas subidas siguen en curso en kDrive. Abre la aplicación y mantén el dispositivo conectado para acelerar la carga.</string>
     <string name="uploadPausedTitle">Pausa de importación</string>
     <string name="uploadPermissionError">Permisos adicionales solicitados</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -269,6 +269,7 @@
     <string name="errorFileAlreadyExists">Tiedosto tai kansio on jo olemassa</string>
     <string name="errorFileLocked">Tämä tiedosto on tällä hetkellä toisen käyttäjän avaama eikä sitä voi muokata</string>
     <string name="errorFilesLimitExceeded">Kansion tiedostoraja saavutettu</string>
+    <string name="errorGeneric">Virhe on tapahtunut</string>
     <string name="errorGetBookmarkURL">Linkkiä ei voi palauttaa</string>
     <string name="errorLeaveShare">Virhe jaon lopettamisessa</string>
     <string name="errorLimitExceeded">Raja saavutettu</string>
@@ -277,6 +278,7 @@
     <string name="errorMove">Siirtovirhe</string>
     <string name="errorNetwork">Verkkovirhe</string>
     <string name="errorNetworkDescription">Tulokset voivat olla puutteellisia</string>
+    <string name="errorPhotoLibraryAccessLimited">kDrivella ei ole pääsyä valokuvakirjastoosi</string>
     <string name="errorPreviewDeleted">Tämä tiedosto on poistettu pysyvästi</string>
     <string name="errorPreviewTrash">Tiedoston esikatselu roskakorissa ei ole mahdollista</string>
     <string name="errorQuotaExceeded">Ei tarpeeksi tilaa kDrivessa</string>
@@ -760,6 +762,7 @@
     <string name="uploadNetworkErrorTitle">Lähetys keskeytetty</string>
     <string name="uploadNetworkErrorWifiRequired">Odotetaan Wi-Fi-verkkoa</string>
     <string name="uploadOutOfMemoryError">Keskusmuisti ei riitä</string>
+    <string name="uploadOverDataRestrictedError">Odotetaan Wi-Fiä</string>
     <string name="uploadPausedDescription">Joitakin lähetyksiä on vielä käynnissä kDrivessä. Avaa sovellus ja pidä laite kytkettynä nopeuttaaksesi lähetystä.</string>
     <string name="uploadPausedTitle">Lähetys keskeytetty</string>
     <string name="uploadPermissionError">Lisää käyttöoikeuksia pyydetty</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -269,6 +269,7 @@
     <string name="errorFileAlreadyExists">Le fichier ou le dossier existe déjà</string>
     <string name="errorFileLocked">Le fichier est actuellement ouvert par un utilisateur et ne peut être modifié</string>
     <string name="errorFilesLimitExceeded">Limite de fichiers dans le dossier atteinte</string>
+    <string name="errorGeneric">Une erreur est survenue</string>
     <string name="errorGetBookmarkURL">Lien non récupérable</string>
     <string name="errorLeaveShare">Erreur lors de l’abandon du partage</string>
     <string name="errorLimitExceeded">Limite atteinte</string>
@@ -277,6 +278,7 @@
     <string name="errorMove">Erreur lors du déplacement</string>
     <string name="errorNetwork">Problème de réseau</string>
     <string name="errorNetworkDescription">Les résultats peuvent être incomplets</string>
+    <string name="errorPhotoLibraryAccessLimited">kDrive n’a pas accès à votre photothèque</string>
     <string name="errorPreviewDeleted">Ce fichier a été supprimé définitivement</string>
     <string name="errorPreviewTrash">L’aperçu d’un fichier dans la corbeille n’est pas disponible</string>
     <string name="errorQuotaExceeded">Espace insuffisant sur votre kDrive</string>
@@ -760,6 +762,7 @@
     <string name="uploadNetworkErrorTitle">Importation suspendue</string>
     <string name="uploadNetworkErrorWifiRequired">En attente de réseau Wi-Fi</string>
     <string name="uploadOutOfMemoryError">Mémoire vive disponible insuffisante</string>
+    <string name="uploadOverDataRestrictedError">En attente de Wi-Fi</string>
     <string name="uploadPausedDescription">Des importations sont toujours en cours dans kDrive. Ouvrez l’app et gardez l’appareil branché pour accélérer l’upload.</string>
     <string name="uploadPausedTitle">Importation en pause</string>
     <string name="uploadPermissionError">Autorisations supplémentaires demandées</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -269,6 +269,7 @@
     <string name="errorFileAlreadyExists">Il file o la cartella esiste già</string>
     <string name="errorFileLocked">Il file è attualmente aperto da un utente e non può essere modificato</string>
     <string name="errorFilesLimitExceeded">Limite file raggiunto nella cartella</string>
+    <string name="errorGeneric">Si è verificato un errore</string>
     <string name="errorGetBookmarkURL">Link non recuperabile</string>
     <string name="errorLeaveShare">Errore durante l’abbandono della condivisione</string>
     <string name="errorLimitExceeded">Limite raggiunto</string>
@@ -277,6 +278,7 @@
     <string name="errorMove">Errore durante lo spostamento</string>
     <string name="errorNetwork">Problema di connessione</string>
     <string name="errorNetworkDescription">I risultati possono essere incompleti</string>
+    <string name="errorPhotoLibraryAccessLimited">kDrive non ha accesso alla vostra libreria di foto</string>
     <string name="errorPreviewDeleted">Il file è stato eliminato definitivamente</string>
     <string name="errorPreviewTrash">L’anteprima di un file spostato nel cestino non è disponibile</string>
     <string name="errorQuotaExceeded">Spazio insufficiente sul kDrive</string>
@@ -760,6 +762,7 @@
     <string name="uploadNetworkErrorTitle">Importazione sospesa</string>
     <string name="uploadNetworkErrorWifiRequired">In attesa di connessione alla rete Wi-Fi</string>
     <string name="uploadOutOfMemoryError">Insufficiente RAM disponibile</string>
+    <string name="uploadOverDataRestrictedError">In attesa del Wi-Fi</string>
     <string name="uploadPausedDescription">Alcuni caricamenti sono ancora in corso in kDrive. Aprite l’app e mantenete il dispositivo connesso per accelerare il caricamento.</string>
     <string name="uploadPausedTitle">Pausa importazione</string>
     <string name="uploadPermissionError">Permessi aggiuntivi richiesti</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -269,6 +269,7 @@
     <string name="errorFileAlreadyExists">Fil eller mappe finnes allerede</string>
     <string name="errorFileLocked">Denne filen er for øyeblikket åpen av en annen bruker og kan ikke endres</string>
     <string name="errorFilesLimitExceeded">Grensen for filer i mappen er nådd</string>
+    <string name="errorGeneric">En feil har oppstått</string>
     <string name="errorGetBookmarkURL">Ikke-gjenopprettbar lenke</string>
     <string name="errorLeaveShare">Feil ved avslutning av deling</string>
     <string name="errorLimitExceeded">Grensen er nådd</string>
@@ -277,6 +278,7 @@
     <string name="errorMove">Feil ved flytting</string>
     <string name="errorNetwork">Nettverksfeil</string>
     <string name="errorNetworkDescription">Resultatene kan være ufullstendige</string>
+    <string name="errorPhotoLibraryAccessLimited">kDrive har ikke tilgang til ditt bild bibliotek</string>
     <string name="errorPreviewDeleted">Denne filen har blitt permanent slettet</string>
     <string name="errorPreviewTrash">Forhåndsvisning av en fil i papirkurven er ikke mulig</string>
     <string name="errorQuotaExceeded">Ikke nok plass på din kDrive</string>
@@ -760,6 +762,7 @@
     <string name="uploadNetworkErrorTitle">Opplasting suspendert</string>
     <string name="uploadNetworkErrorWifiRequired">Venter på Wi-Fi-nettverk</string>
     <string name="uploadOutOfMemoryError">Utilstrekkelig tilgjengelig RAM-minne</string>
+    <string name="uploadOverDataRestrictedError">Venter på Wi-Fi</string>
     <string name="uploadPausedDescription">Noen opplastinger er fortsatt i gang i kDrive. Åpne appen og hold enheten tilkoblet for å øke hastigheten på opplastingen.</string>
     <string name="uploadPausedTitle">Opplasting suspendert</string>
     <string name="uploadPermissionError">Tilleggstillatelser forespurt</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -269,6 +269,7 @@
     <string name="errorFileAlreadyExists">Bestand of map bestaat al</string>
     <string name="errorFileLocked">Dit bestand is momenteel geopend door een andere gebruiker en kan niet worden gewijzigd</string>
     <string name="errorFilesLimitExceeded">Limiet van bestanden in map bereikt</string>
+    <string name="errorGeneric">Er is een fout opgetreden</string>
     <string name="errorGetBookmarkURL">Link niet herstelbaar</string>
     <string name="errorLeaveShare">Fout bij het stoppen van delen</string>
     <string name="errorLimitExceeded">Limiet bereikt</string>
@@ -277,6 +278,7 @@
     <string name="errorMove">Verplaatsfout</string>
     <string name="errorNetwork">Netwerkfout</string>
     <string name="errorNetworkDescription">Resultaten kunnen onvolledig zijn</string>
+    <string name="errorPhotoLibraryAccessLimited">kDrive heeft geen toegang tot je fotobibliotheek</string>
     <string name="errorPreviewDeleted">Dit bestand is permanent verwijderd</string>
     <string name="errorPreviewTrash">Een voorbeeld van een bestand in de prullenbak is niet mogelijk</string>
     <string name="errorQuotaExceeded">Niet genoeg ruimte op uw kDrive</string>
@@ -760,6 +762,7 @@
     <string name="uploadNetworkErrorTitle">Uploaden onderbroken</string>
     <string name="uploadNetworkErrorWifiRequired">Wachten op Wi-Fi netwerk</string>
     <string name="uploadOutOfMemoryError">Onvoldoende beschikbaar ram-geheugen</string>
+    <string name="uploadOverDataRestrictedError">Wachten op Wi-Fi</string>
     <string name="uploadPausedDescription">Sommige uploads zijn nog bezig in kDrive. Open de app en houd het apparaat verbonden om de upload te versnellen.</string>
     <string name="uploadPausedTitle">Uploaden gepauzeerd</string>
     <string name="uploadPermissionError">Aanvullende toestemmingen aangevraagd</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -279,6 +279,7 @@
     <string name="errorFileAlreadyExists">Plik lub folder już istnieje</string>
     <string name="errorFileLocked">Ten plik jest obecnie otwarty przez innego użytkownika i nie może być zmodyfikowany</string>
     <string name="errorFilesLimitExceeded">Osiągnięto limit plików w folderze</string>
+    <string name="errorGeneric">Wystąpił błąd</string>
     <string name="errorGetBookmarkURL">Nieodzyskiwalny link</string>
     <string name="errorLeaveShare">Błąd podczas zatrzymywania udostępniania</string>
     <string name="errorLimitExceeded">Osiągnięto limit</string>
@@ -287,6 +288,7 @@
     <string name="errorMove">Błąd przenoszenia</string>
     <string name="errorNetwork">Błąd sieci</string>
     <string name="errorNetworkDescription">Wyniki mogą być niekompletne</string>
+    <string name="errorPhotoLibraryAccessLimited">kDrive nie ma dostępu do biblioteki zdjęć</string>
     <string name="errorPreviewDeleted">Ten plik został trwale usunięty</string>
     <string name="errorPreviewTrash">Podgląd pliku w koszu nie jest możliwy</string>
     <string name="errorQuotaExceeded">Brak miejsca na Twoim kDrive</string>
@@ -834,6 +836,7 @@
     <string name="uploadNetworkErrorTitle">Przesyłanie wstrzymane</string>
     <string name="uploadNetworkErrorWifiRequired">Oczekiwanie na sieć Wi-Fi</string>
     <string name="uploadOutOfMemoryError">Niewystarczająca ilość dostępnej pamięci RAM</string>
+    <string name="uploadOverDataRestrictedError">Oczekiwanie na Wi-Fi</string>
     <string name="uploadPausedDescription">Niektóre przesyłania są nadal w toku w kDrive. Otwórz aplikację i utrzymuj urządzenie podłączone, aby przyspieszyć przesyłanie.</string>
     <string name="uploadPausedTitle">Przesyłanie wstrzymane</string>
     <string name="uploadPermissionError">Zażądano dodatkowych uprawnień</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -269,6 +269,7 @@
     <string name="errorFileAlreadyExists">O ficheiro ou pasta já existe</string>
     <string name="errorFileLocked">Este ficheiro está atualmente aberto por outro utilizador e não pode ser modificado</string>
     <string name="errorFilesLimitExceeded">Limite de ficheiros na pasta atingido</string>
+    <string name="errorGeneric">Ocorreu um erro</string>
     <string name="errorGetBookmarkURL">Link não recuperável</string>
     <string name="errorLeaveShare">Erro ao parar a partilha</string>
     <string name="errorLimitExceeded">Limite excedido</string>
@@ -277,6 +278,7 @@
     <string name="errorMove">Erro ao mover</string>
     <string name="errorNetwork">Erro de rede</string>
     <string name="errorNetworkDescription">Os resultados podem estar incompletos</string>
+    <string name="errorPhotoLibraryAccessLimited">O kDrive não tem acesso à sua biblioteca de fotos</string>
     <string name="errorPreviewDeleted">Este ficheiro foi eliminado permanentemente</string>
     <string name="errorPreviewTrash">Não é possível pré-visualizar um ficheiro na reciclagem</string>
     <string name="errorQuotaExceeded">Espaço insuficiente no seu kDrive</string>
@@ -760,6 +762,7 @@
     <string name="uploadNetworkErrorTitle">Carregamento suspenso</string>
     <string name="uploadNetworkErrorWifiRequired">À espera de rede Wi-Fi</string>
     <string name="uploadOutOfMemoryError">Memória RAM disponível insuficiente</string>
+    <string name="uploadOverDataRestrictedError">À espera de Wi-Fi</string>
     <string name="uploadPausedDescription">Alguns carregamentos estão ainda em curso no kDrive. Abra a app e mantenha o dispositivo ligado para acelerar o carregamento.</string>
     <string name="uploadPausedTitle">Carregamento suspenso</string>
     <string name="uploadPermissionError">Permissões adicionais solicitadas</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -269,6 +269,7 @@
     <string name="errorFileAlreadyExists">Filen eller mappen finns redan</string>
     <string name="errorFileLocked">Denna fil är för närvarande öppen av en annan användare och kan inte ändras</string>
     <string name="errorFilesLimitExceeded">Gränsen för filer i mappen nådd</string>
+    <string name="errorGeneric">Ett fel har inträffat</string>
     <string name="errorGetBookmarkURL">Ej återvinningsbar länk</string>
     <string name="errorLeaveShare">Fel vid avslutning av delning</string>
     <string name="errorLimitExceeded">Gränsen nådd</string>
@@ -277,6 +278,7 @@
     <string name="errorMove">Flyttningsfel</string>
     <string name="errorNetwork">Nätverksfel</string>
     <string name="errorNetworkDescription">Resultaten kan vara ofullständiga</string>
+    <string name="errorPhotoLibraryAccessLimited">kDrive har inte tillgång till ditt fotobibliotek</string>
     <string name="errorPreviewDeleted">Denna fil har permanent tagits bort</string>
     <string name="errorPreviewTrash">Förhandsvisning av en fil i papperskorgen är inte möjlig</string>
     <string name="errorQuotaExceeded">Inte tillräckligt med utrymme på din kDrive</string>
@@ -760,6 +762,7 @@
     <string name="uploadNetworkErrorTitle">Uppladdning pausad</string>
     <string name="uploadNetworkErrorWifiRequired">Väntar på Wi-Fi-nätverk</string>
     <string name="uploadOutOfMemoryError">Otillräckligt RAM-minne</string>
+    <string name="uploadOverDataRestrictedError">Väntar på Wi-Fi</string>
     <string name="uploadPausedDescription">Vissa uppladdningar pågår fortfarande i kDrive. Öppna appen och håll enheten ansluten för att påskynda uppladdningen.</string>
     <string name="uploadPausedTitle">Uppladdning pausad</string>
     <string name="uploadPermissionError">Ytterligare behörigheter begärs</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -269,6 +269,7 @@
     <string name="errorFileAlreadyExists">File or folder already exists</string>
     <string name="errorFileLocked">This file is currently opened by another user and cannot be modified</string>
     <string name="errorFilesLimitExceeded">Limit of files in folder reached</string>
+    <string name="errorGeneric">An error has occurred</string>
     <string name="errorGetBookmarkURL">Non-recoverable link</string>
     <string name="errorLeaveShare">Error when stopping sharing</string>
     <string name="errorLimitExceeded">Limit exceeded</string>
@@ -277,6 +278,7 @@
     <string name="errorMove">Move error</string>
     <string name="errorNetwork">Network error</string>
     <string name="errorNetworkDescription">Results may be incomplete</string>
+    <string name="errorPhotoLibraryAccessLimited">kDrive does not have access to your photo library</string>
     <string name="errorPreviewDeleted">This file has been permanently deleted</string>
     <string name="errorPreviewTrash">Previewing a file in the trash is not possible</string>
     <string name="errorQuotaExceeded">Not enough space on your kDrive</string>
@@ -760,6 +762,7 @@
     <string name="uploadNetworkErrorTitle">Upload suspended</string>
     <string name="uploadNetworkErrorWifiRequired">Waiting for WiFi network</string>
     <string name="uploadOutOfMemoryError">Insufficient available ram memory</string>
+    <string name="uploadOverDataRestrictedError">Waiting for Wi-Fi</string>
     <string name="uploadPausedDescription">Some uploads are still in progress in kDrive. Open the app and keep the device connected to speed up the upload.</string>
     <string name="uploadPausedTitle">Upload suspended</string>
     <string name="uploadPermissionError">Additional permissions requested</string>


### PR DESCRIPTION
Add errors from iOS code to the UploadFile type. For sake of simplicity, I choose to only store the key and retrieve the error when needed (thus don't store resIs in DB, don't manage to store an enum, etc)

depends on #2012 

Part of feature on updating upload error management