### PR TITLE
fix: Fix the formatting of a string so it matches with all of the others

### DIFF
--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -723,7 +723,7 @@
     </plurals>
     <plurals name="trashedFileRestoreFileInSuccess">
         <item quantity="one">%1$s restaurado en %2$s</item>
-        <item quantity="other">%1$s elementos restaurados en %2$s</item>
+        <item quantity="other">%1$d elementos restaurados en %2$s</item>
     </plurals>
     <plurals name="trashedFileRestoreFileToOriginalPlaceSuccess">
         <item quantity="one">%s restaurado en el emplazamiento original</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -723,7 +723,7 @@
     </plurals>
     <plurals name="trashedFileRestoreFileInSuccess">
         <item quantity="one">%1$s ripristinato in %2$s</item>
-        <item quantity="other">%1$s elementi ripristinati in %2$s</item>
+        <item quantity="other">%1$d elementi ripristinati in %2$s</item>
     </plurals>
     <plurals name="trashedFileRestoreFileToOriginalPlaceSuccess">
         <item quantity="one">%s ripristinato nell’ubicazione di origine</item>


### PR DESCRIPTION
All other locales had the type "d" instead of "s", only it and es had "s", so I update the format to be coherent