### PR TITLE
fix: Workaround rare crash caused by Fragments + Navigation weirdness

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/home/HomeActivitiesFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/home/HomeActivitiesFragment.kt
@@ -24,9 +24,9 @@ import android.view.ViewGroup
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.distinctUntilChanged
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.navGraphViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.infomaniak.core.legacy.utils.safeNavigate
@@ -45,7 +45,7 @@ class HomeActivitiesFragment : Fragment() {
     private var _binding: FragmentHomeActivitiesBinding? = null
     private val binding get() = _binding!! // This property is only valid between onCreateView and onDestroyView
 
-    private val homeViewModel: HomeViewModel by navGraphViewModels(R.id.homeFragment)
+    private val homeViewModel: HomeViewModel by viewModels()
     private val mainViewModel: MainViewModel by activityViewModels()
 
     private var isDownloadingActivities = false


### PR DESCRIPTION
Since HomeFragment's layout file (fragment_home.xml) defines HomeActivitiesFragment, and since it's the only place where HomeActivitiesFragment is used, their lifecycle is technically the same, theoretically. That means we shouldn't have the crash in the first place, but that also means that using `navGraphViewModels(…)` is overkill, `viewModels()` is enough, and should not crash for unexplained reasons.

Here is the stracktrace we would get:

```stacktrace
Exception java.lang.IllegalArgumentException:
  at androidx.navigation.internal.NavControllerImpl.getBackStackEntry$navigation_runtime_release (NavControllerImpl.kt:1709)
  at androidx.navigation.NavController.getBackStackEntry (NavController.android.kt:1128)
  at com.infomaniak.drive.ui.home.HomeActivitiesFragment$special$$inlined$navGraphViewModels$default$1.invoke (NavGraphViewModelLazy.kt:107)
  at com.infomaniak.drive.ui.home.HomeActivitiesFragment$special$$inlined$navGraphViewModels$default$1.invoke (NavGraphViewModelLazy.kt:107)
  at kotlin.SynchronizedLazyImpl.getValue (LazyJVM.kt:86)
  at androidx.navigation.NavGraphViewModelLazyKt.navGraphViewModels$lambda-1 (NavGraphViewModelLazy.kt:107)
  at androidx.navigation.NavGraphViewModelLazyKt.access$navGraphViewModels$lambda-1 (NavGraphViewModelLazy.kt:1)
  at com.infomaniak.drive.ui.home.HomeActivitiesFragment$special$$inlined$navGraphViewModels$default$2.invoke (NavGraphViewModelLazy.kt:108)
  at com.infomaniak.drive.ui.home.HomeActivitiesFragment$special$$inlined$navGraphViewModels$default$2.invoke (NavGraphViewModelLazy.kt:108)
  at androidx.lifecycle.ViewModelLazy.getValue (ViewModelLazy.kt:49)
  at androidx.lifecycle.ViewModelLazy.getValue (ViewModelLazy.kt:35)
  at com.infomaniak.drive.ui.home.HomeActivitiesFragment.getHomeViewModel (HomeActivitiesFragment.kt:48)
  at com.infomaniak.drive.ui.home.HomeActivitiesFragment.onViewCreated (HomeActivitiesFragment.kt:63)
  at androidx.fragment.app.Fragment.performViewCreated (Fragment.java:3152)
```