### PR TITLE
fix: PreviewPDFActivity was not handling edge to edge properly

### DIFF
--- a/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewPDFActivity.kt
+++ b/app/src/main/java/com/infomaniak/drive/ui/fileList/preview/PreviewPDFActivity.kt
@@ -20,18 +20,19 @@ package com.infomaniak.drive.ui.fileList.preview
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.infomaniak.core.common.extensions.isNightModeEnabled
+import com.infomaniak.core.common.extensions.lightStatusBar
 import com.infomaniak.core.common.utils.inWholeSeconds
 import com.infomaniak.core.file.getFileDatesWithFallback
 import com.infomaniak.core.file.retrieveAndUse
 import com.infomaniak.core.twofactorauth.front.TwoFactorAuthApprovalAutoManagedBottomSheet
 import com.infomaniak.core.twofactorauth.front.addComposeOverlay
+import com.infomaniak.core.ui.view.edgetoedge.EdgeToEdgeActivity
 import com.infomaniak.core.ui.view.extension.setMargins
 import com.infomaniak.core.ui.view.utils.SnackbarUtils.showSnackbar
 import com.infomaniak.drive.MatomoDrive.MatomoName
@@ -54,7 +55,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 import java.util.Date
 
-class PreviewPDFActivity : AppCompatActivity(), OnItemClickListener {
+class PreviewPDFActivity : EdgeToEdgeActivity(), OnItemClickListener {
 
     val binding: ActivityPreviewPdfBinding by lazy { ActivityPreviewPdfBinding.inflate(layoutInflater) }
 
@@ -79,7 +80,7 @@ class PreviewPDFActivity : AppCompatActivity(), OnItemClickListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        window.lightStatusBar(false)
         with(binding) {
             setContentView(root)
             addComposeOverlay {


### PR DESCRIPTION
|AndroidVersion | Before    | After |
| --------------- | -------- |------ |
Android < 15 |  <img width="200" alt="Screenshot_20260722_110717" src="https://github.com/user-attachments/assets/671f078f-f37d-40f4-93a9-2d3cc46cbe37" /> |  <img width="200" alt="Screenshot_20260722_110822" src="https://github.com/user-attachments/assets/c0d570f3-8163-44de-897f-6b29ea3cac73" />  |
Android > 15 | <img width="200"  alt="Screenshot_20260722_110555" src="https://github.com/user-attachments/assets/b6dd079d-dc97-49bc-ad91-eba18fade91c" /> | <img width="200" alt="Screenshot_20260722_110931" src="https://github.com/user-attachments/assets/e2c6c26a-ab1f-4a1d-b00b-8ee21592c97e" />   |



