### PR TITLE
feat: Remove plural forms of product names

### DIFF
--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -241,12 +241,12 @@
     </plurals>
     <plurals name="driveBlockedTitle">
         <item quantity="one">kDrive %s er i øjeblikket blokeret</item>
-        <item quantity="other">Alle dine kDrives er i øjeblikket blokeret</item>
+        <item quantity="other">Alle dine kDrive er i øjeblikket blokeret</item>
     </plurals>
     <string name="driveMaintenanceDescription">En opdatering er i gang for at forbedre kDrive. Processen kan tage et par minutter. Tak for din tålmodighed.</string>
     <plurals name="driveMaintenanceTitle">
         <item quantity="one">kDrive %s er i øjeblikket under vedligeholdelse</item>
-        <item quantity="other">Alle dine kDrives er i øjeblikket under vedligeholdelse</item>
+        <item quantity="other">Alle dine kDrive er i øjeblikket under vedligeholdelse</item>
     </plurals>
     <string name="dropBoxDescription">Inviter dine partnere, brugere eller kunder til at overføre filer til din kDrive, selvom de ikke har en Infomaniak-konto.</string>
     <string name="dropBoxLinkTitle">Link til indleveringsboks</string>
@@ -685,7 +685,7 @@
     <string name="supportTitle">Hjælp &amp;amp; support</string>
     <string name="switchAccountTitle">Skift konto</string>
     <string name="switchDriveSearchViewHint">Søg efter en kDrive</string>
-    <string name="switchUserDescription">Se kDrives fra dine andre Infomaniak-profiler. Du kan tilføje så mange brugerprofiler, som du vil.</string>
+    <string name="switchUserDescription">Se kDrive fra dine andre Infomaniak-profiler. Du kan tilføje så mange brugerprofiler, som du vil.</string>
     <string name="syncConfigureDescription">Dine fotos, videoer og skærmbilleder vil automatisk blive gemt i din kDrive %s.</string>
     <string name="syncConfigureTitle">Gem dine minder på et sikkert sted</string>
     <string name="syncOnlyWifiDescription">Offline filer vil kun blive synkroniseret med Wi-Fi</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -241,12 +241,12 @@
     </plurals>
     <plurals name="driveBlockedTitle">
         <item quantity="one">Das kDrive %s ist derzeit gesperrt</item>
-        <item quantity="other">Alle Ihre kDrives sind derzeit gesperrt</item>
+        <item quantity="other">Alle Ihre kDrive sind derzeit gesperrt</item>
     </plurals>
     <string name="driveMaintenanceDescription">Ein Update zur Verbesserung von kDrive ist in Arbeit. Dieser Vorgang kann ein paar Minuten dauern. Wir danken Ihnen für Ihre Geduld.</string>
     <plurals name="driveMaintenanceTitle">
         <item quantity="one">Das kDrive %s wird derzeit gewartet</item>
-        <item quantity="other">Alle Ihre kDrives sind derzeit in Wartung</item>
+        <item quantity="other">Alle Ihre kDrive sind derzeit in Wartung</item>
     </plurals>
     <string name="dropBoxDescription">Laden Sie Ihre Partner, Benutzer oder Kunden ein, Dateien in Ihren kDrive zu übertragen, auch wenn sie kein Infomaniak-Konto besitzen.</string>
     <string name="dropBoxLinkTitle">Link des Briefkastens</string>
@@ -685,7 +685,7 @@
     <string name="supportTitle">Hilfe und Unterstützung</string>
     <string name="switchAccountTitle">Konto wechseln</string>
     <string name="switchDriveSearchViewHint">kDrive suchen</string>
-    <string name="switchUserDescription">Sehen Sie die kDrives Ihrer anderen Infomaniak-Profile. Sie können so viele Benutzerprofile hinzufügen wie Sie möchten.</string>
+    <string name="switchUserDescription">Sehen Sie die kDrive Ihrer anderen Infomaniak-Profile. Sie können so viele Benutzerprofile hinzufügen wie Sie möchten.</string>
     <string name="syncConfigureDescription">Ihre Fotos, Videos und Screenshots werden automatisch in Ihrem kDrive %s gespeichert.</string>
     <string name="syncConfigureTitle">Speichern Sie Ihre Erinnerungen an einem sicheren Ort</string>
     <string name="syncOnlyWifiDescription">Offline-Dateien werden nur mit Wi-Fi synchronisiert</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -241,12 +241,12 @@
     </plurals>
     <plurals name="driveBlockedTitle">
         <item quantity="one">El kDrive %s está actualmente bloqueado</item>
-        <item quantity="other">Todos sus kDrives están actualmente bloqueados</item>
+        <item quantity="other">Todos sus kDrive están actualmente bloqueados</item>
     </plurals>
     <string name="driveMaintenanceDescription">Se está realizando una actualización para mejorar kDrive. Este proceso puede durar unos minutos. Gracias por su paciencia.</string>
     <plurals name="driveMaintenanceTitle">
         <item quantity="one">El kDrive %s está actualmente en mantenimiento</item>
-        <item quantity="other">Todos sus kDrives están actualmente en mantenimiento</item>
+        <item quantity="other">Todos sus kDrive están actualmente en mantenimiento</item>
     </plurals>
     <string name="dropBoxDescription">Invita a tus socios, usuarios o clientes a transferir archivos a tu kDrive aunque no tengan cuenta Infomaniak.</string>
     <string name="dropBoxLinkTitle">Enlace del buzón de depósito</string>
@@ -685,7 +685,7 @@
     <string name="supportTitle">Ayuda y asistencia</string>
     <string name="switchAccountTitle">Cambiar de cuenta</string>
     <string name="switchDriveSearchViewHint">Buscar un kDrive</string>
-    <string name="switchUserDescription">Consultar las kDrives de tus otros perfiles Infomaniak. Puedes añadir tantos perfiles de usuario como desees.</string>
+    <string name="switchUserDescription">Consultar las kDrive de tus otros perfiles Infomaniak. Puedes añadir tantos perfiles de usuario como desees.</string>
     <string name="syncConfigureDescription">Tus fotos, vídeos y capturas de pantalla se guardarán automáticamente en tu kDrive %s.</string>
     <string name="syncConfigureTitle">Haz copia de seguridad de tus recuerdos en un lugar seguro</string>
     <string name="syncOnlyWifiDescription">Los archivos sin conexión sólo se sincronizarán con Wi-Fi</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -241,12 +241,12 @@
     </plurals>
     <plurals name="driveBlockedTitle">
         <item quantity="one">kDrive %s on tällä hetkellä estetty</item>
-        <item quantity="other">Kaikki kDrivet ovat tällä hetkellä estettyjä</item>
+        <item quantity="other">Kaikki kDrive ovat tällä hetkellä estettyjä</item>
     </plurals>
     <string name="driveMaintenanceDescription">Päivitys on käynnissä kDriven parantamiseksi. Tämä prosessi voi kestää muutaman minuutin. Kiitos kärsivällisyydestäsi.</string>
     <plurals name="driveMaintenanceTitle">
         <item quantity="one">kDrive %s on tällä hetkellä huollossa</item>
-        <item quantity="other">Kaikki kDrivet ovat tällä hetkellä huollossa</item>
+        <item quantity="other">Kaikki kDrive ovat tällä hetkellä huollossa</item>
     </plurals>
     <string name="dropBoxDescription">Kutsu yhteistyökumppanisi, käyttäjät tai asiakkaat siirtämään tiedostoja kDriveesi, vaikka heillä ei olisi Infomaniak-tiliä.</string>
     <string name="dropBoxLinkTitle">Dropbox-linkki</string>
@@ -685,7 +685,7 @@
     <string name="supportTitle">Ohje ja tuki</string>
     <string name="switchAccountTitle">Vaihda tiliä</string>
     <string name="switchDriveSearchViewHint">Etsi kDrive</string>
-    <string name="switchUserDescription">Näytä kDrivet muista Infomaniak-profiileistasi. Voit lisätä niin monta käyttäjäprofiilia kuin haluat.</string>
+    <string name="switchUserDescription">Näytä kDrive muista Infomaniak-profiileistasi. Voit lisätä niin monta käyttäjäprofiilia kuin haluat.</string>
     <string name="syncConfigureDescription">Kuvasi, videosi ja kuvakaappaustesi tallennetaan automaattisesti kDrive %s -palveluun.</string>
     <string name="syncConfigureTitle">Tallenna muistosi turvalliseen paikkaan</string>
     <string name="syncOnlyWifiDescription">Offline-tiedostot synkronoidaan vain Wi-Fi-yhteydellä</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -241,12 +241,12 @@
     </plurals>
     <plurals name="driveBlockedTitle">
         <item quantity="one">Le kDrive %s est actuellement bloqué</item>
-        <item quantity="other">Tous vos kDrives sont actuellement bloqués</item>
+        <item quantity="other">Tous vos kDrive sont actuellement bloqués</item>
     </plurals>
     <string name="driveMaintenanceDescription">Une mise à jour est en cours pour améliorer kDrive. Ce processus peut durer quelques minutes. Merci pour votre patience.</string>
     <plurals name="driveMaintenanceTitle">
         <item quantity="one">Le kDrive %s est actuellement en maintenance</item>
-        <item quantity="other">Tous vos kDrives sont actuellement en maintenance</item>
+        <item quantity="other">Tous vos kDrive sont actuellement en maintenance</item>
     </plurals>
     <string name="dropBoxDescription">Invitez vos partenaires, utilisateurs ou clients à transférer des fichiers dans votre kDrive, même s’ils n’ont pas de compte Infomaniak.</string>
     <string name="dropBoxLinkTitle">Lien de la boîte de dépôt</string>
@@ -685,7 +685,7 @@
     <string name="supportTitle">Aide &amp; support</string>
     <string name="switchAccountTitle">Changer de compte</string>
     <string name="switchDriveSearchViewHint">Rechercher un kDrive</string>
-    <string name="switchUserDescription">Consulter les kDrives de vos autres profils Infomaniak. Vous pouvez ajouter autant de profil d’utilisateurs que vous souhaitez.</string>
+    <string name="switchUserDescription">Consulter les kDrive de vos autres profils Infomaniak. Vous pouvez ajouter autant de profil d’utilisateurs que vous souhaitez.</string>
     <string name="syncConfigureDescription">Vos photos, vidéos et captures écran seront enregistrées automatiquement dans votre kDrive %s.</string>
     <string name="syncConfigureTitle">Sauvegardez vos souvenirs en lieu sûr</string>
     <string name="syncOnlyWifiDescription">Les fichiers hors ligne seront synchronisés uniquement via le Wi-Fi</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -685,7 +685,7 @@
     <string name="supportTitle">Aiuto e supporto</string>
     <string name="switchAccountTitle">Cambia account</string>
     <string name="switchDriveSearchViewHint">Cerca un kDrive</string>
-    <string name="switchUserDescription">Consulta le kDrives dei tuoi altri profili Infomaniak. Puoi aggiungere tutti i profili utente che vuoi.</string>
+    <string name="switchUserDescription">Consulta le kDrive dei tuoi altri profili Infomaniak. Puoi aggiungere tutti i profili utente che vuoi.</string>
     <string name="syncConfigureDescription">Le tue foto, i tuoi video e le tue schermate verranno salvati automaticamente nel tuo kDrive %s.</string>
     <string name="syncConfigureTitle">Salva i tuoi ricordi in un luogo sicuro</string>
     <string name="syncOnlyWifiDescription">I file offline saranno sincronizzati solo con il Wi-Fi</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -241,12 +241,12 @@
     </plurals>
     <plurals name="driveBlockedTitle">
         <item quantity="one">kDrive %s er for øyeblikket blokkert</item>
-        <item quantity="other">Alle kDrive-ene dine er for øyeblikket blokkert</item>
+        <item quantity="other">Alle dine kDrive er for øyeblikket blokkert</item>
     </plurals>
     <string name="driveMaintenanceDescription">En oppdatering pågår for å forbedre kDrive. Denne prosessen kan ta noen minutter. Takk for tålmodigheten.</string>
     <plurals name="driveMaintenanceTitle">
         <item quantity="one">kDrive %s er for øyeblikket under vedlikehold</item>
-        <item quantity="other">Alle kDrive-ene dine er for øyeblikket under vedlikehold</item>
+        <item quantity="other">Alle dine kDrive er for øyeblikket under vedlikehold</item>
     </plurals>
     <string name="dropBoxDescription">Inviter partnerne, brukerne eller kundene dine til å overføre filer til kDrive-en din, selv om de ikke har en Infomaniak-konto.</string>
     <string name="dropBoxLinkTitle">Dropboks-link</string>
@@ -685,7 +685,7 @@
     <string name="supportTitle">Hjelp og support</string>
     <string name="switchAccountTitle">Bytt konto</string>
     <string name="switchDriveSearchViewHint">Søk etter en kDrive</string>
-    <string name="switchUserDescription">Se kDrive-ene til de andre Infomaniak-profilene dine. Du kan legge til så mange brukerprofiler du vil.</string>
+    <string name="switchUserDescription">Se kDrive for de andre Infomaniak-profilene dine. Du kan legge til så mange brukerprofiler du vil.</string>
     <string name="syncConfigureDescription">Bildene, videoene og skjermbildene dine vil automatisk lagres i kDrive %s.</string>
     <string name="syncConfigureTitle">Lagre minnene dine på et trygt sted</string>
     <string name="syncOnlyWifiDescription">Frakoblede filer vil kun synkroniseres via Wi-Fi</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -241,12 +241,12 @@
     </plurals>
     <plurals name="driveBlockedTitle">
         <item quantity="one">De kDrive %s is momenteel geblokkeerd</item>
-        <item quantity="other">Al je kDrives zijn momenteel geblokkeerd</item>
+        <item quantity="other">Al je kDrive zijn momenteel geblokkeerd</item>
     </plurals>
     <string name="driveMaintenanceDescription">Een update is bezig om kDrive te verbeteren. Dit proces kan enkele minuten duren. Bedankt voor je geduld.</string>
     <plurals name="driveMaintenanceTitle">
         <item quantity="one">De kDrive %s is momenteel in onderhoud</item>
-        <item quantity="other">Al je kDrives zijn momenteel in onderhoud</item>
+        <item quantity="other">Al je kDrive zijn momenteel in onderhoud</item>
     </plurals>
     <string name="dropBoxDescription">Nodig je partners, gebruikers of klanten uit om bestanden over te zetten naar je kDrive, zelfs als ze geen Infomaniak-account hebben.</string>
     <string name="dropBoxLinkTitle">Dropbox-link</string>
@@ -685,7 +685,7 @@
     <string name="supportTitle">Help &amp; ondersteuning</string>
     <string name="switchAccountTitle">Wissel van account</string>
     <string name="switchDriveSearchViewHint">Zoek een kDrive</string>
-    <string name="switchUserDescription">Bekijk de kDrives van je andere Infomaniak-profielen. Je kunt zoveel gebruikersprofielen toevoegen als je wilt.</string>
+    <string name="switchUserDescription">Bekijk de kDrive van je andere Infomaniak-profielen. Je kunt zoveel gebruikersprofielen toevoegen als je wilt.</string>
     <string name="syncConfigureDescription">Je foto’s, video’s en schermafbeeldingen worden automatisch opgeslagen in je kDrive %s.</string>
     <string name="syncConfigureTitle">Sla je herinneringen op een veilige plek op</string>
     <string name="syncOnlyWifiDescription">Offline bestanden worden alleen gesynchroniseerd via Wi-Fi</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -241,12 +241,12 @@
     </plurals>
     <plurals name="driveBlockedTitle">
         <item quantity="one">O kDrive %s está atualmente bloqueado</item>
-        <item quantity="other">Todos os seus kDrives estão atualmente bloqueados</item>
+        <item quantity="other">Todos os seus kDrive estão atualmente bloqueados</item>
     </plurals>
     <string name="driveMaintenanceDescription">Está em curso uma atualização para melhorar o kDrive. Este processo pode demorar alguns minutos. Obrigado pela sua paciência.</string>
     <plurals name="driveMaintenanceTitle">
         <item quantity="one">O kDrive %s está atualmente em manutenção</item>
-        <item quantity="other">Todos os seus kDrives estão atualmente em manutenção</item>
+        <item quantity="other">Todos os seus kDrive estão atualmente em manutenção</item>
     </plurals>
     <string name="dropBoxDescription">Convide os seus parceiros, utilizadores ou clientes a transferir ficheiros para o seu kDrive, mesmo que não tenham uma conta Infomaniak.</string>
     <string name="dropBoxLinkTitle">Ligação da caixa de depósito</string>
@@ -685,7 +685,7 @@
     <string name="supportTitle">Ajuda e suporte</string>
     <string name="switchAccountTitle">Mudar de conta</string>
     <string name="switchDriveSearchViewHint">Pesquisar um kDrive</string>
-    <string name="switchUserDescription">Ver os kDrives dos seus outros perfis Infomaniak. Pode adicionar quantos perfis de utilizador quiser.</string>
+    <string name="switchUserDescription">Ver os kDrive dos seus outros perfis Infomaniak. Pode adicionar quantos perfis de utilizador quiser.</string>
     <string name="syncConfigureDescription">As suas fotos, vídeos e capturas de ecrã serão guardados automaticamente no seu kDrive %s.</string>
     <string name="syncConfigureTitle">Guarde as suas memórias num lugar seguro</string>
     <string name="syncOnlyWifiDescription">Os ficheiros offline serão sincronizados apenas via Wi-Fi</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -241,12 +241,12 @@
     </plurals>
     <plurals name="driveBlockedTitle">
         <item quantity="one">kDrive %s är för närvarande blockerad</item>
-        <item quantity="other">Alla dina kDrives är för närvarande blockerade</item>
+        <item quantity="other">Alla dina kDrive är för närvarande blockerade</item>
     </plurals>
     <string name="driveMaintenanceDescription">En uppdatering pågår för att förbättra kDrive. Denna process kan ta några minuter. Tack för ditt tålamod.</string>
     <plurals name="driveMaintenanceTitle">
         <item quantity="one">kDrive %s är för närvarande under underhåll</item>
-        <item quantity="other">Alla dina kDrives är för närvarande under underhåll</item>
+        <item quantity="other">Alla dina kDrive är för närvarande under underhåll</item>
     </plurals>
     <string name="dropBoxDescription">Bjud in dina partners, användare eller kunder att överföra filer till din kDrive, även om de inte har ett Infomaniak-konto.</string>
     <string name="dropBoxLinkTitle">Dropbox-länk</string>
@@ -685,7 +685,7 @@
     <string name="supportTitle">Hjälp &amp; support</string>
     <string name="switchAccountTitle">Byt konto</string>
     <string name="switchDriveSearchViewHint">Sök en kDrive</string>
-    <string name="switchUserDescription">Visa kDrives för dina andra Infomaniak-profiler. Du kan lägga till så många användarprofiler du vill.</string>
+    <string name="switchUserDescription">Visa kDrive för dina andra Infomaniak-profiler. Du kan lägga till så många användarprofiler du vill.</string>
     <string name="syncConfigureDescription">Dina foton, videor och skärmbilder sparas automatiskt i din kDrive %s.</string>
     <string name="syncConfigureTitle">Spara dina minnen på en säker plats</string>
     <string name="syncOnlyWifiDescription">Filer offline synkroniseras endast med Wi-Fi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,12 +241,12 @@
     </plurals>
     <plurals name="driveBlockedTitle">
         <item quantity="one">The kDrive %s is currently blocked</item>
-        <item quantity="other">All your kDrives are currently blocked</item>
+        <item quantity="other">All your kDrive are currently blocked</item>
     </plurals>
     <string name="driveMaintenanceDescription">An update is in progress to improve kDrive. This process may take a few minutes. Thank you for your patience.</string>
     <plurals name="driveMaintenanceTitle">
         <item quantity="one">The kDrive %s is currently under maintenance</item>
-        <item quantity="other">All your kDrives are currently under maintenance</item>
+        <item quantity="other">All your kDrive are currently under maintenance</item>
     </plurals>
     <string name="dropBoxDescription">Invite your partners, users or customers to transfer files to your kDrive even if they don’t have an Infomaniak account.</string>
     <string name="dropBoxLinkTitle">Drop box link</string>
@@ -685,7 +685,7 @@
     <string name="supportTitle">Help &amp; support</string>
     <string name="switchAccountTitle">Switch account</string>
     <string name="switchDriveSearchViewHint">Search a kDrive</string>
-    <string name="switchUserDescription">View the kDrives of your other Infomaniak profiles. You can add as many user profiles as you like.</string>
+    <string name="switchUserDescription">View the kDrive of your other Infomaniak profiles. You can add as many user profiles as you like.</string>
     <string name="syncConfigureDescription">Your photos, videos and screenshots will be automatically saved in your kDrive %s.</string>
     <string name="syncConfigureTitle">Save your memories in a safe place</string>
     <string name="syncOnlyWifiDescription">Offline files will be only synchronized with Wi-Fi</string>


### PR DESCRIPTION
Product names should not be pluralized, this PR fixes the strings that had this issue