### PR TITLE
fix: Fix sharedWithMe files sometimes being wrongly queried int the DB

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,7 +42,7 @@ android {
         setProperty("archivesBaseName", "kdrive-$versionName ($versionCode)")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "CLIENT_ID", "\"9473D73C-C20F-4971-9E10-D957C563FA68\"")
+        buildConfigField("String", "CLIENT_ID", "\"6B9A260B-EE8C-46C9-8B4F-61B2169B31ED\"")
 
         buildConfigField("String", "BUGTRACKER_DRIVE_BUCKET_ID", "\"app_drive\"")
         buildConfigField("String", "BUGTRACKER_DRIVE_PROJECT_NAME", "\"drive\"")

--- a/app/src/androidTest/java/com/infomaniak/drive/FileControllerTest.kt
+++ b/app/src/androidTest/java/com/infomaniak/drive/FileControllerTest.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -299,11 +299,11 @@ class FileControllerTest : KDriveTest() {
             FileController.saveRemoteFileToDb(remoteFile, userDrive, okHttpClient)
 
             assertNotNull(
-                FileController.getFileById(remoteFile.id, userDrive),
+                FileController.getFileByUidOrId(remoteFile.id, userDrive),
                 "the saved remote file must be stored in realm",
             )
 
-            val localParent = FileController.getFileById(folder.id, userDrive)
+            val localParent = FileController.getFileByUidOrId(folder.id, userDrive)
             assertNotNull(localParent, "the ancestor folder must be fetched and stored in realm")
 
             assertNotNull(

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -159,8 +159,23 @@ object FileController {
 
     fun getFileById(fileId: Int, userDrive: UserDrive? = null): File? {
         return getRealmInstance(userDrive).use { realm ->
-            realm.where(File::class.java).equalTo(File::id.name, fileId).findFirst()?.let {
-                realm.copyFromRealm(it, 1)
+            realm.run {
+                where(File::class.java)
+                    .equalTo(File::uid.name, "${fileId}_${userDrive?.driveId}")
+                    .findFirst()
+                    ?.let { realm.copyFromRealm(it, 1) }
+            }
+        }
+    }
+
+    fun getFileByUid(fileId: Int, userDrive: UserDrive): File? {
+        val uid = "${fileId}_${userDrive.driveId}"
+        return getRealmInstance(userDrive).use { realm ->
+            realm.run {
+                where(File::class.java)
+                    .equalTo(File::uid.name, uid)
+                    .findFirst()
+                    ?.let { realm.copyFromRealm(it, 1) }
             }
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -158,16 +158,13 @@ object FileController {
     }
 
     fun getFileByUidOrId(fileId: Int, userDrive: UserDrive? = null): File? {
-        return userDrive?.let { getFileByUid(fileId, userDrive = it) } ?: getFileById(fileId, userDrive = null)
+        return userDrive?.let { getFileByUid(fileId, userDrive = it) } ?: getFileById(fileId)
     }
 
-    fun getFileById(fileId: Int, userDrive: UserDrive? = null): File? {
-        return getRealmInstance(userDrive).use { realm ->
-            realm.run {
-                where(File::class.java)
-                    .equalTo(File::uid.name, "${fileId}_${userDrive?.driveId}")
-                    .findFirst()
-                    ?.let { realm.copyFromRealm(it, 1) }
+    private fun getFileById(fileId: Int): File? {
+        return getRealmInstance().use { realm ->
+            realm.where(File::class.java).equalTo(File::id.name, fileId).findFirst()?.let {
+                realm.copyFromRealm(it, 1)
             }
         }
     }
@@ -175,12 +172,10 @@ object FileController {
     private fun getFileByUid(fileId: Int, userDrive: UserDrive): File? {
         val uid = "${fileId}_${userDrive.driveId}"
         return getRealmInstance(userDrive).use { realm ->
-            realm.run {
-                where(File::class.java)
-                    .equalTo(File::uid.name, uid)
-                    .findFirst()
-                    ?.let { realm.copyFromRealm(it, 1) }
-            }
+            realm.where(File::class.java)
+                .equalTo(File::uid.name, uid)
+                .findFirst()
+                ?.let { realm.copyFromRealm(it, 1) }
         }
     }
 
@@ -332,7 +327,7 @@ object FileController {
         if (filesToDelete.isEmpty()) return
 
         val file = filesToDelete.removeAt(0)
-        val children = getFileById(file.id, userDrive)?.children ?: emptyList()
+        val children = getFileByUidOrId(file.id, userDrive)?.children ?: emptyList()
 
         filesToDelete.addAll(children)
         file.deleteCaches(context)

--- a/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/cache/FileController.kt
@@ -157,6 +157,10 @@ object FileController {
         return customRealm?.let(block) ?: getRealmInstance(userDrive).use(block)
     }
 
+    fun getFileByUidOrId(fileId: Int, userDrive: UserDrive? = null): File? {
+        return userDrive?.let { getFileByUid(fileId, userDrive = it) } ?: getFileById(fileId, userDrive = null)
+    }
+
     fun getFileById(fileId: Int, userDrive: UserDrive? = null): File? {
         return getRealmInstance(userDrive).use { realm ->
             realm.run {
@@ -168,7 +172,7 @@ object FileController {
         }
     }
 
-    fun getFileByUid(fileId: Int, userDrive: UserDrive): File? {
+    private fun getFileByUid(fileId: Int, userDrive: UserDrive): File? {
         val uid = "${fileId}_${userDrive.driveId}"
         return getRealmInstance(userDrive).use { realm ->
             realm.run {

--- a/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/documentprovider/CloudStorageProvider.kt
@@ -359,7 +359,7 @@ class CloudStorageProvider : DocumentsProvider() {
         val accessMode = ParcelFileDescriptor.parseMode(mode)
         val fileId = getFileIdFromDocumentId(documentId)
         val userDrive = createUserDrive(documentId)
-        val localFile = FileController.getFileById(fileId, userDrive)
+        val localFile = FileController.getFileByUidOrId(fileId, userDrive)
 
         val updatedFile = runCatching {
             getRemoteFile(localFile, fileId, userDrive.driveId)

--- a/app/src/main/java/com/infomaniak/drive/data/models/deeplink/DeeplinkType.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/models/deeplink/DeeplinkType.kt
@@ -215,7 +215,7 @@ sealed interface DeeplinkType : Parcelable {
 
                 val deeplinkTargetFile = getDrives(sharedWithMe = withSharedDrives).firstNotNullOfOrNull { userDrive ->
                     newUserId = userDrive.userId
-                    FileController.getFileById(fileId, userDrive = userDrive)
+                    FileController.getFileByUidOrId(fileId, userDrive = userDrive)
                 }
 
                 return deeplinkTargetFile?.let { file ->

--- a/app/src/main/java/com/infomaniak/drive/data/services/BulkDownloadWorker.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/services/BulkDownloadWorker.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2024-2025 Infomaniak Network SA
+ * Copyright (C) 2024-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,7 +35,7 @@ class BulkDownloadWorker(context: Context, workerParams: WorkerParameters) : Bas
     private val folderId: Int by lazy { inputData.getInt(FOLDER_ID, 0) }
     private val files: List<File> by lazy {
         FileController.getFolderOfflineFilesId(folderId = folderId, sortType = UiSettings(context).sortType)
-            .map { FileController.getFileById(it, userDrive)!! }
+            .map { FileController.getFileByUidOrId(it, userDrive)!! }
     }
 
     private val userDrive: UserDrive by lazy {

--- a/app/src/main/java/com/infomaniak/drive/data/services/DownloadWorker.kt
+++ b/app/src/main/java/com/infomaniak/drive/data/services/DownloadWorker.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2025 Infomaniak Network SA
+ * Copyright (C) 2022-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ import com.infomaniak.drive.utils.NotificationUtils.cancelNotification
 class DownloadWorker(context: Context, workerParams: WorkerParameters) : BaseDownloadWorker(context, workerParams) {
 
     private val fileId: Int by lazy { inputData.getInt(FILE_ID, 0) }
-    private val file: File? by lazy { FileController.getFileById(fileId) }
+    private val file: File? by lazy { FileController.getFileByUidOrId(fileId) }
     private val fileName: String by lazy { inputData.getString(FILE_NAME) ?: "" }
     private val userDrive: UserDrive by lazy {
         UserDrive(
@@ -47,7 +47,7 @@ class DownloadWorker(context: Context, workerParams: WorkerParameters) : BaseDow
         )
     }
 
-    override fun downloadNotification(): DownloadNotification? {
+    override fun downloadNotification(): DownloadNotification {
         return DownloadNotification(id = fileId, notification = downloadProgressNotification)
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/MainViewModel.kt
@@ -208,7 +208,7 @@ class MainViewModel(
 
         // Emit destination folder id
         viewModelScope.launch(Dispatchers.IO) {
-            val file = FileController.getFileById(fileId, userDrive)
+            val file = FileController.getFileByUidOrId(fileId, userDrive)
                 ?: FileController.getFileDetails(fileId, userDrive = userDrive)
                 ?: return@launch
             navigateFileListTo.postValue(FileListNavigationType.Folder(file))
@@ -216,7 +216,7 @@ class MainViewModel(
     }
 
     fun loadCurrentFolder(folderId: Int, userDrive: UserDrive) = viewModelScope.launch(Dispatchers.IO) {
-        postCurrentFolder(FileController.getFileById(folderId, userDrive))
+        postCurrentFolder(FileController.getFileByUidOrId(folderId, userDrive))
     }
 
     fun createMultiSelectMediator(): MediatorLiveData<MultiSelectMediatorState> =
@@ -602,7 +602,7 @@ class MainViewModel(
     private fun initCurrentFolderFromRealm() {
         val savedFolderId: Int? = savedStateHandle[SAVED_STATE_FOLDER_ID_KEY]
         if (currentFolder.value == null && savedFolderId != null) {
-            FileController.getFileById(savedFolderId)?.let {
+            FileController.getFileByUidOrId(savedFolderId)?.let {
                 _currentFolder.value = it
                 saveCurrentFolder()
             }

--- a/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/SaveExternalFilesActivity.kt
@@ -279,7 +279,7 @@ class SaveExternalFilesActivity : BaseActivity() {
                 )
                 driveIdSharedWithMe = FileController.getSharedDrive(userDrive.userId, folderId)?.driveId
 
-                FileController.getFileById(folderId, userDrive) ?: FileController.getFileById(
+                FileController.getFileByUidOrId(folderId, userDrive) ?: FileController.getFileByUidOrId(
                     fileId = folderId,
                     userDrive = UserDrive(
                         userId = selectedUserId.value!!,

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/FileInfoActionsBottomSheetDialog.kt
@@ -96,7 +96,7 @@ class FileInfoActionsBottomSheetDialog : EdgeToEdgeBottomSheetDialog(), FileInfo
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        currentFile = FileController.getFileById(navigationArgs.fileId, navigationArgs.userDrive) ?: run {
+        currentFile = FileController.getFileByUidOrId(navigationArgs.fileId, navigationArgs.userDrive) ?: run {
             findNavController().popBackStack()
             return
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/NotSupportedExtensionBottomSheetDialog.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/bottomSheetDialogs/NotSupportedExtensionBottomSheetDialog.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -43,7 +43,7 @@ class NotSupportedExtensionBottomSheetDialog : InformationBottomSheetDialog() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?): Unit = with(binding) {
         super.onViewCreated(view, savedInstanceState)
 
-        FileController.getFileById(navigationArgs.fileId, userDrive)?.let { currentFile ->
+        FileController.getFileByUidOrId(navigationArgs.fileId, userDrive)?.let { currentFile ->
 
             title.text = getString(R.string.notSupportedExtensionTitle, currentFile.getFileExtension())
             description.text = getString(R.string.notSupportedExtensionDescription, currentFile.name)

--- a/app/src/main/java/com/infomaniak/drive/ui/deeplink/DeeplinkHandler.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/deeplink/DeeplinkHandler.kt
@@ -89,7 +89,7 @@ class DeeplinkHandler(registryOwner: SavedStateRegistryOwner) : SavedStateRegist
         activity.lifecycleScope.launch(context = Dispatchers.IO) {
             DriveInfosController.getDrive(userId = userId, driveId = driveId, maintenance = false)
                 ?.ensureRightUser()
-                ?.run { FileController.getFileById(fileId = fileId, userDrive = UserDrive(userId = userId, driveId = id)) }
+                ?.run { FileController.getFileByUidOrId(fileId = fileId, userDrive = UserDrive(userId = userId, driveId = id)) }
                 ?.let { Dispatchers.Main { activity.openOnlyOfficeActivity(it) } }
         }
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/dropbox/ConvertToDropboxFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/dropbox/ConvertToDropboxFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2025 Infomaniak Network SA
+ * Copyright (C) 2022-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,7 +47,7 @@ class ConvertToDropboxFragment : ManageDropboxFragment() {
         shareLinkCardView.isGone = true
         disableButton.isGone = true
 
-        val file = FileController.getFileById(navigationArgs.fileId) ?: return
+        val file = FileController.getFileByUidOrId(navigationArgs.fileId) ?: return
 
         updateUi(file)
 

--- a/app/src/main/java/com/infomaniak/drive/ui/dropbox/ManageDropboxFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/dropbox/ManageDropboxFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2025 Infomaniak Network SA
+ * Copyright (C) 2022-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -92,7 +92,7 @@ open class ManageDropboxFragment : Fragment() {
         disableButton.isEnabled = false
         saveButton.isEnabled = false
 
-        FileController.getFileById(navigationArgs.fileId)?.let { file ->
+        FileController.getFileByUidOrId(navigationArgs.fileId)?.let { file ->
             disableButton.isEnabled = true
 
             if (isManageDropBox) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/DownloadProgressViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/DownloadProgressViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2024-2025 Infomaniak Network SA
+ * Copyright (C) 2024-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -40,7 +40,7 @@ class DownloadProgressViewModel : ViewModel() {
     val localFile = SingleLiveEvent<File?>()
 
     fun getLocalFile(fileId: Int, userDrive: UserDrive) {
-        localFile.value = FileController.getFileById(fileId, userDrive)
+        localFile.value = FileController.getFileByUidOrId(fileId, userDrive)
     }
 
     fun downloadFile(context: Context, file: File, userDrive: UserDrive) = viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListFragment.kt
@@ -205,7 +205,7 @@ open class FileListFragment : MultiSelectFragment(
             is DeeplinkFilePath.FilePreviewInFolder -> fileType.folderId
             else -> navigationArgs.folderId
         }
-        folderName = fileType?.let { FileController.getFileById(folderId, userDrive)?.name } ?: navigationArgs.folderName
+        folderName = fileType?.let { FileController.getFileByUidOrId(folderId, userDrive)?.name } ?: navigationArgs.folderName
     }
 
     override fun initMultiSelectLayout(): MultiSelectLayoutBinding? = binding.multiSelectLayout
@@ -384,7 +384,7 @@ open class FileListFragment : MultiSelectFragment(
             lifecycleScope.launchWhenResumed {
                 with(requireActivity() as SelectFolderActivity) {
                     showSaveButton()
-                    val currentFolderRights = FileController.getFileById(folderId, userDrive)?.rights ?: Rights()
+                    val currentFolderRights = FileController.getFileByUidOrId(folderId, userDrive)?.rights ?: Rights()
                     val enable = folderId != selectFolderViewModel.disableSelectedFolderId
                             && (currentFolderRights.canMoveInto || currentFolderRights.canCreateFile)
                     enableSaveButton(enable)
@@ -654,7 +654,7 @@ open class FileListFragment : MultiSelectFragment(
         activitiesRefreshTimer.cancel()
         isLoadingActivities = true
         mainViewModel.currentFolder.value?.let { localCurrentFolder ->
-            FileController.getFileById(localCurrentFolder.id, userDrive)?.let { updatedFolder ->
+            FileController.getFileByUidOrId(localCurrentFolder.id, userDrive)?.let { updatedFolder ->
                 downloadFolderActivities(updatedFolder)
                 activitiesRefreshTimer.start()
             } ?: run { activitiesRefreshTimer.start() }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/FileListViewModel.kt
@@ -361,7 +361,7 @@ class FileListViewModel(application: Application) : AndroidViewModel(application
     }
 
     fun shouldDisplaySubtitle(folderId: Int, userDrive: UserDrive?): Boolean {
-        val folder = FileController.getFileById(folderId, userDrive) ?: return false
+        val folder = FileController.getFileByUidOrId(folderId, userDrive) ?: return false
         return folder.getVisibilityType() == File.VisibilityType.IS_TEAM_SPACE
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderActivity.kt
@@ -192,7 +192,7 @@ class SelectFolderActivity : BaseActivity() {
             val selectedFolderName = if (folderId == ROOT_ID) {
                 currentDrive?.name
             } else {
-                FileController.getFileById(folderId, userDrive)?.name
+                FileController.getFileByUidOrId(folderId, userDrive)?.name
             }
             return selectedFolderName ?: "/"
         }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SelectFolderFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2025 Infomaniak Network SA
+ * Copyright (C) 2022-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -57,7 +57,7 @@ class SelectFolderFragment : FileListFragment() {
         toolbar.menu.findItem(R.id.addFolderItem).apply {
             setOnMenuItemClickListener {
                 val selectFolderActivity = requireActivity() as? SelectFolderActivity
-                if (FileController.getFileById(folderId, userDrive)?.rights?.canCreateDirectory == true) {
+                if (FileController.getFileByUidOrId(folderId, userDrive)?.rights?.canCreateDirectory == true) {
                     selectFolderActivity?.hideSaveButton()
                     trackNewElementEvent(MatomoName.CreateFolderOnTheFly)
                     safeNavigate(
@@ -96,7 +96,7 @@ class SelectFolderFragment : FileListFragment() {
         lifecycleScope.launchWhenResumed {
             with(requireActivity() as SelectFolderActivity) {
                 showSaveButton()
-                val currentFolderRights = FileController.getFileById(folderId, userDrive)?.rights ?: Rights()
+                val currentFolderRights = FileController.getFileByUidOrId(folderId, userDrive)?.rights ?: Rights()
                 val enable = folderId != selectFolderViewModel.disableSelectedFolderId
                         && (currentFolderRights.canMoveInto || currentFolderRights.canCreateFile)
                 enableSaveButton(enable)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/SharedWithMeViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/SharedWithMeViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2024 Infomaniak Network SA
+ * Copyright (C) 2024-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -65,7 +65,7 @@ class SharedWithMeViewModel : ViewModel() {
                 FileController.createSharedWithMeFolderIfNeeded(userDrive)
             }
 
-            val folderIsNotEmpty = FileController.getFileById(folderId, userDrive)?.children?.isNotEmpty() == true
+            val folderIsNotEmpty = FileController.getFileByUidOrId(folderId, userDrive)?.children?.isNotEmpty() == true
             if (folderIsNotEmpty) notifyUiToLoadData()
 
             if (!isNewSort) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/UploadInProgressViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/UploadInProgressViewModel.kt
@@ -49,7 +49,7 @@ class UploadInProgressViewModel(application: Application) : AndroidViewModel(app
     private val getFolderJob = Job()
 
     fun getFolder(folderId: Int, userDrive: UserDrive) = liveData(getFolderJob + Dispatchers.IO) {
-        val localFolder = FileController.getFileById(folderId, userDrive)
+        val localFolder = FileController.getFileByUidOrId(folderId, userDrive)
         var remoteFolder: File? = null
 
         if (localFolder == null) {
@@ -156,7 +156,7 @@ class UploadInProgressViewModel(application: Application) : AndroidViewModel(app
     }
 
     private fun createFolderFile(fileId: Int, userDrive: UserDrive): File? {
-        val folder = FileController.getFileById(fileId, userDrive)
+        val folder = FileController.getFileByUidOrId(fileId, userDrive)
             ?: FileController.getFileDetails(fileId, userDrive)
             ?: return null
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/CreateOrEditCategoryViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/CreateOrEditCategoryViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@ class CreateOrEditCategoryViewModel : ViewModel() {
     val driveId: Int by lazy { selectedFiles.first().driveId }
 
     fun init(filesId: IntArray?): LiveData<Boolean> = liveData(Dispatchers.IO) {
-        selectedFiles = filesId?.toList()?.mapNotNull { fileId -> FileController.getFileById(fileId) } ?: emptyList()
+        selectedFiles = filesId?.toList()?.mapNotNull { fileId -> FileController.getFileByUidOrId(fileId) } ?: emptyList()
         emit(selectedFiles.isEmpty())
     }
 

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/FileDetailsFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/FileDetailsFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2025 Infomaniak Network SA
+ * Copyright (C) 2022-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,9 +35,9 @@ import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.button.MaterialButton
 import com.infomaniak.core.common.extensions.isNightModeEnabled
 import com.infomaniak.core.common.extensions.lightStatusBar
+import com.infomaniak.core.common.utils.format
 import com.infomaniak.core.legacy.utils.context
 import com.infomaniak.core.legacy.utils.safeBinding
-import com.infomaniak.core.common.utils.format
 import com.infomaniak.core.ui.view.extension.setMargins
 import com.infomaniak.drive.R
 import com.infomaniak.drive.data.api.ApiRoutes
@@ -68,7 +68,7 @@ class FileDetailsFragment : FileDetailsSubFragment() {
 
         binding.toolbar.setNavigationOnClickListener { findNavController().popBackStack() }
 
-        FileController.getFileById(fileId, userDrive)?.let(::setFile)
+        FileController.getFileByUidOrId(fileId, userDrive)?.let(::setFile)
 
         mainViewModel.getFileDetails(fileId, userDrive).observe(viewLifecycleOwner) { fileResponse ->
             fileResponse?.let(::setFile)

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/SelectCategoriesViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileDetails/SelectCategoriesViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -52,7 +52,7 @@ class SelectCategoriesViewModel : ViewModel() {
             CategoryRights()
         } else {
             selectedFiles = filesIds?.toList()?.mapNotNull { fileId ->
-                FileController.getFileById(fileId, userDrive)
+                FileController.getFileByUidOrId(fileId, userDrive)
             } ?: emptyList()
 
             if (selectedFiles.isEmpty()) {

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/fileShare/FileShareViewModel.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2024 Infomaniak Network SA
+ * Copyright (C) 2022-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -42,7 +42,7 @@ class FileShareViewModel : ViewModel() {
 
     fun fetchCurrentFile(fileId: Int) = liveData(Dispatchers.IO) {
         emit(
-            FileController.getFileById(fileId)
+            FileController.getFileByUidOrId(fileId)
                 ?: ApiRepository.getFileDetails(File(id = fileId, driveId = AccountUtils.currentDriveId)).data
         )
     }

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewFragment.kt
@@ -1,6 +1,6 @@
 /*
  * Infomaniak kDrive - Android
- * Copyright (C) 2022-2025 Infomaniak Network SA
+ * Copyright (C) 2022-2026 Infomaniak Network SA
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -55,7 +55,7 @@ open class PreviewFragment : Fragment() {
     }
 
     private fun getCurrentFile(fileId: Int): File? = runCatching {
-        FileController.getFileById(fileId, previewSliderViewModel.userDrive) ?: mainViewModel.currentPreviewFileList[fileId]
+        FileController.getFileByUidOrId(fileId, previewSliderViewModel.userDrive) ?: mainViewModel.currentPreviewFileList[fileId]
     }.getOrElse { exception ->
         exception.printStackTrace()
         Sentry.captureException(exception) { scope ->

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewSliderFragment.kt
@@ -87,7 +87,7 @@ class PreviewSliderFragment : BasePreviewSliderFragment(), FileInfoActionsView.O
         if (previewSliderViewModel.currentPreview == null) {
             userDrive = UserDrive(driveId = navigationArgs.driveId, sharedWithMe = navigationArgs.isSharedWithMe)
 
-            currentFile = FileController.getFileById(navigationArgs.fileId, userDrive)
+            currentFile = FileController.getFileByUidOrId(navigationArgs.fileId, userDrive)
                 ?: mainViewModel.currentPreviewFileList[navigationArgs.fileId] ?: throw Exception("No current preview found")
 
             previewSliderViewModel.currentPreview = currentFile

--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/playback/PlaybackViewModel.kt
@@ -65,7 +65,7 @@ class PlaybackViewModel(application: Application) : AndroidViewModel(application
     }
 
     private suspend fun loadDriveFile(fileId: Int): File? = runCatching {
-        FileController.getFileById(fileId, userDrive) ?: withContext(Dispatchers.IO) {
+        FileController.getFileByUidOrId(fileId, userDrive) ?: withContext(Dispatchers.IO) {
             val okHttpClient = AccountUtils.getHttpClient(userDrive.userId)
             FileController.getRemoteFile(fileId, userDrive.driveId, okHttpClient)?.also { remoteFile ->
                 FileController.saveRemoteFileToDb(remoteFile, userDrive, okHttpClient)

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/SharedWithMeFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/SharedWithMeFragment.kt
@@ -123,10 +123,12 @@ class SharedWithMeFragment : FileSubTypeListFragment() {
     }
 
     override fun previewFile(fileId: Int) {
-        FileController.getFileById(fileId, userDrive)?.let { file ->
-            openFileOrFolder(file)
-            fileListViewModel.isPreviewManaged = true
-        }
+        userDrive?.let { FileController.getFileByUid(folderId, it) }
+            ?: FileController.getFileById(folderId, null)
+                ?.let { file ->
+                    openFileOrFolder(file)
+                    fileListViewModel.isPreviewManaged = true
+                }
     }
 
     private fun openFileOrFolder(file: File) {
@@ -146,7 +148,10 @@ class SharedWithMeFragment : FileSubTypeListFragment() {
     }
 
     private fun canShowButton(): Boolean {
-        val currentFolderRights = FileController.getFileById(folderId, userDrive)?.rights ?: Rights()
+        val currentFolderRights = userDrive?.let {
+            FileController.getFileByUid(folderId, it)?.rights ?: Rights()
+        } ?: FileController.getFileById(folderId, null)?.rights ?: Rights()
+
         val isFromExternalOrCurrentDrive = navigationArgs.fromSaveExternal || userDrive?.driveId == AccountUtils.currentDriveId
         return folderId != selectFolderViewModel.disableSelectedFolderId
                 && (currentFolderRights.canMoveInto || currentFolderRights.canCreateFile)

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/SharedWithMeFragment.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/SharedWithMeFragment.kt
@@ -123,12 +123,10 @@ class SharedWithMeFragment : FileSubTypeListFragment() {
     }
 
     override fun previewFile(fileId: Int) {
-        userDrive?.let { FileController.getFileByUid(folderId, it) }
-            ?: FileController.getFileById(folderId, null)
-                ?.let { file ->
-                    openFileOrFolder(file)
-                    fileListViewModel.isPreviewManaged = true
-                }
+        FileController.getFileByUidOrId(fileId, userDrive)?.let { file ->
+            openFileOrFolder(file)
+            fileListViewModel.isPreviewManaged = true
+        }
     }
 
     private fun openFileOrFolder(file: File) {
@@ -148,9 +146,7 @@ class SharedWithMeFragment : FileSubTypeListFragment() {
     }
 
     private fun canShowButton(): Boolean {
-        val currentFolderRights = userDrive?.let {
-            FileController.getFileByUid(folderId, it)?.rights ?: Rights()
-        } ?: FileController.getFileById(folderId, null)?.rights ?: Rights()
+        val currentFolderRights = FileController.getFileByUidOrId(folderId, userDrive)?.rights ?: Rights()
 
         val isFromExternalOrCurrentDrive = navigationArgs.fromSaveExternal || userDrive?.driveId == AccountUtils.currentDriveId
         return folderId != selectFolderViewModel.disableSelectedFolderId

--- a/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/menu/settings/SyncSettingsActivity.kt
@@ -34,10 +34,10 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.datepicker.CalendarConstraints
 import com.google.android.material.datepicker.DateValidatorPointBackward
 import com.google.android.material.datepicker.MaterialDatePicker
+import com.infomaniak.core.common.extensions.isNightModeEnabled
 import com.infomaniak.core.common.utils.FORMAT_DATE_CLEAR_MONTH
 import com.infomaniak.core.common.utils.format
 import com.infomaniak.core.common.utils.startOfTheDay
-import com.infomaniak.core.common.extensions.isNightModeEnabled
 import com.infomaniak.core.legacy.utils.context
 import com.infomaniak.core.legacy.utils.startAppSettingsConfig
 import com.infomaniak.core.legacy.utils.whenResultIsOk
@@ -311,7 +311,7 @@ class SyncSettingsActivity : BaseActivity() {
             val selectedUserId = selectDriveViewModel.selectedUserId.value
             val selectedDriveId = selectDriveViewModel.selectedDrive.value?.id
             if (syncFolderId != null && selectedUserId != null && selectedDriveId != null) {
-                FileController.getFileById(syncFolderId, UserDrive(selectedUserId, selectedDriveId))?.let {
+                FileController.getFileByUidOrId(syncFolderId, UserDrive(selectedUserId, selectedDriveId))?.let {
                     selectPath.setIconColor(it.color?.toColorInt() ?: context.getColor(R.color.folderDefaultColor))
                     selectPath.title = it.name
                     changeSaveButtonStatus()

--- a/app/src/main/java/com/infomaniak/drive/ui/selectPermission/SelectPermissionViewModel.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/selectPermission/SelectPermissionViewModel.kt
@@ -33,7 +33,7 @@ internal class SelectPermissionViewModel(savedStateHandle: SavedStateHandle) : V
     private val args = SelectPermissionBottomSheetDialogArgs.fromSavedStateHandle(savedStateHandle)
 
     val currentFileFlow = flow {
-        emit(FileController.getFileById(args.currentFileId))
+        emit(FileController.getFileByUidOrId(args.currentFileId))
     }
 
     fun editFileShareLinkOfficePermission(canEdit: Boolean) = liveData(Dispatchers.IO) {


### PR DESCRIPTION
As SharedWithMe files are all in a single DB but originate from multiple drives, several files can have the same fileId (because it's their id on their parent's drive). 

We were querying the first matching id from the DB, thus we could have the wrong file.

With this new getFileByUidOrId, we now query the file by their uid in the `sharedWithMeFragment` to avoid this problem.
